### PR TITLE
hotfix 1 resolved

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Every new session should read these files in order before making changes:
 - issue `#15`: `docs/roadmap/issues/issue-15-domain-model-generator.md`
 - issue `#16`: `docs/roadmap/issues/issue-16-generation-pipeline-tests.md`
 - issue `#17`: `docs/roadmap/issues/issue-17-workflow-documentation.md`
+- hotfix `#1`: `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`
 
 ### Development Reference
 

--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -2,7 +2,7 @@
 
 ## Status Date
 
-- Last updated: 2026-04-06
+- Last updated: 2026-04-10
 
 ## Completed Or Stabilized Work
 
@@ -33,6 +33,15 @@
   - `SpecificationManual.xml`: OK
   - `CVNTreeModel.xml`: fails due to XML/XSD mismatch, documented in
     `docs/pipeline/known_limitations.md`
+
+### Hotfix `#1`
+
+- `src/cvn_codegen/xsdata_runner.py` now reports operational status through
+  `logging` instead of `print`
+- `print` is reserved for direct console interaction examples and ad hoc shell
+  snippets
+- project conventions now explicitly require f-strings for string interpolation
+  in repository code instead of old `%`-style formatting
 
 ## Current Technical Baseline
 
@@ -92,3 +101,4 @@ uv run pytest tests/test_xsdata_runner_smoke.py -v
 4. `docs/roadmap/issues/issue-11-project-infrastructure.md`
 5. `docs/roadmap/issues/issue-12-structural-bindings.md`
 6. `docs/pipeline/known_limitations.md`
+7. `docs/roadmap/hotfixes/

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -19,6 +19,7 @@ Anyone resuming work on the repository should start here after reading
 - Project: open CVN schema and tooling for Spanish academic CV processing
 - Current pipeline stage: structural generation from official XSDs completed
 - Last documented issues: `#11` and `#12`
+- Last documented hotfix: `#1`
 - Next planned issue: `#13`
 - Canonical source package: `docs/CvnXML_v1.4.3_2.1_17012025/`
 
@@ -57,6 +58,8 @@ Anyone resuming work on the repository should start here after reading
   issue `#16`
 - `docs/roadmap/issues/issue-17-workflow-documentation.md`: planned scope of
   issue `#17`
+- `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`: maintenance
+  record for the runner logging convention update
 
 ### Development And Contribution
 
@@ -94,6 +97,7 @@ docs/CvnXML_v1.4.3_2.1_17012025/
 
 - Issue `#11`: `docs/roadmap/issues/issue-11-project-infrastructure.md`
 - Issue `#12`: `docs/roadmap/issues/issue-12-structural-bindings.md`
+- Hotfix `#1`: `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`
 
 Each issue document records:
 

--- a/docs/development/code_style.md
+++ b/docs/development/code_style.md
@@ -34,6 +34,23 @@ Use this order:
 - Use specific exceptions where possible
 - Wrap external tool failures with project-specific exceptions when needed
 
+### Logging And Console Output
+
+- Use `logging` for operational messages, progress reporting, and error
+  reporting inside repository code
+- Reserve `print` for direct console interactions, short shell examples, or
+  explicit user-facing terminal snippets
+- Define module loggers with `logging.getLogger(__name__)`
+- Use the logging level that matches the situation: `info` for normal progress,
+  `error` for controlled failures, and `exception` when a traceback should be
+  recorded
+
+### String Formatting
+
+- Use f-strings for interpolated strings, for example
+  `f"target '{target_name}' no reconocido"`
+- Do not use old `%`-style string formatting in repository code
+
 ## Generated Code Boundaries
 
 - `src/generated/` is generated code and must not be edited manually

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -90,6 +90,24 @@ Authoritative record:
 
 - `docs/roadmap/issues/issue-12-structural-bindings.md`
 
