### PR TITLE
alingning the issues to the new requirements in because of the new CV…

### DIFF
--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -2,7 +2,11 @@
 
 ## Status Date
 
+<<<<<<< Updated upstream
 - Last updated: 2026-05-07
+=======
+- Last updated: 2026-06-08
+>>>>>>> Stashed changes
 
 ## Completed Or Stabilized Work
 
@@ -228,6 +232,28 @@
 - the hotfix is documentation-only and does not yet modify the pending issue
   files themselves
 
+### Issue `#14` Planning
+
+- the semantic mapping rules issue now has an agreed execution policy recorded
+  in `docs/roadmap/issues/issue-14-semantic-mapping-rules.md`
+- the policy plan fixes the semantic input contract around the implemented
+  normalization names `reference_resolution.source_artifact` and
+  `reference_resolution.semantic_kind`
+- issue `#14` implementation is expected to create explicit typed policy
+  contracts under `src/cvn_codegen/` without editing `src/generated/`
+- the agreed policy covers:
+  - semantic base kinds
+  - controlled-reference domain shapes
+  - strict enum eligibility
+  - wrapper and `xs:choice` treatment
+  - presence and cardinality mapping
+  - Spanish-first domain naming
+  - deterministic override precedence
+  - representative validation cases for handoff into issue `#15`
+- pending issue documents `#15`, `#16`, and `#17` are aligned with the agreed
+  semantic-policy handoff before issue `#14` code implementation starts
+- no final domain model emission is implemented yet; that remains issue `#15`
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -237,9 +263,9 @@
   `generated.*` resolves to `src/generated/*`
 - `tree_model` generation requires a target-specific override
 
-## Next Planned Issue
+## Next Planned Work
 
-- Next issue to start: `#14`
+- Next work item: implement issue `#14` semantic policy contracts and tests
 - Required corrective references before starting:
   - `docs/roadmap/hotfixes/hotfix-4-structural-scope-correction-for-auxiliary-source-package-artifacts.md`
   - `docs/roadmap/hotfixes/hotfix-5-normalization-resolution-layer-for-auxiliary-reference-sources.md`

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -29,10 +29,17 @@ Goal:
 | `#11` | Project infrastructure for code generation | Completed | Baseline repository layout and config established |
 | `#12` | Generate structural Pydantic bindings from CVN XSDs | Completed with documented limitations | Tree model XML/XSD mismatch remains documented |
 | `#13` | Parse and normalize `SpecificationManual.xml` and `CVNTreeModel.xml` | Completed | Core normalization and auxiliary-reference resolution enrichment implemented; baseline overlap counts preserved |
+<<<<<<< Updated upstream
 | `#14` | Define semantic mapping rules and override policy | Pending | Depends on enriched normalization metadata from issue `#13` |
 | `#15` | Implement the domain Pydantic model generator | Pending | Depends on `#13` and `#14` |
 | `#16` | Add automated tests for the generation pipeline | Pending | Extend from smoke tests to pipeline tests |
 | `#17` | Document and automate the complete workflow | Pending | Final workflow and documentation closure |
+=======
+| `#14` | Define semantic mapping rules and override policy | Planned with agreed execution policy | Semantic policy plan documented; implementation still pending and depends on enriched normalization metadata from issue `#13` after hotfix `#5` |
+| `#15` | Implement the domain Pydantic model generator | Pending | Depends on `#14` semantic policy and consumes enriched normalized metadata rather than rediscovering sources |
+| `#16` | Add automated tests for the generation pipeline | Pending | Must cover both core pipeline and auxiliary enrichment path |
+| `#17` | Document and automate the complete workflow | Pending | Must document corrected full workflow including auxiliary stages |
+>>>>>>> Stashed changes
 | `#25` | GitHub Actions CI pipeline for PR testing on main and development | Completed | PRs to `main` and `development` now run the `tests` check |
 
 Corrective planning after hotfixes `#4`, `#5`, and `#6`:
@@ -216,6 +223,15 @@ Authoritative record:
   - explicit override mechanism
   - semantic treatment for auxiliary reference families and serialization
     patterns described by hotfixes `#5` and `#6`
+<<<<<<< Updated upstream
+=======
+  - avoid re-deriving source-family or subtype-backed detection already handled
+    by normalization
+- Planning outcome:
+  - typed semantic policy families, enum categories, override precedence,
+    Spanish-first naming, strict enum eligibility, wrapper treatment, and
+    representative validation cases are now documented in the issue record
+>>>>>>> Stashed changes
 
 ### Issue `#15`
 

--- a/docs/roadmap/issues/issue-14-semantic-mapping-rules.md
+++ b/docs/roadmap/issues/issue-14-semantic-mapping-rules.md
@@ -3,7 +3,7 @@
 ## Summary
 
 Issue `#14` will define the rules that transform normalized CVN metadata into
- domain-oriented Pydantic models.
+domain-oriented Pydantic models.
 
 ## Original Goal
 
@@ -19,11 +19,509 @@ Issue `#14` will define the rules that transform normalized CVN metadata into
 5. create an explicit override mechanism
 6. document all decisions in versioned repository files
 
+<<<<<<< Updated upstream
+=======
+## Corrected Prerequisite Chain
+
+Issue `#14` no longer begins from only raw normalized manual and tree metadata.
+It must start from the validated enriched normalization output implemented in
+issue `#13` after hotfix `#5`, with auxiliary structural visibility already in
+place from hotfix `#4`.
+
+The corrected semantic-policy input now includes at minimum:
+
+- `manual_type`
+- `manual_multiplicity`
+- `manual_obligatory`
+- `xml_path`
+- `reference_resolution.status`
+- `reference_resolution.source_family`
+- `reference_resolution.source_artifact`
+- `reference_resolution.serialization_pattern`
+- `reference_resolution.semantic_kind`
+- `reference_resolution.trace`
+
+Issue `#14` must consume that typed metadata. It must not rebuild source-family,
+side-package, subtype-backed, or hierarchical-reference detection from prose
+documents or ad hoc table-name inspection.
+
+>>>>>>> Stashed changes
 ## Planned Execution Steps
 
 The implementation of issue `#14` should begin from the normalized metadata
 layer produced in issue `#13` and should leave issue `#15` with an explicit,
+<<<<<<< Updated upstream
 deterministic semantic policy to consume.
