### PR TITLE
Issue1 inicialización del repositorio

### DIFF
--- a/references/posibles_herramientas.md
+++ b/references/posibles_herramientas.md
@@ -5,3 +5,7 @@
 - **[``Crixet``](https://crixet.com/)** Aplicación gratuita de edición y compilación, permite acceso desde diferentes dispositivos.
 
 -**[``Crixet``](https://www.overleaf.com/)** Otra alternativa para edición y compilación. Condición de gratuidad más estricta.
+
+## Python
+
+- **[``UV``](https://docs.astral.sh/uv/)** Gestor de paquetes para python, alternativa a pip, aparentemente mejor, hay que investigarla

--- a/references/posibles_herramientas.md
+++ b/references/posibles_herramientas.md
@@ -4,7 +4,7 @@
 
 - **[``Crixet``](https://crixet.com/)** Aplicación gratuita de edición y compilación, permite acceso desde diferentes dispositivos.
 
--**[``Crixet``](https://www.overleaf.com/)** Otra alternativa para edición y compilación. Condición de gratuidad más estricta.
+-**[``Overleaf``](https://www.overleaf.com/)** Otra alternativa para edición y compilación. Condición de gratuidad más estricta.
 
 ## Python
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-Aun nada aqui


### PR DESCRIPTION
This pull request updates the `references/posibles_herramientas.md` file to correct a tool name and add a new Python package manager to the list of resources.

Documentation updates:

* Corrected the tool name from `Crixet` to `Overleaf` for the Overleaf link, fixing a copy-paste error in the alternatives list.
* Added a new section for Python tools and included `UV`, a package manager alternative to pip, with a note to investigate further.