+## Documented Maintenance Hotfixes
+
+### Hotfix `#1`
+
+- Goal:
+  replace operational `print` usage in the xsdata runner with `logging` and
+  document the repository convention for logging and string interpolation
+- Scope:
+  - define a module logger in `src/cvn_codegen/xsdata_runner.py`
+  - replace runner progress and error `print` calls with the appropriate
+    logging level
+  - document that `print` is reserved for direct console interaction
+  - document f-strings as the project standard for interpolated strings
+
+Authoritative record:
+
+- `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`
+
 ## Future Work Focus
 
 ### Issue `#13`

--- a/docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md
+++ b/docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md
@@ -1,0 +1,95 @@
+# Hotfix 1 - Runner Logging Convention Update
+
+## Summary
+
+Hotfix `#1` replaced the operational `print` calls in
+`src/cvn_codegen/xsdata_runner.py` with `logging`, kept console-oriented
+examples under `print`, and documented the repository convention that
+interpolated strings should use f-strings.
+
+## Original Goal
+
+- replace the runner `print` calls with `logging`
+- define the logger correctly in `src/cvn_codegen/xsdata_runner.py`
+- use the appropriate logging level for progress and failure paths
+- document that `print` is only for direct console interactions
+- document that repository code should use f-strings instead of old `%`-style
+  formatting
+
+## Original Plan
+
+1. inspect the current `print` usage in `src/cvn_codegen/xsdata_runner.py`
+2. add a module logger and enable the logging baseline for CLI execution
+3. replace each runner `print` with the matching logging call
+4. update persistent documentation for the logging and string-formatting
+   convention
+5. record the maintenance change in a dedicated hotfix file
+
+## Adjustments Made During Implementation
+
+The requested scope was kept intentionally narrow. No additional runner logic,
+exception flow, or generation behavior was changed beyond logger definition,
+basic logging setup, and the direct replacement of the existing `print` calls.
+
+## Implementation Performed
+
+### Runner Update
+
+File updated:
+
+- `src/cvn_codegen/xsdata_runner.py`
+
+Changes applied:
+
+- imported `logging`
+- defined `logger = logging.getLogger(__name__)`
+- enabled `logging.basicConfig(level=logging.INFO)` in `main()`
+- replaced progress messages with `logger.info(...)`
+- replaced the controlled runner failure output with `logger.error(...)`
+
+### Documentation Update
+
+Files updated:
+
+- `AGENTS.md`
+- `docs/context/project_context_index.md`
+- `docs/context/current_status.md`
+- `docs/development/code_style.md`
+- `docs/roadmap/cvn_generation_roadmap.md`
+
+Convention documented:
+
+- repository code should use `logging` for operational messages
+- `print` is reserved for direct console interactions and terminal examples
+- interpolated strings should use f-strings instead of `%`-style formatting
+
+## Verification
+
+The change was verified with:
+
+- `uv run pytest tests/test_xsdata_runner_unit.py -v`
+
+## Findings
+
+- The runner only needed a minimal logging integration because the previous
+  console output was concentrated in the orchestration path
+- No new functional limitation was introduced; the change is behavioral only in
+  how status information is emitted
+
+## Known Limitations
+
+- This hotfix does not introduce centralized logging configuration beyond the
+  local CLI baseline in `xsdata_runner.py`
+- Other modules may still need the same convention applied in future maintenance
+  work if they currently use `print` for operational reporting
+
+## Impact On Future Issues
+
+- Future automation and workflow documentation can now assume runner status is
+  emitted through `logging`
+- Later maintenance work should follow the same distinction between operational
+  logging and direct console interaction
+
+## Status
+
+- Status: completed and verified

--- a/src/cvn_codegen/xsdata_runner.py
+++ b/src/cvn_codegen/xsdata_runner.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentParser
+import logging
 from subprocess import run, CalledProcessError
 from dataclasses import dataclass
 from pathlib import Path
@@ -6,74 +7,83 @@ from typing import Final
 from shutil import rmtree
 
 
+logger = logging.getLogger(__name__)
 