+=======
+deterministic semantic policy to consume without reopening source-discovery
+questions.
+
+## Agreed Execution Plan
+
+The following plan was agreed before starting implementation work on issue
+`#14`. It is the operative execution sequence for the issue and should guide the
+step-by-step development session.
+
+### Step `1 / 9` - Define Exact Scope Boundary
+
+- Step summary:
+  - define the exact execution boundary of issue `#14` so semantic policy,
+    normalization responsibilities, and generator responsibilities stay clearly
+    separated
+- Step type:
+  - standards, contracts, and documentation
+- Files to modify or add if needed:
+  - `docs/roadmap/issues/issue-14-semantic-mapping-rules.md`
+  - `docs/adr/` if a stronger architecture decision must be recorded
+- Root task `1 / 9`:
+  - fix what belongs to issue `#14` and what remains deferred to issue `#15`
+- Subtask `1.1 / 9`:
+  - list the exact semantic-policy inputs consumed from `NormalizationResult`
+- Subtask `1.2 / 9`:
+  - list the exact outputs expected from the semantic policy layer
+- Subtask `1.3 / 9`:
+  - make explicit which upstream source-resolution logic must not be
+    reimplemented in issue `#14`
+
+### Step `2 / 9` - Design Semantic Output Contract
+
+- Step summary:
+  - define the machine-readable contract that issue `#15` will consume so later
+    generation does not depend on prose interpretation
+- Step type:
+  - contract definition and technical design
+- Files to modify or add if needed:
+  - one or more new hand-maintained semantic-policy modules under
+    `src/cvn_codegen/`
+  - `docs/roadmap/issues/issue-14-semantic-mapping-rules.md`
+- Root task `2 / 9`:
+  - define the output shape of the semantic policy layer
+- Subtask `2.1 / 9`:
+  - decide the minimum record families needed, such as field-level semantic
+    rules, naming rules, and override records
+- Subtask `2.2 / 9`:
+  - decide the indexing keys used by the policy, such as CVN `code`,
+    `xml_path`, `reference_resolution.semantic_kind`, or serialization pattern
+- Subtask `2.3 / 9`:
+  - decide whether the contract should use dataclasses, enums, typed
+    dictionaries, or another explicit typed structure
+
+### Step `3 / 9` - Build Representative Case Inventory
+
+- Step summary:
+  - collect real normalized cases covering the main semantic categories so the
+    policy is grounded in validated repository inputs
+- Step type:
+  - analysis and traceability
+- Files to modify or add if needed:
+  - `docs/roadmap/issues/issue-14-semantic-mapping-rules.md`
+  - optional auxiliary analysis notes if a persistent inventory becomes useful
+- Root task `3 / 9`:
+  - select a representative set of enriched normalized entries
+- Subtask `3.1 / 9`:
+  - include a compact enum-like direct table case such as `CVN_SEX_A`
+- Subtask `3.2 / 9`:
+  - include a subtype-backed case such as `CVN_KNOW_A`
+- Subtask `3.3 / 9`:
+  - include a side-package registry case such as `ENTITY@Entity.xsd`
+- Subtask `3.4 / 9`:
+  - include a side-package thesaurus case such as `THESAURUS@thesaurus.xsd`
+- Subtask `3.5 / 9`:
+  - include a hierarchical thematic case such as `UNESCO_CODES`
+- Subtask `3.6 / 9`:
+  - include an unresolved case such as `CVN_AGENCY_C`
+- Subtask `3.7 / 9`:
+  - include an under-traced case such as `CVN_INTERVENTION_A` or `CVN_PRUEBA`
+
+### Step `4 / 9` - Define Base Type, Wrapper, And Multiplicity Rules
+
+- Step summary:
+  - define the common semantic rules for scalar types, XML helper wrappers, and
+    multiplicity behavior before handling controlled-reference policy
+- Step type:
+  - semantic design and contract definition
+- Files to modify or add if needed:
+  - one or more new hand-maintained semantic-policy modules under
+    `src/cvn_codegen/`
+  - `docs/roadmap/issues/issue-14-semantic-mapping-rules.md`
+  - `docs/pipeline/known_limitations.md` if new limitations are found
+- Root task `4 / 9`:
+  - map manual types and structural wrappers to intended domain-facing types
+- Subtask `4.1 / 9`:
+  - decide the semantic treatment of `Alphanumeric`, `Date`, `Double`,
+    `Boolean`, and `Duration`
+- Subtask `4.2 / 9`:
+  - decide which XML helper wrappers collapse to primitives and which should
+    stay as dedicated value objects
+- Subtask `4.3 / 9`:
+  - decide how `manual_obligatory` and `manual_multiplicity` become required,
+    optional, or repeated domain fields
+- Subtask `4.4 / 9`:
+  - document impacts from known structural limitations such as `xs:choice`,
+    weak `minOccurs` enforcement, and attributes typed as `object`
+
+### Step `5 / 9` - Define Policy Per Semantic Reference Kind
+
+- Step summary:
+  - define the core semantic treatment for each normalized
+    `SemanticReferenceKind`
+- Step type:
+  - semantic design
+- Files to modify or add if needed:
+  - one or more new hand-maintained semantic-policy modules under
+    `src/cvn_codegen/`
+  - `docs/roadmap/issues/issue-14-semantic-mapping-rules.md`
+- Root task `5 / 9`:
+  - define open-versus-closed treatment and semantic shape by normalized
+    reference kind
+- Subtask `5.1 / 9`:
+  - compact enum-like table
+- Subtask `5.2 / 9`:
+  - compact scale or measure table
+- Subtask `5.3 / 9`:
+  - identifier-type table
+- Subtask `5.4 / 9`:
+  - scope table
+- Subtask `5.5 / 9`:
+  - subtype-backed controlled family
+- Subtask `5.6 / 9`:
+  - hierarchical thematic classification
+- Subtask `5.7 / 9`:
+  - side-package registry
+- Subtask `5.8 / 9`:
+  - side-package thesaurus or vocabulary
+- Subtask `5.9 / 9`:
+  - unresolved manual-only reference
+- Subtask `5.10 / 9`:
+  - technically present but under-traced table
+
+### Step `6 / 9` - Define Naming And Traceability Rules
+
+- Step summary:
+  - define how domain-facing names are derived while preserving CVN code and
+    XML traceability
+- Step type:
+  - standards and technical design
+- Files to modify or add if needed:
+  - one or more new hand-maintained semantic-policy modules under
+    `src/cvn_codegen/`
+  - `docs/roadmap/issues/issue-14-semantic-mapping-rules.md`
+- Root task `6 / 9`:
+  - define naming rules for future domain classes, fields, and modules
+- Subtask `6.1 / 9`:
+  - decide the naming-language policy, including the role of Spanish academic
+    terminology
+- Subtask `6.2 / 9`:
+  - decide how multilingual manual labels are normalized into stable
+    identifiers
+- Subtask `6.3 / 9`:
+  - define collision-resolution rules for repeated or technically noisy names
+- Subtask `6.4 / 9`:
+  - define how semantic outputs preserve traceability back to CVN `code` and
+    `xml_path`
+
+### Step `7 / 9` - Design Override Mechanism
+
+- Step summary:
+  - design explicit override support for cases that generic semantic rules
+    cannot resolve safely
+- Step type:
+  - contract definition and technical design
+- Files to modify or add if needed:
+  - one or more new hand-maintained override modules under `src/cvn_codegen/`
+  - `docs/roadmap/issues/issue-14-semantic-mapping-rules.md`
+- Root task `7 / 9`:
+  - define override granularity, structure, and precedence
+- Subtask `7.1 / 9`:
+  - decide whether overrides can target CVN `code`
+- Subtask `7.2 / 9`:
+  - decide whether overrides can target `xml_path`
+- Subtask `7.3 / 9`:
+  - decide whether overrides can target `reference_resolution.semantic_kind`
+- Subtask `7.4 / 9`:
+  - decide whether overrides can target serialization pattern
+- Subtask `7.5 / 9`:
+  - define precedence rules when multiple generic or specific rules collide
+
+### Step `8 / 9` - Validate Policy Against Real Cases
+
+- Step summary:
+  - verify that the semantic policy can classify and explain representative real
+    cases without reopening unresolved semantic design work in issue `#15`
+- Step type:
+  - validation, documentation, and possible contract-level test preparation
+- Files to modify or add if needed:
+  - `docs/roadmap/issues/issue-14-semantic-mapping-rules.md`
+  - `docs/pipeline/known_limitations.md` if a new limitation is discovered
+  - optional semantic-policy tests if validation is captured in executable form
+- Root task `8 / 9`:
+  - validate the policy against representative normalized examples
+- Subtask `8.1 / 9`:
+  - validate a simple scalar field
+- Subtask `8.2 / 9`:
+  - validate a compact closed controlled table
+- Subtask `8.3 / 9`:
+  - validate a compact open controlled table
+- Subtask `8.4 / 9`:
+  - validate registry, thesaurus, and hierarchical references
+- Subtask `8.5 / 9`:
+  - validate a subtype-backed controlled family
+- Subtask `8.6 / 9`:
+  - validate unresolved and under-traced references
+- Subtask `8.7 / 9`:
+  - validate wrapper, `choice`, recursion, and override cases
+
+### Step `9 / 9` - Document Final Policy And Prepare Handoff
+
+- Step summary:
+  - record final semantic-policy decisions, unresolved limits, and the handoff
+    contract that issue `#15` will consume
+- Step type:
+  - documentation and issue closure preparation
+- Files to modify or add if needed:
+  - `docs/roadmap/issues/issue-14-semantic-mapping-rules.md`
+  - `docs/context/current_status.md`
+  - `docs/roadmap/cvn_generation_roadmap.md`
+  - `docs/pipeline/known_limitations.md` if new limitations are found
+- Root task `9 / 9`:
+  - document the final policy and prepare the downstream handoff to issue `#15`
+- Subtask `9.1 / 9`:
+  - record any deviations from the original issue plan
+- Subtask `9.2 / 9`:
+  - leave a clear downstream checklist for issue `#15`
+- Subtask `9.3 / 9`:
+  - update roadmap and context documents when issue state changes
+>>>>>>> Stashed changes
+
+## Established Semantic Policy Plan
+
+The issue `#14` planning session established the decisions below. These
+decisions are the operative specification for implementation work.
+
+### Scope Boundary
+
+Issue `#14` consumes only typed normalized metadata from issue `#13` as policy
+inputs. Raw XML, raw XSD, and generated structural classes may be inspected for
+human validation or override evidence, but they must not become base semantic
+inputs.
+
+Required normalized inputs are:
+
+- `code`
+- `xml_path`
+- `manual_type`
+- `manual_multiplicity`
+- `manual_obligatory`
+- `reference_resolution.status`
+- `reference_resolution.source_family`
+- `reference_resolution.source_artifact`
+- `reference_resolution.resolved_name`
+- `reference_resolution.serialization_pattern`
+- `reference_resolution.semantic_kind`
+- `reference_resolution.trace`
+
+Issue `#14` must not reimplement source-family detection, serialization-pattern
+classification, semantic-kind classification, side-package detection,
+subtype-backed detection, unresolved-reference detection, under-traced-table
+detection, manual/tree overlap computation, or `xml_path` construction.
+
+If a repeated semantic decision needs raw source inspection, the missing data
+belongs in issue `#13`. If the need is isolated and not generalizable, issue
+`#14` may express it as an explicit override with trace evidence.
+
+### Contract Families
+
+The semantic policy contract should be implemented as explicit typed Python
+structures, using `dataclass` records and `Enum` values. The root contract should
+be an indexed `SemanticPolicyBundle`.
+
+Minimum contract families are:
+
+- `SemanticPolicyBundle`
+- `SemanticFieldPolicy`
+- `ReferenceKindPolicy`
+- `BaseTypePolicy`
+- `NamingPolicy`
+- `MultiplicityPolicy`
+- `ChoiceWrapperPolicy`
+- `OverrideRule`
+- `ValidationCaseDefinition`
+- `PolicyMetadata`
+- `SemanticDecisionTrace`
+
+The bundle should expose deterministic lookups by CVN `code`, `xml_path`,
+`reference_resolution.semantic_kind`, `reference_resolution.serialization_pattern`,
+`manual_type`, and wrapper family.
+
+### Policy Enums
+
+The semantic contract should define these policy categories:
+
+| Category | Values |
+| --- | --- |
+| `SemanticBaseKind` | `TEXT`, `CONTROLLED_REFERENCE`, `DATE_LIKE`, `DECIMAL_NUMBER`, `BOOLEAN`, `DURATION_LIKE`, `UNKNOWN` |
+| `WrapperPolicyKind` | `COLLAPSE`, `VALUE_OBJECT_CANDIDATE`, `CHOICE_OBJECT_CANDIDATE`, `PRESERVE_STRUCTURAL_TRACE` |
+| `PresenceKind` | `REQUIRED`, `OPTIONAL`, `UNKNOWN` |
+| `CardinalityKind` | `SINGLE`, `REPEATED`, `UNKNOWN` |
+| `StructuralLimitationFlag` | `CHOICE_NOT_ENFORCED`, `LIST_MIN_OCCURS_WEAK`, `OBJECT_TYPED_ATTRIBUTE`, `WRAPPER_ERGONOMICS` |
+| `DomainShapeKind` | `PLAIN_VALUE`, `STRICT_ENUM_CANDIDATE`, `OPEN_CODED_VALUE`, `MEASURE_OR_SCALE_VALUE`, `IDENTIFIER_REFERENCE`, `SCOPE_REFERENCE`, `SUBTYPE_BACKED_VALUE`, `HIERARCHICAL_CODE_REFERENCE`, `REGISTRY_REFERENCE`, `VOCABULARY_REFERENCE`, `UNRESOLVED_REFERENCE`, `UNDER_TRACED_REFERENCE` |
+| `PolicyConfidence` | `HIGH`, `MEDIUM`, `LOW`, `REQUIRES_REVIEW` |
+| `EnumEligibility` | `ELIGIBLE`, `INELIGIBLE`, `REVIEW_REQUIRED` |
+
+### Lookup And Override Precedence
+
+Semantic policy resolution must use this precedence order:
+
+1. `code + xml_path` override
+2. `code` override
+3. `xml_path` override
+4. `reference_resolution.semantic_kind` policy or override
+5. `reference_resolution.serialization_pattern` refinement
+6. `manual_type` base policy
+7. wrapper policy
+8. presence/cardinality policy
+9. global defaults
+
+Overrides may change only semantic-policy outputs such as `domain_shape_kind`,
+`fallback_shape_kind`, `enum_eligibility`, `policy_confidence`,
+`wrapper_policy`, `presence_kind`, `cardinality_kind`, `normalized_name`,
+`naming_confidence`, `structural_limitation_flags`, notes, and diagnostics.
+
+Overrides must not mutate normalized input facts such as `code`, `xml_path`,
+`manual_type`, `manual_reference_table`, `reference_resolution.status`,
+`reference_resolution.source_family`, `reference_resolution.semantic_kind`,
+`reference_resolution.serialization_pattern`, or upstream trace facts.
+
+Same-priority conflicts should produce `PolicyConfidence.REQUIRES_REVIEW` rather
+than silently choosing one rule.
+
+### Base Type Policy
+
+Issue `#14` defines semantic base kinds, not final Python/domain output types.
+Issue `#15` will map these semantic kinds to concrete generated Python artifacts.
+
+| `manual_type` condition | Semantic base kind |
+| --- | --- |
+| `Alphanumeric` without resolved controlled reference | `TEXT` |
+| `Alphanumeric` with `reference_resolution.semantic_kind` | `CONTROLLED_REFERENCE` |
+| `Date` | `DATE_LIKE` |
+| `Double` | `DECIMAL_NUMBER` |
+| `Boolean` | `BOOLEAN` |
+| `Duration` | `DURATION_LIKE` |
+| missing or unknown manual type | `UNKNOWN` |
+
+Wrappers should collapse only when they add no domain information and do not
+represent meaningful `xs:choice`, variable granularity, or structural
+traceability concerns. `FlexibleDatesType`, `OfficialIdType`, `EntityTypeType`,
+and `EntityNameType` must be marked as `CHOICE_OBJECT_CANDIDATE`.
+
+### Presence And Cardinality Policy
+
+| Normalized field | Value | Policy output |
+| --- | --- | --- |
+| `manual_obligatory` | `True` | `PresenceKind.REQUIRED` |
+| `manual_obligatory` | `False` | `PresenceKind.OPTIONAL` |
+| `manual_obligatory` | `None` | `PresenceKind.UNKNOWN` |
+| `manual_multiplicity` | `True` | `CardinalityKind.REPEATED` |
+| `manual_multiplicity` | `False` | `CardinalityKind.SINGLE` |
+| `manual_multiplicity` | `None` | `CardinalityKind.UNKNOWN` |
+
+Issue `#14` records semantic cardinality. Issue `#15` decides concrete Pydantic
+field shape and validation behavior.
+
+### Reference Kind Policy Matrix
+
+| `reference_resolution.semantic_kind` | Domain shape | Fallback shape | Enum eligibility default | Confidence default |
+| --- | --- | --- | --- | --- |
+| `COMPACT_ENUM_LIKE_TABLE` | `STRICT_ENUM_CANDIDATE` | `OPEN_CODED_VALUE` | eligibility criteria required | `HIGH` or `REVIEW_REQUIRED` |
+| `COMPACT_SCALE_OR_MEASURE` | `MEASURE_OR_SCALE_VALUE` | `OPEN_CODED_VALUE` | `REVIEW_REQUIRED` | `MEDIUM` |
+| `IDENTIFIER_TYPE_TABLE` | `IDENTIFIER_REFERENCE` | `OPEN_CODED_VALUE` | `INELIGIBLE` for full identifier | `MEDIUM` |
+| `SCOPE_TABLE` | `SCOPE_REFERENCE` | `OPEN_CODED_VALUE` | eligibility criteria required | `MEDIUM` |
+| `SUBTYPE_BACKED_CONTROLLED_FAMILY` | `SUBTYPE_BACKED_VALUE` | `SUBTYPE_BACKED_VALUE` | `INELIGIBLE` until strict bridge exists | `MEDIUM` |
+| `HIERARCHICAL_THEMATIC_CLASSIFICATION` | `HIERARCHICAL_CODE_REFERENCE` | `HIERARCHICAL_CODE_REFERENCE` | `INELIGIBLE` | `HIGH` |
+| `SIDE_PACKAGE_REGISTRY` | `REGISTRY_REFERENCE` | `REGISTRY_REFERENCE` | `INELIGIBLE` | `HIGH` |
+| `SIDE_PACKAGE_THESAURUS_OR_VOCABULARY` | `VOCABULARY_REFERENCE` | `VOCABULARY_REFERENCE` | `INELIGIBLE` | `HIGH` |
+| `UNRESOLVED_MANUAL_ONLY_REFERENCE` | `UNRESOLVED_REFERENCE` | `UNRESOLVED_REFERENCE` | `INELIGIBLE` | `REQUIRES_REVIEW` |
+| `UNDER_TRACED_REFERENCE_TABLE` | `UNDER_TRACED_REFERENCE` | `UNDER_TRACED_REFERENCE` | `INELIGIBLE` | `REQUIRES_REVIEW` |
+
+Strict enum eligibility requires a resolved `REFERENCE_TABLE` source, no
+hierarchy, no delegate, not subtype-backed, not side-package, not unresolved,
+not under-traced, reasonable item count, stable codes, usable labels, and no
+`OTHERS` or delegate-open behavior unless explicitly accepted by override.
+
+### Naming Policy
+
+The domain-facing naming policy is Spanish-first because the tool is aimed at a
+Spanish research and university audience.
+
+Accepted naming rules:
+
+- use Spanish `manual_name` as the default label source
+- use `manual_short_name` only when clearer and non-ambiguous
+- normalize domain-facing identifiers to ASCII
+- remove accents and punctuation deterministically
+- use `snake_case` for fields and modules
+- use `PascalCase` for classes
+- preserve important acronyms such as `CVN`, `UNESCO`, `ORCID`, `DOI`, `ISBN`,
+  `ISSN`, and `H`
+- preserve CVN source identifiers literally in trace metadata
+- use English technical names for internal codegen and policy-contract classes
+
+Collision resolution should prefer readable Spanish names first, then semantic
+context, then CVN-code suffix as the last deterministic fallback. Ambiguous
+names should carry `naming_confidence=REQUIRES_REVIEW`.
+
+### Representative Inventory And Validation Results
+
+| Case | Role | Expected policy result | Validation |
+| --- | --- | --- | --- |
+| `000.010.000.020` / `Nombre` | simple scalar | `PLAIN_VALUE`, `TEXT`, enum ineligible | pass |
+| `CVN_SEX_A` / `000.010.000.030` | compact closed enum-like table | `STRICT_ENUM_CANDIDATE`, enum eligible | pass |
+| `CVN_ENTITY_TYPE` / `010.010.000.040` | compact open/review controlled table | `OPEN_CODED_VALUE`, enum review required | pass |
+| `CVN_KNOW_A` / `050.030.010.030` | subtype-backed family | `SUBTYPE_BACKED_VALUE`, enum ineligible | pass |
+| `ENTITY@Entity.xsd` / `010.010.000.020` | side-package registry | `REGISTRY_REFERENCE`, enum ineligible | pass |
+| `THESAURUS@thesaurus.xsd` / `010.010.000.260` | side-package vocabulary | `VOCABULARY_REFERENCE`, enum ineligible | pass |
+| `UNESCO_CODES` / `010.010.000.220` | hierarchical thematic classification | `HIERARCHICAL_CODE_REFERENCE`, enum ineligible | pass |
+| `CVN_AGENCY_C` / `060.010.000.030` | unresolved manual-only reference | `UNRESOLVED_REFERENCE`, review required | pass |
+| `CVN_INTERVENTION_A` | under-traced table, primary case | `UNDER_TRACED_REFERENCE`, review required | pass |
+| `CVN_PRUEBA` | under-traced table, secondary case | `UNDER_TRACED_REFERENCE`, review required | pass |
+| `FlexibleDatesType` | `xs:choice` date wrapper | `CHOICE_OBJECT_CANDIDATE` with limitation flags | pass |
+| `OfficialIdType` | `xs:choice` identifier wrapper | `CHOICE_OBJECT_CANDIDATE` with limitation flags | pass |
+| `EntityTypeType` | `xs:choice` entity type wrapper | `CHOICE_OBJECT_CANDIDATE` with limitation flags | pass |
+| `EntityNameType` | `xs:choice` entity name wrapper | `CHOICE_OBJECT_CANDIDATE` with limitation flags | pass |
+
+Under-traced tables may not produce generated domain fields in issue `#15` unless
+future normalized entries reference them.
+
+### Handoff Checklist For Issue `#15`
+
+Issue `#15` should:
+
+1. consume `SemanticPolicyBundle`
+2. avoid re-deriving auxiliary-source resolution
+3. generate by `domain_shape_kind`
+4. preserve `SemanticDecisionTrace`
+5. honor `enum_eligibility`
+6. honor `fallback_shape_kind`
+7. honor wrapper policies
+8. keep domain-facing names Spanish-first and normalized
+9. avoid strict enums for registry, thesaurus, hierarchical, subtype-backed,
+   unresolved, or under-traced references
+10. avoid under-traced field output unless normalized metadata later references
+    those tables
+
+### Established Open Limits
+
+The following limitations remain visible for issue `#15`:
+
+- `Subtype_Spa.xml` lacks a strict per-table bridge such as `CVN_KNOW_A` to
+  subtype records
+- `CVN_AGENCY_C` remains unresolved from the package alone
+- `CVN_INTERVENTION_A` and `CVN_PRUEBA` remain technically present but
+  under-traced
+- generated bindings do not enforce `xs:choice` mutual exclusivity
+- generated list defaults do not reliably enforce `minOccurs`
+- final domain emission remains deferred to issue `#15`
 
 ### Main Objective
 