-#---------------- Zona de definicion de tipos de datos ----------------
+
+# ---------------- Zona de definicion de tipos de datos ----------------
+
 
 @dataclass
 class XSDTargetSpec:
     """
     Esta clase representa la configuracion del objetivo de generación de código a partir de un archivo XSD.
     """
-    name : str #nombre logico del objetivo
-    source_xsd : Path #ruta original del archivo xsd
-    package : str #nombre del paquete destino en el que se generará el código
-    output_dir : Path #ruta del directorio donde se guardará el archivo generado
+
+    name: str  # nombre logico del objetivo
+    source_xsd: Path  # ruta original del archivo xsd
+    package: str  # nombre del paquete destino en el que se generará el código
+    output_dir: Path  # ruta del directorio donde se guardará el archivo generado
 
 
-#---------------- Zona de definicion de excepciones ----------------
+# ---------------- Zona de definicion de excepciones ----------------
+
 
 class RunnerError(Exception):
     """Excepcion base para errores relacionados con la ejecución del runner de xsdata."""
+
     pass
 
 
-#---------------- Zona de definicion de constantes ----------------
+# ---------------- Zona de definicion de constantes ----------------
 
-REPO_ROOT : Final[Path] = Path(__file__).resolve().parent.parent.parent
-#Ruta raiz del repositorio
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent.parent
+# Ruta raiz del repositorio
 
-XSDATA_CONFIG_FILE_PATH : Final[Path] = REPO_ROOT/ "config" / ".xsdata.xml"
-#Ruta del archivo de configuracion del xsdata
+XSDATA_CONFIG_FILE_PATH: Final[Path] = REPO_ROOT / "config" / ".xsdata.xml"
+# Ruta del archivo de configuracion del xsdata
 
-CANONICAL_XSD_DIR : Final[Path] = REPO_ROOT / "docs" / "CvnXML_v1.4.3_2.1_17012025" / "XSD"
-#ruta donde se encuentran los archivos xsd
+CANONICAL_XSD_DIR: Final[Path] = (
+    REPO_ROOT / "docs" / "CvnXML_v1.4.3_2.1_17012025" / "XSD"
+)
+# ruta donde se encuentran los archivos xsd
 
-GENERATED_ROOT_DIR : Final[Path] = REPO_ROOT / "src" / "generated"
-#ruta raiz donde se guardaran los archivos generados 
+GENERATED_ROOT_DIR: Final[Path] = REPO_ROOT / "src" / "generated"
+# ruta raiz donde se guardaran los archivos generados
 
-TARGET_TABLE : Final[dict[str, XSDTargetSpec]] = {
+TARGET_TABLE: Final[dict[str, XSDTargetSpec]] = {
     "cvn": XSDTargetSpec(
         name="cvn",
-        source_xsd = CANONICAL_XSD_DIR / "CVN.xsd",
-        package = "generated.cvn",
-        output_dir = GENERATED_ROOT_DIR / "cvn"
+        source_xsd=CANONICAL_XSD_DIR / "CVN.xsd",
+        package="generated.cvn",
+        output_dir=GENERATED_ROOT_DIR / "cvn",
     ),
     "specification_manual": XSDTargetSpec(
         name="specification_manual",
-        source_xsd = CANONICAL_XSD_DIR / "SpecificationManual.xsd",
-        package = "generated.specification_manual",
-        output_dir = GENERATED_ROOT_DIR / "specification_manual"
+        source_xsd=CANONICAL_XSD_DIR / "SpecificationManual.xsd",
+        package="generated.specification_manual",
+        output_dir=GENERATED_ROOT_DIR / "specification_manual",
     ),
     "tree_model": XSDTargetSpec(
         name="tree_model",
-        source_xsd = CANONICAL_XSD_DIR / "CVNTreeModel_v1.0.xsd",
-        package = "generated.tree_model",
-        output_dir = GENERATED_ROOT_DIR / "tree_model"
-    )
+        source_xsd=CANONICAL_XSD_DIR / "CVNTreeModel_v1.0.xsd",
+        package="generated.tree_model",
+        output_dir=GENERATED_ROOT_DIR / "tree_model",
+    ),
 }
-#Tabla que mapea el nombre logico del xsd a su especificacion completa
+# Tabla que mapea el nombre logico del xsd a su especificacion completa
 
-EXECUTION_ORDER_ALL : Final[list[str]] = ["cvn", "specification_manual", "tree_model"]
-#lista de las claves de TARGET_TABLE en el orden en el que deben ser ejecutados 
+EXECUTION_ORDER_ALL: Final[list[str]] = ["cvn", "specification_manual", "tree_model"]
+# lista de las claves de TARGET_TABLE en el orden en el que deben ser ejecutados
 
-TARGET_OVERRIDES : Final[dict[str, list[str]]] = {
+TARGET_OVERRIDES: Final[dict[str, list[str]]] = {
     "tree_model": ["--unnest-classes"],
 }
-#Tabla que mapea el nombre logico del xsd a una lista de argumentos adicionales que se le pasaran a xsdata al generar ese objetivo
+# Tabla que mapea el nombre logico del xsd a una lista de argumentos adicionales que se le pasaran a xsdata al generar ese objetivo
 
-#---------------- Zona de definicion de funciones ----------------
+# ---------------- Zona de definicion de funciones ----------------
 
-def xsdata_target_resolver (target_name : str) -> list[XSDTargetSpec]:
+
+def xsdata_target_resolver(target_name: str) -> list[XSDTargetSpec]:
     """
     Resuelve el nombre del objetivo a su especificacion completa.
     Args:
@@ -90,10 +100,12 @@ def xsdata_target_resolver (target_name : str) -> list[XSDTargetSpec]:
     elif target_name in TARGET_TABLE:
         return [TARGET_TABLE[target_name]]
     else:
-        raise RunnerError(f"Target '{target_name}' no reconocido. Opciones válidas: {EXECUTION_ORDER_ALL + ['all']}")
+        raise RunnerError(
+            f"Target '{target_name}' no reconocido. Opciones válidas: {EXECUTION_ORDER_ALL + ['all']}"
+        )
 
 
-def is_path_within(output_dir : Path, root_dir : Path) -> bool:
+def is_path_within(output_dir: Path, root_dir: Path) -> bool:
     """
     Valida que el directorio de salida dado se encuentre dentro del directorio raíz de generación.
     Args:
@@ -106,24 +118,40 @@ def is_path_within(output_dir : Path, root_dir : Path) -> bool:
     root_dir_resolved = root_dir.resolve()
     return output_dir_resolved.is_relative_to(root_dir_resolved)
 
-def validate_xsdata_and_xsdata_pydantic()-> None:
+
+def validate_xsdata_and_xsdata_pydantic() -> None:
     """
     Valida que xsdata y su plugin de pydantic estén instalados y accesibles desde la línea de comandos.
     Raises:
         RunnerError: Si xsdata o el plugin de pydantic no están instalados o no son accesibles.
     """
     try:
-        run(["uv","run","xsdata", "--version"], check=True, capture_output=True, text=True)
+        run(
+            ["uv", "run", "xsdata", "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
     except (CalledProcessError, FileNotFoundError) as e:
-        raise RunnerError("xsdata no está instalado o no es accesible desde la línea de comandos.") from e
+    
+        raise RunnerError(
+            "xsdata no está instalado o no es accesible desde la línea de comandos."
+        ) from e
 
     try:
-        run(["uv","run","python","-c","import xsdata_pydantic"], check=True, capture_output=True, text=True)
+        run(
+            ["uv", "run", "python", "-c", "import xsdata_pydantic"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
     except (CalledProcessError, FileNotFoundError) as e:
-        raise RunnerError("El plugin xsdata-pydantic no está instalado o no es accesible desde la línea de comandos.") from e
+        raise RunnerError(
+            "El plugin xsdata-pydantic no está instalado o no es accesible desde la línea de comandos."
+        ) from e
 
 
-def validate_xsdata_prerequistes(target : XSDTargetSpec) -> None:
+def validate_xsdata_prerequistes(target: XSDTargetSpec) -> None:
     """
     Valida que se cumplan los prerrequisitos para ejecutar xsdata en el objetivo dado.
     Args:
@@ -131,52 +159,63 @@ def validate_xsdata_prerequistes(target : XSDTargetSpec) -> None:
     Raises:
         RunnerError: Si no se cumple algun prerrequisito.
     """
-    #comprobaciones del archivo de configuracion
+    # comprobaciones del archivo de configuracion
     if not XSDATA_CONFIG_FILE_PATH.is_file():
-        raise RunnerError(f"El archivo de configuración de xsdata '{XSDATA_CONFIG_FILE_PATH}' no existe o no es un archivo.")
+        raise RunnerError(
+            f"El archivo de configuración de xsdata '{XSDATA_CONFIG_FILE_PATH}' no existe o no es un archivo."
+        )
 
-
-    #comprobaciones del archivo source_xsd
-    if not isinstance(target, XSDTargetSpec): 
+    # comprobaciones del archivo source_xsd
+    if not isinstance(target, XSDTargetSpec):
         raise RunnerError(f"El objetivo {target} no es una instancia de XSDTargetSpec.")
 
     if not target.source_xsd.is_file():
-        raise RunnerError(f"El archivo XSD '{target.source_xsd}' no existe o no es un archivo")
-    
+        raise RunnerError(
+            f"El archivo XSD '{target.source_xsd}' no existe o no es un archivo"
+        )
+
     if not target.source_xsd.suffix.lower() == ".xsd":
-        raise RunnerError(f"El archivo '{target.source_xsd}' debe ser un fichero \".xsd\", sim embargo es de tipo \"{target.source_xsd.suffix}\"")
+        raise RunnerError(
+            f'El archivo \'{target.source_xsd}\' debe ser un fichero ".xsd", sim embargo es de tipo "{target.source_xsd.suffix}"'
+        )
 
-
-    #comprobacion de que el directorio raiz de salida existe
+    # comprobacion de que el directorio raiz de salida existe
 
     if not GENERATED_ROOT_DIR.is_dir():
-        raise RunnerError(f"El directorio raíz de salida '{GENERATED_ROOT_DIR}' no existe o no es un directorio.")
+        raise RunnerError(
+            f"El directorio raíz de salida '{GENERATED_ROOT_DIR}' no existe o no es un directorio."
+        )
 
-    #comprobacion de que el directorio de salida se encuentra dentro del directorio raiz de generacion
+    # comprobacion de que el directorio de salida se encuentra dentro del directorio raiz de generacion
     if not is_path_within(target.output_dir, GENERATED_ROOT_DIR):
-        raise RunnerError(f"El directorio de salida '{target.output_dir}' no se encuentra dentro del directorio raíz de generación '{GENERATED_ROOT_DIR}'.")
-    
-    validate_xsdata_and_xsdata_pydantic()    
+        raise RunnerError(
+            f"El directorio de salida '{target.output_dir}' no se encuentra dentro del directorio raíz de generación '{GENERATED_ROOT_DIR}'."
+        )
+
+    validate_xsdata_and_xsdata_pydantic()
 
 
-
-def clean_generated_code(target : XSDTargetSpec) -> None:
+def clean_generated_code(target: XSDTargetSpec) -> None:
     """
     Limpia la salida generada anteriormente para cada uno de los objetivos
     Args:
         target (XSDTargetSpec): La especificacion del objetivo a limpiar.
-    
+
     Raises:
         RunnerError: Si ocurre un error al limpiar el código generado.
     """
     if not is_path_within(target.output_dir, GENERATED_ROOT_DIR):
-        raise RunnerError(f"El directorio de salida '{target.output_dir}' no se encuentra dentro del directorio raíz de generación '{GENERATED_ROOT_DIR}'.")
-    
+        raise RunnerError(
+            f"El directorio de salida '{target.output_dir}' no se encuentra dentro del directorio raíz de generación '{GENERATED_ROOT_DIR}'."
+        )
+
     if target.output_dir.resolve() == GENERATED_ROOT_DIR.resolve():
-        raise RunnerError(f"El directorio de salida '{target.output_dir}' no puede ser el mismo que el directorio raíz de generación '{GENERATED_ROOT_DIR}' para evitar borrados accidentales.")
+        raise RunnerError(
+            f"El directorio de salida '{target.output_dir}' no puede ser el mismo que el directorio raíz de generación '{GENERATED_ROOT_DIR}' para evitar borrados accidentales."
+        )
 
     target.output_dir.mkdir(parents=True, exist_ok=True)
-    
+
     for item in target.output_dir.iterdir():
         try:
             if item.is_dir() and not item.is_symlink():
@@ -184,9 +223,12 @@ def clean_generated_code(target : XSDTargetSpec) -> None:
             else:
                 item.unlink()
         except OSError as e:
-            raise RunnerError(f"Error al limpiar el código generado en '{item}': {e}") from e
+            raise RunnerError(
+                f"Error al limpiar el código generado en '{item}': {e}"
+            ) from e
 
-def build_xsdata_command(target : XSDTargetSpec) -> list[str]:
+
+def build_xsdata_command(target: XSDTargetSpec) -> list[str]:
     """
     Construye el comando de xsdata para generar el código a partir del objetivo dado.
     Args:
@@ -194,13 +236,13 @@ def build_xsdata_command(target : XSDTargetSpec) -> list[str]:
     Returns:
         list[str]: El comando de xsdata construido como una lista de argumentos.
     """
-    
+
     command = [
         "uv",
         "run",
         "xsdata",
         "generate",
-        "--config", 
+        "--config",
         str(XSDATA_CONFIG_FILE_PATH),
         "--package",
         target.package,
@@ -210,7 +252,8 @@ def build_xsdata_command(target : XSDTargetSpec) -> list[str]:
 
     return command
 
-def execute_xsdata_command(target : XSDTargetSpec) -> None:
+
+def execute_xsdata_command(target: XSDTargetSpec) -> None:
     """
     Ejecuta el comando de xsdata dado.
     Args:
@@ -220,12 +263,14 @@ def execute_xsdata_command(target : XSDTargetSpec) -> None:
     """
     command = build_xsdata_command(target)
     try:
-        run(command, check=True, cwd=REPO_ROOT / "src" )
+        run(command, check=True, cwd=REPO_ROOT / "src")
     except (CalledProcessError, FileNotFoundError) as e:
-        raise RunnerError(f"Error al ejecutar el comando '{' '.join(command)}': {e}") from e
+        raise RunnerError(
+            f"Error al ejecutar el comando '{' '.join(command)}': {e}"
+        ) from e
 
 
-def validate_generated_output(target : XSDTargetSpec) -> None:
+def validate_generated_output(target: XSDTargetSpec) -> None:
     """
     Valida que se ha generado el código correctamente para el objetivo dado.
     Args:
@@ -234,15 +279,21 @@ def validate_generated_output(target : XSDTargetSpec) -> None:
         RunnerError: Si no se encuentra ningún archivo .py en el directorio de salida después de la generación.
     """
     if not target.output_dir.is_dir():
-        raise RunnerError(f"El directorio de salida '{target.output_dir}' no existe o no es un directorio después de ejecutar xsdata para el objetivo '{target.name}'.")
-    
+        raise RunnerError(
+            f"El directorio de salida '{target.output_dir}' no existe o no es un directorio después de ejecutar xsdata para el objetivo '{target.name}'."
+        )
+
     if not any(target.output_dir.iterdir()):
-        raise RunnerError(f"El directorio de salida '{target.output_dir}' está vacío después de ejecutar xsdata para el objetivo '{target.name}'.")
+        raise RunnerError(
+            f"El directorio de salida '{target.output_dir}' está vacío después de ejecutar xsdata para el objetivo '{target.name}'."
+        )
 
     if not any(target.output_dir.glob("**/*.py")):
-        raise RunnerError(f"No se encontraron archivos .py generados en '{target.output_dir}' después de ejecutar xsdata para el objetivo '{target.name}'.")
-    
-    
+        raise RunnerError(
+            f"No se encontraron archivos .py generados en '{target.output_dir}' después de ejecutar xsdata para el objetivo '{target.name}'."
+        )
+
+
 def run_xsdata_generation_per_target(target: XSDTargetSpec) -> None:
     """
     Ejecuta el proceso completo de generación de código a partir de un archivo XSD para el objetivo dado, incluyendo validaciones, limpieza y ejecución del comando de xsdata.
@@ -261,7 +312,6 @@ def run_xsdata_generation_per_target(target: XSDTargetSpec) -> None:
     validate_generated_output(target)
 
 
-
 def run_targets_generation(targets: list[XSDTargetSpec]) -> None:
     """
     Lanza el proceso de generación de código a partir de archivos XSD para una lista de objetivos dada, ejecutando el proceso completo para cada objetivo en orden.
@@ -273,35 +323,47 @@ def run_targets_generation(targets: list[XSDTargetSpec]) -> None:
     generated_outputs: list[str] = []
 
     for target in targets:
-        print(f"Ejecutando generación de código para el objetivo '{target.name}'...")
+        logger.info(
+            f"Ejecutando generación de código para el objetivo '{target.name}'..."
+        )
         run_xsdata_generation_per_target(target)
-        print(f"Generación de código para el objetivo '{target.name}' completada exitosamente.\n")
+        logger.info(
+            f"Generación de código para el objetivo '{target.name}' completada exitosamente."
+        )
         generated_outputs.append(f"{target.name} -> {target.output_dir}")
 
-    print("Proceso de generación de código para todos los objetivos completado exitosamente.")
-    print("Archivos generados:")
+    logger.info(
+        "Proceso de generación de código para todos los objetivos completado exitosamente."
+    )
+    logger.info("Archivos generados:")
     for archivo in generated_outputs:
-        print(f" - {archivo}")
+        logger.info(f" - {archivo}")
+
 
 def build_parser() -> ArgumentParser:
-    parser = ArgumentParser(description="Runner de generación de código a partir de archivos XSD utilizando xsdata.")
+    parser = ArgumentParser(
+        description="Runner de generación de código a partir de archivos XSD utilizando xsdata."
+    )
     parser.add_argument(
         "target",
         choices=EXECUTION_ORDER_ALL + ["all"],
         type=str,
-        help=f"El objetivo de generación de código a ejecutar. Opciones válidas: {EXECUTION_ORDER_ALL + ['all']}"
+        help=f"El objetivo de generación de código a ejecutar. Opciones válidas: {EXECUTION_ORDER_ALL + ['all']}",
     )
     return parser
 
-def main() -> int :
+
+def main() -> int:
     """Función principal del runner de generación de código a partir de archivos XSD utilizando xsdata. Esta función se encarga de parsear los argumentos de línea de comandos, resolver los objetivos a ejecutar y lanzar el proceso de generación de código para cada objetivo en orden.
     Returns:
         int: El código de salida del programa. 0 si la ejecución fue exitosa, 1 si ocurrió un error.
     """
 
+    logging.basicConfig(level=logging.INFO)
+
     try:
         parser = build_parser()
-        
+
         arguments = parser.parse_args()
 
         execution_list = xsdata_target_resolver(arguments.target)
@@ -309,12 +371,13 @@ def main() -> int :
         run_targets_generation(execution_list)
 
     except RunnerError as e:
-        print(f"Error: {e}")
+        logger.error(f"Error: {e}")
         return 1
 
     return 0
 
+
 if __name__ == "__main__":
     raise SystemExit(main())
 
-#TODO al final de la implementacion del archivo dejar los imports de typing y parthlib con los imports unicos necesarios
+# TODO al final de la implementacion del archivo dejar los imports de typing y parthlib con los imports unicos necesarios


### PR DESCRIPTION
This pull request introduces Hotfix #1, which standardizes logging and string formatting conventions in the repository. The main operational change is the replacement of `print` statements with the Python `logging` module in `src/cvn_codegen/xsdata_runner.py` for all status and error reporting. Additionally, the project documentation is updated to reflect these conventions, and f-strings are now required for all interpolated strings in repository code. The hotfix is thoroughly documented and referenced throughout the documentation.

**Runner logging and string formatting conventions:**

* Replaced all operational `print` calls in `src/cvn_codegen/xsdata_runner.py` with appropriate `logging` calls, using `logger.info` for progress and `logger.error` for failures. A module logger is defined with `logging.getLogger(__name__)`, and basic logging configuration is enabled in `main()`. [[1]](diffhunk://#diff-d909679b3c5e38ead1bebae1fb16bd1f0a4896e535d3b7553a3d7555fe929f20R2-R21) [[2]](diffhunk://#diff-d909679b3c5e38ead1bebae1fb16bd1f0a4896e535d3b7553a3d7555fe929f20L225-R270)
* Updated all error messages in `xsdata_runner.py` to use f-strings for string interpolation, ensuring consistency with the new project standard. [[1]](diffhunk://#diff-d909679b3c5e38ead1bebae1fb16bd1f0a4896e535d3b7553a3d7555fe929f20L93-R105) [[2]](diffhunk://#diff-d909679b3c5e38ead1bebae1fb16bd1f0a4896e535d3b7553a3d7555fe929f20L136-L162) [[3]](diffhunk://#diff-d909679b3c5e38ead1bebae1fb16bd1f0a4896e535d3b7553a3d7555fe929f20L173-R215) [[4]](diffhunk://#diff-d909679b3c5e38ead1bebae1fb16bd1f0a4896e535d3b7553a3d7555fe929f20L187-R229) [[5]](diffhunk://#diff-d909679b3c5e38ead1bebae1fb16bd1f0a4896e535d3b7553a3d7555fe929f20L237-R294)

**Documentation updates:**

* Added a new hotfix record at `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md` detailing the motivation, implementation, and verification of the logging and string formatting changes.
* Updated project documentation (`AGENTS.md`, `docs/context/project_context_index.md`, `docs/context/current_status.md`, `docs/development/code_style.md`, `docs/roadmap/cvn_generation_roadmap.md`) to reference Hotfix #1, clarify the use of `logging` for operational messages, reserve `print` for direct console interaction, and require f-strings for string interpolation. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R54) [[2]](diffhunk://#diff-edb7cc5636d525032a9363fc3810749e1ee2a8b5c91b263fe03c8a2ad0606e6fR22) [[3]](diffhunk://#diff-edb7cc5636d525032a9363fc3810749e1ee2a8b5c91b263fe03c8a2ad0606e6fR61-R62) [[4]](diffhunk://#diff-edb7cc5636d525032a9363fc3810749e1ee2a8b5c91b263fe03c8a2ad0606e6fR100) [[5]](diffhunk://#diff-af079787bf7b6ce442de3db0038c942456c651faee50f98ee071654df5cb5696R37-R45) [[6]](diffhunk://#diff-14a13900efbdd74bd068747d8872cec11a3fe2a83e505174ab8ef7ee779ab36aR37-R53) [[7]](diffhunk://#diff-3fe245a36a2de8adfeb24d497fe031fba737fce1f42306830c278880adbe980aR93-R110)

**Project status and roadmap:**

* Updated status and index files to reflect the completion and verification of Hotfix #1, ensuring that future contributors are aware of the new conventions and maintenance record. [[1]](diffhunk://#diff-af079787bf7b6ce442de3db0038c942456c651faee50f98ee071654df5cb5696L5-R5) [[2]](diffhunk://#diff-af079787bf7b6ce442de3db0038c942456c651faee50f98ee071654df5cb5696R104)

These changes improve code maintainability, clarity, and operational consistency across the repository.