@@ -32,6 +530,13 @@ deterministic semantic policy to consume.
   multiplicity, controlled vocabularies, and explicit exceptions
 - keep semantic cleanup outside `src/generated/` and preserve CVN code
   traceability for every domain-facing decision
+<<<<<<< Updated upstream
+=======
+- preserve semantic distinctions already surfaced by
+  `reference_resolution.semantic_kind` and
+  `reference_resolution.serialization_pattern` instead of collapsing all
+  controlled references into one policy bucket
+>>>>>>> Stashed changes
 
 ### Execution Steps
 
@@ -81,6 +586,7 @@ deterministic semantic policy to consume.
 
 ### Step `4` - Define Controlled-Table Policy
 
+<<<<<<< Updated upstream
 - classify reference tables into semantic categories such as:
   - internal CVN controlled tables that may become enums
   - ISO or other large standardized tables that may require a different policy
@@ -89,6 +595,31 @@ deterministic semantic policy to consume.
 - decide which controlled sets become strict enums and which remain strings,
   aliases, or external-reference representations
 - document the reasoning so issue `#15` can apply the same policy
+=======
+- use `reference_resolution.semantic_kind` as the main policy input
+  rather than rediscovering categories from raw table names alone
+- semantic policy must handle at minimum these normalized kinds:
+  - compact enum-like table
+  - compact scale or measure table
+  - identifier-type table
+  - scope table
+  - subtype-backed controlled family
+  - hierarchical thematic classification
+  - side-package registry
+  - side-package thesaurus or vocabulary
+  - unresolved manual-only reference
+  - technically present but under-traced table
+- define open versus closed treatment for each kind
+- define enum eligibility rules for compact internal tables
+- define explicit treatment for:
+  - `Entity`-backed registry references
+  - `Thesaurus`-backed vocabulary references
+  - `UNESCO_CODES` hierarchical thematic references
+  - subtype-backed `Subtype@Subtypes.xsd` families
+  - unresolved references such as `CVN_AGENCY_C`
+  - under-traced tables such as `CVN_INTERVENTION_A` and `CVN_PRUEBA`
+- document reasoning so issue `#15` can apply policy mechanically
+>>>>>>> Stashed changes
 
 ### Step `5` - Define Naming Rules For Domain Artifacts
 
@@ -129,7 +660,12 @@ deterministic semantic policy to consume.
 - create an explicit override strategy for cases that cannot be handled by the
   generic mapping algorithm alone
 - decide the granularity of overrides, for example by CVN `code`, manual type,
+<<<<<<< Updated upstream
   reference table, or technical path
+=======
+  `reference_resolution.semantic_kind`, serialization pattern, reference table,
+  or technical path
+>>>>>>> Stashed changes
 - keep overrides versioned, reviewable, and separate from generated output
 
 ### Step `9` - Validate Rules Against Representative Examples
@@ -192,6 +728,17 @@ still need to be made explicitly:
 
 - structural bindings preserve fidelity but expose known limitations for
   `choice`, multiplicity, and wrapper ergonomics
+<<<<<<< Updated upstream
+=======
+- auxiliary structural bindings now exist for:
+  - `ReferenceTables.xsd`
+  - `Subtypes.xsd`
+  - `Entity_v1.4.xsd`
+  - `Thesaurus.xsd`
+- normalized aggregate entries already include additive
+  `reference_resolution` metadata with typed status, source family,
+  serialization pattern, semantic kind, and traceability
+>>>>>>> Stashed changes
 - the official source package version recently delivered by FECYT includes
   side-package material for several references that must now be treated as
   recently added auxiliary modules rather than opaque placeholders:
@@ -201,6 +748,66 @@ still need to be made explicitly:
 - not all manual references are fully resolved from the package alone; a known
   example is `CVN_AGENCY_C`
 
+## Adjustments Made During Implementation
+
+- No code implementation has been performed yet.
+- Pre-implementation planning corrected the issue scope so semantic policy
+  consumes enriched normalized metadata from issue `#13` instead of inspecting
+  raw auxiliary sources as primary inputs.
+- The policy input names were aligned with the implemented normalization
+  contract: `reference_resolution.source_artifact` and
+  `reference_resolution.semantic_kind`.
+- Future issue documents for `#15`, `#16`, and `#17` were aligned with the
+  agreed semantic-policy handoff before starting code.
+
+## Implementation Performed
+
+- None yet. Issue `#14` is planned with an agreed execution policy, but semantic
+  policy modules, tests, and validation code are not implemented.
+
+## Verification
+
+- Documentation consistency was checked through issue-doc review and
+  `git diff --check`.
+- No code tests have been run for issue `#14` because no implementation exists
+  yet.
+- Future verification must cover semantic-policy construction, lookup
+  precedence, override conflict handling, base type mapping, reference-kind
+  mapping, enum eligibility, wrapper policy, naming policy, and representative
+  validation cases.
+
+## Findings
+
+- Issue `#14` needs a typed semantic policy contract rather than ad hoc mapping
+  logic inside the future generator.
+- Raw XML, raw XSD, and generated structural classes may support validation and
+  trace evidence, but normalized metadata is the operative semantic input.
+- Override policy must change only semantic outputs, not upstream normalized
+  facts.
+- `CVN_ENTITY_TYPE` is not safe for blind strict-enum generation because its
+  compact controlled table has open/review behavior.
+
+## Known Limitations
+
+- `Subtype_Spa.xml` lacks a strict per-table bridge such as `CVN_KNOW_A` to
+  subtype records.
+- `CVN_AGENCY_C` remains unresolved from the source package alone.
+- `CVN_INTERVENTION_A` and `CVN_PRUEBA` remain technically present but
+  under-traced.
+- Generated structural bindings do not enforce `xs:choice` mutual exclusivity.
+- Generated list defaults do not reliably enforce every `minOccurs` constraint.
+- Final domain model emission remains deferred to issue `#15`.
+
+## Impact On Future Issues
+
+- Issue `#15` must consume `SemanticPolicyBundle` and generate concrete domain
+  artifacts from semantic-policy outputs rather than redefining semantic
+  classification.
+- Issue `#16` must test semantic-policy behavior separately from generator
+  output behavior.
+- Issue `#17` must document `SemanticPolicyBundle` as the source-of-truth
+  handoff between normalized metadata and domain generation.
+
 ## Status
 
-- Status: pending
+- Status: planned with agreed execution policy

--- a/docs/roadmap/issues/issue-15-domain-model-generator.md
+++ b/docs/roadmap/issues/issue-15-domain-model-generator.md
@@ -19,6 +19,67 @@ semantic mapping rules.
 5. keep output separate from structural bindings
 6. make regeneration deterministic
 
+<<<<<<< Updated upstream
+=======
+## Corrected Generator Responsibilities
+
+The generator design for issue `#15` must support distinct domain
+representations for the controlled-reference classes already surfaced by
+normalization and semantic policy.
+
+At minimum, the generator must support:
+
+1. strict enums or near-enums for closed compact tables
+2. open coded-value representations for open controlled tables
+3. structured external registry references for `Entity`-backed values
+4. hierarchical subject or vocabulary references for `Thesaurus` and
+   `UNESCO_CODES`
+5. subtype-backed values with traceability to subtype codification support
+6. explicit unresolved or under-traced reference representations when the
+   package cannot support a stronger domain guarantee
+
+The generator should prefer domain shapes that preserve semantic class
+distinctions instead of flattening all controlled references to `str` plus
+comments.
+
+## Semantic Policy Handoff From Issue `#14`
+
+Issue `#15` must treat the semantic policy contract from issue `#14` as its
+generator input contract. The expected upstream policy artifact is
+`SemanticPolicyBundle`.
+
+The generator should consume these semantic-policy decisions directly:
+
+- `domain_shape_kind`
+- `fallback_shape_kind`
+- `enum_eligibility`
+- `policy_confidence`
+- `wrapper_policy`
+- `presence_kind`
+- `cardinality_kind`
+- `normalized_name`
+- `naming_confidence`
+- `structural_limitation_flags`
+- `SemanticDecisionTrace`
+
+Issue `#15` may decide concrete Python emission details, such as `Enum`,
+`Literal`, Pydantic model classes, wrapper classes, or open coded-value records.
+It must not change the semantic meaning established by issue `#14`.
+
+The generator must not emit strict enums for policy outputs representing:
+
+- registry references
+- thesaurus or vocabulary references
+- hierarchical code references
+- subtype-backed values
+- unresolved references
+- under-traced references
+
+Under-traced references should remain explicit in policy-aware generator logic,
+but issue `#15` should not emit fields for under-traced tables unless normalized
+metadata entries later reference those tables.
+
+>>>>>>> Stashed changes
 ## Recommended First Scope
 
 - identification
@@ -35,6 +96,47 @@ semantic mapping rules.
 ## Generation Principle
 
 - consume normalized metadata rather than generating from raw XSDs directly
+
+## Adjustments Made During Implementation
+
+- No implementation has been performed yet.
+- Pre-implementation planning is now aligned with the agreed semantic policy
+  contract from issue `#14`.
+- The generator scope is clarified so semantic decisions come from
+  `SemanticPolicyBundle`, not from raw XML, raw XSD, or regenerated
+  auxiliary-source classification.
+
+## Implementation Performed
+
+- None yet. Issue `#15` remains pending until issue `#14` implementation is
+  complete.
+
+## Verification
+
+- No code verification has been run for issue `#15`.
+- Future verification must prove generated domain artifacts consume semantic
+  policy outputs instead of redefining semantic classification in generator code.
+
+## Findings
+
+- The generator needs an explicit handoff boundary from issue `#14` to avoid
+  duplicating reference-resolution and semantic-classification logic.
+- Final Python artifact shapes are still an issue `#15` decision, but semantic
+  categories and override outcomes are not.
+
+## Known Limitations
+
+- Domain model emission is not implemented yet.
+- Concrete Python representations for strict enums, open coded values,
+  registries, vocabularies, subtype-backed values, unresolved references, and
+  under-traced references remain undecided until issue `#15` implementation.
+
+## Impact On Future Issues
+
+- Issue `#16` must test generator behavior against `SemanticPolicyBundle`
+  outputs rather than raw source classifications.
+- Issue `#17` must document `SemanticPolicyBundle` as the semantic source of
+  truth for domain generation.
 
 ## Status
 

--- a/docs/roadmap/issues/issue-16-generation-pipeline-tests.md
+++ b/docs/roadmap/issues/issue-16-generation-pipeline-tests.md
@@ -19,6 +19,54 @@ for the structural and semantic generation workflow.
 6. add at least one end-to-end generation test
 7. cover known mismatches and special cases
 
+<<<<<<< Updated upstream
+=======
+## Corrected Minimum Coverage Matrix
+
+The corrected test plan must include:
+
+1. generation tests for auxiliary structural targets in addition to the core
+   schemas
+2. normalization-resolution tests for auxiliary references
+3. regression coverage for subtype-backed tables
+4. regression coverage for side-package registry references
+5. regression coverage for side-package thesaurus and hierarchical references
+6. regression coverage for unresolved references
+7. regression coverage for technically present but under-traced tables
+8. semantic policy tests keyed by normalized reference classifications
+9. generator tests proving distinct domain shapes per semantic class
+10. end-to-end tests proving semantic generation consumes enriched normalization
+    metadata correctly
+
+## Semantic Policy Coverage From Issue `#14`
+
+Issue `#16` must test the semantic policy contract as a first-class pipeline
+stage, not only the final generated models.
+
+Required semantic-policy coverage includes:
+
+1. `SemanticPolicyBundle` construction and deterministic lookup behavior
+2. override precedence for `code + xml_path`, `code`, `xml_path`,
+   `reference_resolution.semantic_kind`, `reference_resolution.serialization_pattern`,
+   `manual_type`, wrapper policy, presence/cardinality policy, and defaults
+3. same-priority override conflicts producing
+   `PolicyConfidence.REQUIRES_REVIEW`
+4. base type mapping for `Alphanumeric`, controlled `Alphanumeric`, `Date`,
+   `Double`, `Boolean`, `Duration`, missing, and unknown manual types
+5. enum eligibility decisions for strict, open, registry, thesaurus,
+   hierarchical, subtype-backed, unresolved, and under-traced references
+6. wrapper policy decisions for `FlexibleDatesType`, `OfficialIdType`,
+   `EntityTypeType`, and `EntityNameType`
+7. Spanish-first naming normalization, including ASCII normalization,
+   `snake_case`, `PascalCase`, acronym preservation, and deterministic collision
+   fallback
+8. trace preservation through CVN `code`, `xml_path`,
+   `reference_resolution.trace`, and `SemanticDecisionTrace`
+
+The test suite should verify semantic policy outputs before generator tests so
+generator failures can be separated from semantic-policy failures.
+
+>>>>>>> Stashed changes
 ## Minimum Coverage Goals
 
 1. structural parsing smoke tests for generated bindings
@@ -32,6 +80,90 @@ for the structural and semantic generation workflow.
 - issue `#12` already added runner smoke tests
 - known XML/XSD mismatches must be asserted as documented behavior rather than
   treated as surprising failures
+<<<<<<< Updated upstream
+=======
+- issue `#13` already preserves the validated normalization baseline:
+  - total normalized codes: `1457`
+  - manual-only codes: `27`
+  - tree-only codes: `1`
+  - overlapping codes: `1429`
+- issue `#13` already reports auxiliary-resolution mismatches including:
+  - unresolved manual reference
+  - ambiguous auxiliary resolution
+  - missing subtype support
+  - under-traced reference table
+
+## Representative Regression Cases Required
+
+The corrected test suite should include explicit coverage for documented cases
+such as:
+
+- `CVN_SEX_A` as compact direct table
+- `CVN_KNOW_A` as subtype-backed reference family
+- `ENTITY@Entity.xsd` as side-package registry reference
+- `THESAURUS@thesaurus.xsd` as side-package thesaurus reference
+- `UNESCO_CODES` as hierarchical thematic reference
+- `CVN_AGENCY_C` as unresolved manual-only reference
+- `CVN_INTERVENTION_A` and `CVN_PRUEBA` as under-traced tables
+
+Additional policy-level expectations from issue `#14` are:
+
+- `000.010.000.020` / `Nombre` remains plain text and enum-ineligible
+- `CVN_SEX_A` remains strict-enum eligible when table evidence is closed and
+  stable
+- `CVN_ENTITY_TYPE` remains open or review-required because delegate/open
+  behavior prevents blind strict-enum generation
+- side-package, hierarchical, subtype-backed, unresolved, and under-traced cases
+  remain strict-enum ineligible by default
+
+## CI Impact
+
+- issue `#25` already provides pull-request execution of all tests under
+  `tests/`
+- new auxiliary-generation, normalization-resolution, semantic-policy, and
+  generator tests should therefore remain under `tests/` so CI picks them up
+  automatically without workflow changes
+>>>>>>> Stashed changes
+
+## Adjustments Made During Implementation
+
+- No implementation has been performed yet.
+- Pre-implementation planning is now aligned with the semantic-policy contract
+  agreed in issue `#14`.
+- The future test scope now separates semantic-policy verification from domain
+  generator verification.
+
+## Implementation Performed
+
+- None yet. Issue `#16` remains pending until issue `#14` and issue `#15`
+  provide implementation artifacts to test.
+
+## Verification
+
+- No code verification has been run for issue `#16`.
+- Future verification must include semantic-policy tests, generator tests, and
+  end-to-end tests under `tests/` so CI from issue `#25` runs them.
+
+## Findings
+
+- Semantic-policy behavior needs dedicated unit coverage before generated-model
+  assertions, otherwise failures may be misattributed to the generator.
+- Representative cases from issue `#14` provide the minimum regression inventory
+  for controlled-reference behavior.
+
+## Known Limitations
+
+- The final semantic-policy test commands and fixtures cannot be finalized until
+  issue `#14` implementation creates concrete modules and public functions.
+- Generator-output tests cannot be finalized until issue `#15` defines concrete
+  Python artifact shapes.
+
+## Impact On Future Issues
+
+- Issue `#17` must document how to run semantic-policy tests separately from
+  structural, normalization, generator, and end-to-end tests.
+- CI workflow from issue `#25` does not need changes if new tests remain under
+  `tests/`.
 
 ## Status
 

--- a/docs/roadmap/issues/issue-17-workflow-documentation.md
+++ b/docs/roadmap/issues/issue-17-workflow-documentation.md
@@ -19,6 +19,48 @@ models.
 5. update repository documentation
 6. leave one obvious workflow for future contributors
 
+<<<<<<< Updated upstream
+=======
+## Corrected Workflow Stages That Must Be Documented
+
+The final workflow documentation must explicitly include:
+
+1. generation of core structural bindings
+2. generation of auxiliary structural bindings
+3. normalization of manual and tree metadata
+4. auxiliary-source loading and deterministic reference-resolution enrichment
+5. semantic policy application over enriched normalized metadata
+6. domain-model generation
+7. pipeline verification and CI coverage
+
+The semantic policy stage should be documented as the handoff from normalized
+metadata to domain generation:
+
+```text
+normalized metadata + auxiliary reference resolution
+-> SemanticPolicyBundle
+-> domain generator
+-> domain-oriented Pydantic artifacts
+```
+
+The workflow must make clear that `SemanticPolicyBundle` is the source of truth
+for generator semantics. Raw XML, raw XSD, and generated structural bindings may
+support validation and traceability, but they are not the source for redefining
+semantic policy in later stages.
+
+## Controlled-Reference Source-Of-Truth Order
+
+The workflow documentation must explain the effective source-of-truth order for
+controlled references already materialized by normalization logic:
+
+1. explicit side-package references such as `ENTITY@Entity.xsd` and
+   `THESAURUS@thesaurus.xsd`
+2. direct `ReferenceTables.xml` matches where applicable
+3. subtype-backed classification through `Subtype@Subtypes.xsd`
+4. hierarchical thematic classification where technical metadata supports it
+5. unresolved documented exceptions and under-traced tables
+
+>>>>>>> Stashed changes
 ## Expected Documentation Outcome
 
 - one obvious regeneration workflow
@@ -26,6 +68,102 @@ models.
 - explicit documentation of known limitations and unresolved external tables
 - sufficient guidance for another contributor to rerun the complete workflow
   from a clean checkout
+<<<<<<< Updated upstream
+=======
+- explicit documentation of repository boundaries between structural fidelity,
+  normalization/resolution logic, semantic policy, and domain outputs
+
+## Semantic Policy Documentation Requirements
+
+The final workflow documentation must describe these issue `#14` policy outputs
+because issue `#15` and issue `#16` depend on them:
+
+- `domain_shape_kind`
+- `fallback_shape_kind`
+- `enum_eligibility`
+- `policy_confidence`
+- `wrapper_policy`
+- `presence_kind`
+- `cardinality_kind`
+- `normalized_name`
+- `naming_confidence`
+- `structural_limitation_flags`
+- `SemanticDecisionTrace`
+
+The workflow documentation must also explain:
+
+- Spanish-first domain naming and deterministic identifier normalization
+- versioned and reviewable override policy
+- strict-enum eligibility limits
+- open coded-value fallback behavior
+- wrapper and `xs:choice` treatment
+- preservation of CVN source identifiers in trace metadata
+- separation between semantic policy decisions and concrete Python emission
+  choices
+
+## Repository Boundaries To Document
+
+- `src/generated/` remains structural fidelity layer generated from canonical
+  schemas
+- `src/cvn_codegen/` contains hand-maintained loading, normalization,
+  resolution, semantic-policy, and generation logic
+- `src/models/cvn/` remains target location for future domain-oriented outputs
+
+Traceability documentation should identify these values as the minimum chain
+from source metadata to domain output:
+
+- CVN `code`
+- `xml_path`
+- `reference_resolution.trace`
+- `SemanticDecisionTrace`
+
+## Known Limitations
+
+- `CVN_AGENCY_C` remains unresolved from package alone
+- subtype catalog availability does not always expose a strict per-table key for
+  direct subtype verification
+- `CVN_INTERVENTION_A` and `CVN_PRUEBA` remain technically present but
+  under-traced
+- structural bindings do not enforce `xs:choice` mutual exclusivity
+- generated list defaults do not reliably enforce every `minOccurs` constraint
+- known XML/XSD mismatch behavior, such as `CVNTreeModel.xml`, must remain
+  documented as validated limitation rather than hidden failure
+>>>>>>> Stashed changes
+
+## Adjustments Made During Implementation
+
+- No implementation has been performed yet.
+- Pre-implementation planning is now aligned with the issue `#14` semantic
+  policy contract and the issue `#15` generator handoff.
+- The future workflow documentation scope now treats semantic policy application
+  as an explicit pipeline stage.
+
+## Implementation Performed
+
+- None yet. Issue `#17` remains pending until semantic policy, domain generator,
+  and test coverage are implemented.
+
+## Verification
+
+- No workflow verification has been run for issue `#17`.
+- Future verification must confirm that the documented commands regenerate or
+  validate structural bindings, normalization, semantic policy, domain outputs,
+  and tests from a clean checkout.
+
+## Findings
+
+- Workflow documentation must prevent future contributors from treating raw XML,
+  raw XSD, or generated structural bindings as semantic-policy sources after
+  issue `#14` establishes `SemanticPolicyBundle`.
+- The final workflow needs separate explanations for structural fidelity,
+  normalization/resolution, semantic policy, generation, and verification.
+
+## Impact On Future Issues
+
+- Issue `#17` should use issue `#14`, issue `#15`, and issue `#16` records as
+  source documents for the final workflow.
+- Human-facing entry guidance should be updated only if the final workflow
+  changes repository orientation, reading order, or document map.
 
 ## Status
 


### PR DESCRIPTION
This pull request updates the CVN code generation roadmap and associated issue documentation to reflect the agreed semantic mapping policy for issue `#14`, and clarifies the downstream impact on planned implementation, testing, and workflow documentation for issues `#15`, `#16`, and `#17`. No code has been implemented yet; all changes are to planning documents and issue records. The main focus is to document the explicit semantic-policy handoff, correct dependencies, and clarify verification and workflow boundaries for future contributors.

**Semantic Policy Planning and Documentation:**

* Updated the status and planning records for issue `#14` to indicate that an execution policy is agreed and documented, specifying the semantic input contract and policy plan for normalization names, domain shapes, enum eligibility, and handoff to issue `#15`. [[1]](diffhunk://#diff-af079787bf7b6ce442de3db0038c942456c651faee50f98ee071654df5cb5696R235-R256) [[2]](diffhunk://#diff-3fe245a36a2de8adfeb24d497fe031fba737fce1f42306830c278880adbe980aR32-R42) [[3]](diffhunk://#diff-3fe245a36a2de8adfeb24d497fe031fba737fce1f42306830c278880adbe980aR226-R234)
* Clarified that issue `#14` implementation will create explicit typed policy contracts in `src/cvn_codegen/` and not edit `src/generated/`.

**Downstream Issue Planning and Handoff:**

* Updated issue `#15` to require that the domain model generator consumes semantic-policy outputs (from `SemanticPolicyBundle`) rather than re-deriving semantic classification, and clarified the generator’s responsibilities and limitations. [[1]](diffhunk://#diff-09143b91e7c90c9d9cdbecaa937e8f6d4b68afdc07ec4c7602a9e15ff00f7a12R22-R82) [[2]](diffhunk://#diff-09143b91e7c90c9d9cdbecaa937e8f6d4b68afdc07ec4c7602a9e15ff00f7a12R100-R140)
* Updated issue `#16` to require that generation pipeline tests verify semantic-policy outputs as a first-class stage, with a detailed coverage matrix and representative regression cases. [[1]](diffhunk://#diff-d9d41342db9148b8372fa494e222ef7baf23d31f5ac0eeaaf538a5c18e7415eeR22-R69) [[2]](diffhunk://#diff-d9d41342db9148b8372fa494e222ef7baf23d31f5ac0eeaaf538a5c18e7415eeR83-R166)
* Updated issue `#17` to require workflow documentation to explicitly cover all pipeline stages, clarify repository boundaries, and document `SemanticPolicyBundle` as the source of truth for generator semantics.

**Terminology and Status Updates:**

* Changed terminology from "Next Planned Issue" to "Next Planned Work" and clarified that the next work item is implementing issue `#14` semantic policy contracts and tests.
* Updated status dates and planning tables to reflect the current state and new dependencies after semantic policy agreement. [[1]](diffhunk://#diff-af079787bf7b6ce442de3db0038c942456c651faee50f98ee071654df5cb5696R5-R9) [[2]](diffhunk://#diff-3fe245a36a2de8adfeb24d497fe031fba737fce1f42306830c278880adbe980aR32-R42)

These changes ensure that all future implementation and testing is aligned with the documented semantic policy, and that workflow documentation will guide contributors through the correct pipeline stages and repository boundaries.…N stuff