### PR TITLE
 Implement wrapper type traceability handoff for CVN domain generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ Every new session should read these files in order before making changes:
   `docs/roadmap/hotfixes/hotfix-6-roadmap-realignment-for-auxiliary-catalog-semantic-integration.md`
 - hotfix `#7`:
   `docs/roadmap/hotfixes/hotfix-7-dynamic-reference-table-enum-eligibility-evaluation.md`
+- hotfix `#8`:
+  `docs/roadmap/hotfixes/hotfix-8-wrapper-type-traceability-in-normalized-handoff.md`
 
 ### Development Reference
 

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -120,8 +120,8 @@ files in order:
   corrective plan for replacing hardcoded enum decisions with dynamic
   `ReferenceTables.xml` evidence in the normalization-to-semantic handoff
 - `docs/roadmap/hotfixes/hotfix-8-wrapper-type-traceability-in-normalized-handoff.md`:
-  corrective plan for exposing wrapper type evidence to semantic and domain
-  generation stages without raw structural rediscovery
+  implemented corrective handoff for exposing wrapper type evidence to semantic
+  and domain generation stages without raw structural rediscovery
 
 ### Development Reference
 

--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -2,7 +2,7 @@
 
 ## Status Date
 
-- Last updated: 2026-06-27
+- Last updated: 2026-06-30
 
 ## Completed Or Stabilized Work
 
@@ -278,15 +278,27 @@
 
 ### Hotfix `#8`
 
-- a corrective hotfix record now exists at
+- the corrective hotfix for wrapper type traceability is implemented and verified
+- the authoritative record exists at
   `docs/roadmap/hotfixes/hotfix-8-wrapper-type-traceability-in-normalized-handoff.md`
-- the hotfix records that current normalized tree metadata does not expose
-  wrapper type names such as `FlexibleDatesType`, `OfficialIdType`,
-  `EntityTypeType`, or `EntityNameType`
-- issue `#15` therefore does not attach wrapper-aware field shapes by scanning
-  raw XSD files or generated structural bindings
-- the documented evidence probe found `0` exact and `0` partial wrapper-name
-  matches across `5051` extracted tree entries
+- `src/cvn_codegen/structural_type_trace.py` now resolves structural type
+  evidence from `CVN.xsd`, `Common.xsd`, and normalized `CVNTreeModel.xml`
+  paths
+- normalized entries can now carry `StructuralTypeEvidence` through
+  `TreePathEntry.structural_type_evidence` and
+  `NormalizedCodeEntry.structural_type_evidence`
+- canonical domain generation passes `CVN.xsd` and `Common.xsd` into
+  normalization so wrapper evidence is available without generator-side raw XSD
+  scanning
+- semantic policy now attaches wrapper policies for terminal wrapper evidence
+  from `FlexibleDatesType`, `OfficialIdType`, `EntityTypeType`, and
+  `EntityNameType`
+- shared wrapper value components now exist for `FlexibleDateValue`,
+  `OfficialIdValue`, `EntityTypeValue`, and `EntityNameValue`
+- child alternatives such as `DNI` preserve ancestor wrapper trace without being
+  treated as terminal wrapper fields
+- full-suite verification passed with `uv run pytest -n auto tests`
+  and result `228 passed in 189.76s (0:03:09)`
 
 ### Issue `#15`
 
@@ -310,9 +322,10 @@
   references, subtype-backed values, hierarchical references, registry
   references, vocabulary references, unresolved references, and under-traced
   references
-- wrapper-aware automatic field attachment remains deferred to hotfix `#8`
-- full-suite verification passed with `uv run pytest -n auto tests`
-  and result `215 passed in 208.54s (0:03:28)`
+- wrapper-aware fields now consume hotfix `#8` structural type evidence and map
+  to shared wrapper value components when canonical XSD enrichment is provided
+- latest full-suite verification passed with `uv run pytest -n auto tests`
+  and result `228 passed in 189.76s (0:03:09)`
 
 ## Current Technical Baseline
 
@@ -339,7 +352,7 @@
     domain generation behavior
   - tests should cover canonical generated output, importability, determinism,
     and representative controlled-reference families
-  - tests should preserve the wrapper-handoff boundary documented by hotfix `#8`
+  - tests should cover the wrapper-handoff boundary implemented by hotfix `#8`
 
 ## Blocking Or Relevant Limitations
 
@@ -353,6 +366,8 @@
   per-table subtype verification in the current normalization layer
 - strict enum eligibility for compact `ReferenceTables.xml` tables now uses
   hotfix `#7` evidence in the normalization-to-semantic handoff
+- wrapper-aware domain attachment requires normalization runs that provide
+  `cvn_xsd_path` and `common_xsd_path`; canonical generation provides them
 
 All of these are documented in:
 

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -92,8 +92,8 @@ Agents should also read `AGENTS.md` before this file.
   corrective plan for dynamic strict-enum eligibility evaluation across
   `ReferenceTables.xml` without semantic-policy hardcoding
 - `docs/roadmap/hotfixes/hotfix-8-wrapper-type-traceability-in-normalized-handoff.md`:
-  corrective plan for exposing wrapper type evidence to downstream semantic and
-  domain generation without raw structural rediscovery
+  implemented corrective handoff for exposing wrapper type evidence to downstream
+  semantic and domain generation without raw structural rediscovery
 
 ### Development And Contribution
 
@@ -177,6 +177,8 @@ docs/CvnXML_v1.4.3_2.1_17012025/
   `docs/roadmap/hotfixes/hotfix-6-roadmap-realignment-for-auxiliary-catalog-semantic-integration.md`
 - Hotfix `#7`:
   `docs/roadmap/hotfixes/hotfix-7-dynamic-reference-table-enum-eligibility-evaluation.md`
+- Hotfix `#8`:
+  `docs/roadmap/hotfixes/hotfix-8-wrapper-type-traceability-in-normalized-handoff.md`
 
 Each issue document records:
 

--- a/docs/pipeline/cvn_pydantic_generation_pipeline.md
+++ b/docs/pipeline/cvn_pydantic_generation_pipeline.md
@@ -182,6 +182,7 @@ Official XSDs
   -> structural Pydantic bindings
 
 SpecificationManual.xml + CVNTreeModel.xml
+  + optional CVN.xsd/Common.xsd structural type trace
   -> normalization
   -> semantic mapping rules and overrides
   -> domain Pydantic models
@@ -200,8 +201,13 @@ This means:
   roadmap issues, including:
   - normalized entries by CVN code
   - tree entries by technical XML path
+  - optional structural type evidence when `cvn_xsd_path` and `common_xsd_path`
+    are provided
   - source-exclusive code sets
   - currently documented mismatch reporting
+- canonical domain generation provides `CVN.xsd` and `Common.xsd` to this entry
+  point so wrapper policies can be attached without generator-side raw XSD
+  inspection
 - lower-level helper functions inside `cvn_codegen.normalization` remain
   importable when needed, but they are not the preferred integration surface for
   later stages

--- a/docs/pipeline/known_limitations.md
+++ b/docs/pipeline/known_limitations.md
@@ -21,7 +21,7 @@ do not need to rediscover them.
   - issue `#14` defines the semantic policy
   - issue `#15` should restore domain-facing semantics
 
-### Wrapper Type Names Are Not Present In The Normalized Field Handoff
+### Wrapper Type Evidence Requires XSD-Enriched Normalization
 
 - Affected wrapper families include:
   - `FlexibleDatesType`
@@ -29,22 +29,19 @@ do not need to rediscover them.
   - `EntityTypeType`
   - `EntityNameType`
 - Confirmed behavior:
-  - the current normalized tree handoff preserves CVN codes, XML paths,
-    property names, indicator names, and selected `tree_value` content
-  - it does not preserve wrapper type names needed for automatic wrapper-aware
-    field attachment in the domain generator
-  - the issue `#15` evidence probe found `0` exact and `0` partial wrapper-name
-    matches across `5051` extracted tree entries
+  - hotfix `#8` adds typed `StructuralTypeEvidence` to the normalized handoff
+    when normalization receives `cvn_xsd_path` and `common_xsd_path`
+  - canonical domain generation provides those XSD paths and can attach wrapper
+    policy without scanning raw XSD files inside generator logic
+  - normalization calls that omit XSD paths preserve backward-compatible empty
+    structural evidence and therefore cannot attach wrapper-aware field shapes
 - Impact:
-  - issue `#15` cannot safely attach wrapper-aware field shapes from normalized
-    metadata alone
-  - the generator must not recover wrappers by scanning raw XSD files or
-    generated structural bindings because that would violate the pipeline
-    boundary
+  - canonical issue `#15` generation can consume wrapper-aware domain shapes
+  - custom callers that need wrapper attachment must use the XSD-enriched
+    normalization path
 - Expected follow-up:
-  - hotfix `#8` must extend the normalized or semantic handoff with typed wrapper
-    evidence
-  - issue `#16` should add regression coverage once that handoff exists
+  - issue `#16` should keep regression coverage for both enriched wrapper
+    handoff behavior and no-XSD backward-compatible behavior
 
 ### `minOccurs` Is Not Enforced For Generated Lists
 

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -30,7 +30,7 @@ Goal:
 | `#12` | Generate structural Pydantic bindings from CVN XSDs | Completed with documented limitations | Tree model XML/XSD mismatch remains documented |
 | `#13` | Parse and normalize `SpecificationManual.xml` and `CVNTreeModel.xml` | Completed | Core normalization and auxiliary-reference resolution enrichment implemented; baseline overlap counts preserved |
 | `#14` | Define semantic mapping rules and override policy | Completed | Semantic policy bundle, resolver, overrides, naming, wrapper policies, validation inventory, and tests implemented |
-| `#15` | Implement the domain Pydantic model generator | Completed with documented limitations | Generator, shared components, generated output, and verification are implemented; wrapper-aware auto-attachment remains deferred to hotfix `#8` |
+| `#15` | Implement the domain Pydantic model generator | Completed | Generator, shared components, wrapper-aware handoff, generated output, and verification are implemented |
 | `#16` | Add automated tests for the generation pipeline | Next | Must cover both core pipeline and auxiliary enrichment path |
 | `#17` | Document and automate the complete workflow | Pending | Must document corrected full workflow including auxiliary stages |
 | `#25` | GitHub Actions CI pipeline for PR testing on main and development | Completed | PRs to `main` and `development` now run the `tests` check |
@@ -222,9 +222,9 @@ Authoritative record:
   domain generation can attach wrapper-aware field shapes without re-reading raw
   structural sources
 - Current status:
-  - planned follow-up after issue `#15`
-  - issue `#15` is completed without wrapper auto-attachment and documents this
-    boundary explicitly
+  - implemented and verified after issue `#15`
+  - canonical domain generation now consumes typed wrapper evidence without raw
+    structural rediscovery in generator logic
 
 Authoritative record:
 
@@ -291,7 +291,8 @@ Authoritative record:
   - canonical generated output is emitted under `src/models/cvn/generated/`
   - the canonical generator run emits `105` Python files
   - full repository verification passed after implementation
-  - wrapper-aware automatic field attachment remains deferred to hotfix `#8`
+  - wrapper-aware automatic field attachment consumes hotfix `#8` structural type
+    evidence
 
 ### Issue `#16`
 

--- a/docs/roadmap/hotfixes/hotfix-8-wrapper-type-traceability-in-normalized-handoff.md
+++ b/docs/roadmap/hotfixes/hotfix-8-wrapper-type-traceability-in-normalized-handoff.md
@@ -206,18 +206,289 @@ The hotfix is complete when all of these are true:
 5. issue `#15` documentation is updated to remove or narrow the temporary
    limitation once the handoff exists
 
+## Execution Plan
+
+This section is the accepted implementation plan for hotfix `#8`. During
+execution, progress must be reported by task and, when applicable, by subtask,
+using the identifiers below.
+
+### Execution Reporting Protocol
+
+Each work update for this hotfix must include:
+
+1. current task identifier and title
+2. current subtask identifier when work is inside a subtask
+3. short summary of what the task or subtask will do before starting it
+4. final note stating whether the user must modify any file
+5. next step to follow
+
+When code files must change, the default expectation is that the user performs
+the modification unless explicitly delegated otherwise. Documentation-only edits
+may be made by repository agents when requested.
+
+### Chosen Design
+
+Use an upstream structural-to-normalized bridge:
+
+```text
+CVN.xsd + Common.xsd + CVNTreeModel.xml
+  -> structural wrapper trace index
+  -> normalized metadata handoff
+  -> semantic policy wrapper attachment
+  -> domain generator wrapper-aware field decisions
+```
+
+The domain generator must consume typed handoff data. It must not inspect raw
+XSD files or generated structural bindings to attach wrapper semantics.
+
+### H8-T01 - Structural Trace Contract
+
+Summary: define the additive typed metadata needed to carry structural wrapper
+evidence through normalization without changing generated bindings.
+
+Subtasks:
+
+1. `H8-T01.1`: add a `StructuralTypeEvidence` dataclass to
+   `src/cvn_codegen/normalization_types.py`
+2. `H8-T01.2`: include source fields such as `element_name`,
+   `declaring_type_name`, `structural_type_name`, `xml_path`, and
+   `source_xsd_file`
+3. `H8-T01.3`: include wrapper-specific fields such as
+   `terminal_wrapper_type_name` and `ancestor_wrapper_type_names`
+4. `H8-T01.4`: extend `TreePathEntry` with optional structural evidence
+5. `H8-T01.5`: extend `NormalizedCodeEntry` with aggregated structural evidence
+
+User file modification required: yes, code files under `src/cvn_codegen/`.
+
+Next step: implement structural trace extraction in `H8-T02`.
+
+### H8-T02 - Structural Trace Extraction Module
+
+Summary: create an upstream extractor that reads canonical XSD structure and
+builds a deterministic type-resolution map independent from the domain
+generator.
+
+Subtasks:
+
+1. `H8-T02.1`: create `src/cvn_codegen/structural_type_trace.py`
+2. `H8-T02.2`: parse `CVN.xsd` and `Common.xsd` with namespace-safe XML logic
+3. `H8-T02.3`: extract `complexType -> child element -> child type` mappings
+4. `H8-T02.4`: extract root element mappings for `Version`, `Agent`, and
+   `CvnItem`
+5. `H8-T02.5`: resolve `TreePathEntry.xml_path` segments against the structural
+   map
+6. `H8-T02.6`: detect terminal wrapper types among `FlexibleDatesType`,
+   `OfficialIdType`, `EntityTypeType`, and `EntityNameType`
+7. `H8-T02.7`: preserve ancestor wrapper evidence without treating descendants
+   as terminal wrapper fields
+
+User file modification required: yes, code file under `src/cvn_codegen/`.
+
+Next step: wire extracted evidence into normalization in `H8-T03`.
+
+### H8-T03 - Normalization Integration
+
+Summary: enrich tree entries and normalized aggregate entries with structural
+evidence before semantic policy consumes them.
+
+Subtasks:
+
+1. `H8-T03.1`: update `build_tree_path_entry(...)` to accept optional structural
+   evidence
+2. `H8-T03.2`: add XSD path parameters to the normalization entry point, likely
+   `cvn_xsd_path` and `common_xsd_path`
+3. `H8-T03.3`: enrich tree entries after loading `CVNTreeModel.xml` and before
+   indexing by code and XML path
+4. `H8-T03.4`: aggregate structural evidence from `TreePathEntry` values into
+   each `NormalizedCodeEntry`
+5. `H8-T03.5`: preserve previous behavior when XSD paths are not provided
+
+User file modification required: yes, code files under `src/cvn_codegen/`.
+
+Next step: attach wrapper policies in semantic layer in `H8-T04`.
+
+### H8-T04 - Semantic Policy Attachment
+
+Summary: consume normalized structural evidence and attach existing wrapper
+policies to real normalized fields.
+
+Subtasks:
+
+1. `H8-T04.1`: extend `SemanticDecisionTrace` with wrapper type names
+2. `H8-T04.2`: extend `SemanticFieldPolicy` with applied wrapper policy data
+3. `H8-T04.3`: resolve wrapper policies using `wrapper_policies_by_name`
+4. `H8-T04.4`: add wrapper applied rules such as `wrapper_type:<name>`
+5. `H8-T04.5`: copy wrapper structural limitation flags into field policy
+6. `H8-T04.6`: replace or narrow the old automatic wrapper-application
+   limitation text
+
+User file modification required: yes, code file `src/cvn_codegen/semantic_policy.py`.
+
+Next step: expose wrapper-aware decisions to domain generation in `H8-T05`.
+
+### H8-T05 - Domain Generator Consumption
+
+Summary: make domain generation decide wrapper-aware field shapes from semantic
+handoff data only.
+
+Subtasks:
+
+1. `H8-T05.1`: extend `DomainFieldSpec` with wrapper type names or equivalent
+   wrapper metadata
+2. `H8-T05.2`: include wrapper evidence in `DomainFieldSpec.trace`
+3. `H8-T05.3`: pass canonical `CVN.xsd` and `Common.xsd` paths through
+   `get_canonical_generation_paths()` and `generate_domain_models()`
+4. `H8-T05.4`: update field type resolution to use semantic wrapper evidence,
+   not raw structural files
+5. `H8-T05.5`: ensure generated output remains deterministic
+
+User file modification required: yes, code files under `src/cvn_codegen/`.
+
+Next step: add shared domain wrapper value components in `H8-T06`.
+
+### H8-T06 - Shared Domain Wrapper Components
+
+Summary: add minimal reusable domain value objects for wrapper-aware generated
+fields without broad domain-model redesign.
+
+Subtasks:
+
+1. `H8-T06.1`: add `FlexibleDateValue` to `src/models/cvn/components.py`
+2. `H8-T06.2`: add `OfficialIdValue` to `src/models/cvn/components.py`
+3. `H8-T06.3`: add `EntityTypeValue` to `src/models/cvn/components.py`
+4. `H8-T06.4`: add `EntityNameValue` to `src/models/cvn/components.py`
+5. `H8-T06.5`: update generated-module import collection for these components
+6. `H8-T06.6`: avoid editing `src/generated/` manually
+
+User file modification required: yes, code file `src/models/cvn/components.py`
+and generator code under `src/cvn_codegen/`.
+
+Next step: add targeted tests in `H8-T07`.
+
+### H8-T07 - Unit And Integration Tests
+
+Summary: prove wrapper evidence exists for representative real fields and flows
+from extraction to generator handoff.
+
+Subtasks:
+
+1. `H8-T07.1`: add tests for `structural_type_trace.py`
+2. `H8-T07.2`: cover `OfficialIdType` with code `000.010.000.100`
+3. `H8-T07.3`: cover `EntityTypeType` with a representative `Type` field, such
+   as `010.010.000.040`
+4. `H8-T07.4`: cover `EntityNameType` with a representative `EntityName` field,
+   such as `010.010.000.020`
+5. `H8-T07.5`: cover `FlexibleDatesType` with a representative date field, such
+   as `010.010.000.180` or `020.010.010.130`
+6. `H8-T07.6`: verify child alternatives such as `DNI`, `Passport`, and `Others`
+   keep ancestor wrapper trace but do not become terminal wrapper fields
+7. `H8-T07.7`: update normalization tests for structural evidence aggregation
+8. `H8-T07.8`: update semantic-policy tests for wrapper auto-attachment
+9. `H8-T07.9`: update domain-generator tests for wrapper-aware Python types and
+   trace metadata
+
+User file modification required: yes, test files under `tests/`.
+
+Next step: regenerate and verify outputs in `H8-T08`.
+
+### H8-T08 - Generation And Verification
+
+Summary: regenerate domain output and run targeted plus full regression checks.
+
+Subtasks:
+
+1. `H8-T08.1`: run targeted tests for structural trace, normalization, semantic
+   policy, and domain generator modules
+2. `H8-T08.2`: run canonical domain generation with
+   `uv run python -m cvn_codegen.domain_model_generator`
+3. `H8-T08.3`: verify generated package imports for `models.cvn.generated`
+4. `H8-T08.4`: run full test suite with `uv run pytest -n auto tests`
+5. `H8-T08.5`: record exact verification commands and results in this hotfix
+   document after implementation
+
+User file modification required: no code edit required during verification;
+generated domain files may change as command output.
+
+Next step: update persistent documentation in `H8-T09`.
+
+### H8-T09 - Documentation Updates
+
+Summary: align roadmap, current status, limitation register, and downstream issue
+records once implementation is verified.
+
+Subtasks:
+
+1. `H8-T09.1`: update this hotfix document with implementation notes,
+   artifacts, verification results, and final status
+2. `H8-T09.2`: update `docs/context/current_status.md`
+3. `H8-T09.3`: update `docs/pipeline/known_limitations.md` to remove or narrow
+   the wrapper-handoff limitation
+4. `H8-T09.4`: update
+   `docs/pipeline/cvn_pydantic_generation_pipeline.md` with the new upstream
+   structural trace bridge
+5. `H8-T09.5`: update
+   `docs/roadmap/issues/issue-15-domain-model-generator.md` to remove or narrow
+   the temporary limitation
+6. `H8-T09.6`: update `docs/roadmap/cvn_generation_roadmap.md` if the hotfix
+   status is tracked there
+7. `H8-T09.7`: update `AGENTS.md` because its current document map omits
+   hotfix `#8`
+8. `H8-T09.8`: sweep `PROJECT_GUIDE.md`,
+   `docs/context/project_context_index.md`, and `docs/context/current_status.md`
+   for consistency
+
+User file modification required: yes, documentation files listed above.
+
+Next step: mark hotfix complete only after code, tests, generation, and docs all
+match the acceptance criteria.
+
+## Implementation Performed
+
+Hotfix `#8` is implemented as an upstream structural-to-normalized trace bridge.
+
+Implemented artifacts:
+
+- `StructuralTypeEvidence` in `src/cvn_codegen/normalization_types.py`
+- optional `TreePathEntry.structural_type_evidence`
+- aggregated `NormalizedCodeEntry.structural_type_evidence`
+- `src/cvn_codegen/structural_type_trace.py` for XSD-backed structural type
+  resolution
+- normalization enrichment through optional `cvn_xsd_path` and `common_xsd_path`
+  parameters on `build_normalization_result(...)`
+- semantic wrapper attachment from normalized `structural_type_evidence`
+- wrapper policy trace fields in `SemanticDecisionTrace` and
+  `SemanticFieldPolicy`
+- wrapper-aware domain field specs and trace metadata in the domain generator
+- canonical generator path handoff for `CVN.xsd` and `Common.xsd`
+- shared domain wrapper components in `src/models/cvn/components.py`:
+  `FlexibleDateValue`, `OfficialIdValue`, `EntityTypeValue`, and
+  `EntityNameValue`
+- targeted structural trace tests in `tests/test_structural_type_trace_unit.py`
+
+The domain generator now consumes typed semantic-policy handoff data and does not
+inspect raw XSD files or generated structural bindings for wrapper attachment.
+
 ## Impact On Issue `#15`
 
-Issue `#15` may continue without automatic wrapper field attachment if it records
-this limitation clearly.
+Issue `#15` no longer needs to defer wrapper-aware automatic field attachment for
+the four wrapper families covered by this hotfix.
 
-Until this hotfix is implemented, issue `#15` should:
+Current behavior:
 
-- keep wrapper policy decisions visible as semantic-policy metadata
-- avoid pretending wrapper-aware fields were attached automatically
-- avoid raw XSD or generated-binding scans in generator code
-- leave generated wrapper-specific field shapes as future work dependent on this
-  hotfix
+- canonical generation passes `CVN.xsd` and `Common.xsd` into normalization
+- normalized entries expose terminal wrapper evidence for representative
+  `FlexibleDatesType`, `OfficialIdType`, `EntityTypeType`, and `EntityNameType`
+  fields
+- semantic policy attaches wrapper policies from `SemanticPolicyBundle`
+- domain generation maps wrapper-aware fields to shared wrapper value components
+- child alternatives such as `DNI` preserve ancestor wrapper trace without being
+  treated as terminal wrapper fields
+
+Boundary preserved:
+
+- raw XSD files are inspected only by the upstream structural trace step
+- generated structural bindings under `src/generated/` are not edited manually
+- the domain generator consumes normalized and semantic handoff data only
 
 ## Verification Strategy When Implemented
 
@@ -230,7 +501,26 @@ uv run pytest -n auto tests
 Targeted single-file commands should be used only when debugging a specific
 failure.
 
+## Verification Performed
+
+- Targeted hotfix verification passed with:
+  `uv run pytest -n auto tests/test_structural_type_trace_unit.py tests/test_normalization_unit.py tests/test_semantic_policy_unit.py tests/test_domain_model_generator_unit.py`
+- Observed targeted result:
+  `152 passed in 118.80s (0:01:58)`
+- Canonical generation passed with:
+  `uv run python -m cvn_codegen.domain_model_generator`
+- Observed generation result:
+  `Generated 105 files`
+- Generated import smoke passed for:
+  - `models.cvn.generated`
+  - `models.cvn.generated.enums`
+  - `models.cvn.generated.manual_only`
+- Full repository verification passed with:
+  `uv run pytest -n auto tests`
+- Observed full-suite result:
+  `228 passed in 189.76s (0:03:09)`
+
 ## Status
 
-- Status: planned
-- Implementation state: not started
+- Status: completed
+- Implementation state: implemented and verified

--- a/docs/roadmap/issues/issue-15-domain-model-generator.md
+++ b/docs/roadmap/issues/issue-15-domain-model-generator.md
@@ -152,9 +152,9 @@ Issue `#15` should document and implement at minimum:
 
 ## Wrapper Traceability Limitation And Hotfix `#8` Handoff
 
-During issue `#15` implementation planning, the current normalized tree metadata
-was checked for wrapper type evidence needed to apply semantic wrapper policies
-automatically.
+During issue `#15` implementation planning, the then-current normalized tree
+metadata was checked for wrapper type evidence needed to apply semantic wrapper
+policies automatically.
 
 The relevant wrapper policy names are:
 
@@ -163,21 +163,23 @@ The relevant wrapper policy names are:
 3. `EntityTypeType`
 4. `EntityNameType`
 
-Those names exist in `CVN.xsd`, generated structural bindings, and issue `#14`
-semantic wrapper-policy validation cases, but they are not exposed by the
-current normalized handoff. In particular, `TreePathEntry.tree_value` does not
-carry these wrapper type names for real canonical entries.
+Those names existed in `CVN.xsd`, generated structural bindings, and issue `#14`
+semantic wrapper-policy validation cases, but they were not exposed by the
+normalized handoff available during the original issue `#15` implementation. In
+particular, `TreePathEntry.tree_value` did not carry these wrapper type names for
+real canonical entries.
 
-Issue `#15` must therefore not attach wrapper-aware field shapes by scanning raw
-XSD files or generated structural bindings inside the domain generator. That
-would violate the corrected generator boundary: issue `#15` consumes normalized
-metadata and `SemanticPolicyBundle`; it does not rediscover structural meaning.
+Issue `#15` therefore correctly avoided attaching wrapper-aware field shapes by
+scanning raw XSD files or generated structural bindings inside the domain
+generator. That would have violated the corrected generator boundary: issue
+`#15` consumes normalized metadata and `SemanticPolicyBundle`; it does not
+rediscover structural meaning.
 
 The corrective follow-up is tracked in:
 
 - `docs/roadmap/hotfixes/hotfix-8-wrapper-type-traceability-in-normalized-handoff.md`
 
-Until hotfix `#8` is implemented, issue `#15` should:
+Before hotfix `#8` was implemented, issue `#15` had to:
 
 - keep wrapper policy decisions visible where already provided by issue `#14`
 - avoid pretending wrapper auto-attachment is implemented
@@ -185,6 +187,12 @@ Until hotfix `#8` is implemented, issue `#15` should:
   behavior independently from wrapper auto-attachment
 - leave future wrapper-aware field emission ready to consume typed wrapper
   evidence once hotfix `#8` extends the handoff
+
+Hotfix `#8` has now implemented that typed handoff. Canonical domain generation
+passes `CVN.xsd` and `Common.xsd` into normalization, receives
+`StructuralTypeEvidence`, attaches wrapper policies through semantic policy, and
+maps wrapper-aware fields to shared wrapper value components without raw XSD
+inspection inside the generator.
 
 ## Decisions Recorded During Issue `#15` Execution
 
@@ -370,12 +378,15 @@ trace metadata until there is a concrete domain-facing need.
 
 ### Wrapper Decision
 
-- Wrapper auto-attachment is not implemented in issue `#15` until hotfix `#8`
-  provides typed wrapper evidence in the normalized or semantic handoff.
-- Issue `#15` must not solve this by reading raw XSD or generated structural
-  bindings inside generator logic.
-- The generator should remain ready to consume wrapper evidence later, but it
-  should not pretend wrapper-aware fields are currently attached.
+- Wrapper auto-attachment is implemented after issue `#15` through hotfix `#8`.
+- The generator consumes `SemanticFieldPolicy.wrapper_type_names` and shared
+  wrapper value components instead of reading raw XSD or generated structural
+  bindings.
+- Canonical generation supplies `CVN.xsd` and `Common.xsd` to the upstream
+  normalization stage so wrapper evidence enters before semantic and domain
+  generation.
+- Normalization runs that omit those XSD paths preserve backward-compatible empty
+  wrapper evidence and therefore cannot attach wrapper-aware fields.
 
 ## Accepted Execution Protocol
 
@@ -958,11 +969,11 @@ File-modification rule:
   auxiliary-source classification.
 - The accepted execution protocol and detailed 23-task implementation plan have
   been recorded before generator code changes begin.
-- Wrapper auto-attachment was evaluated during Task `12 / 23`; current normalized
-  metadata does not expose `FlexibleDatesType`, `OfficialIdType`,
-  `EntityTypeType`, or `EntityNameType` as field-level wrapper evidence.
-- A follow-up hotfix record now exists for the required handoff fix:
-  `docs/roadmap/hotfixes/hotfix-8-wrapper-type-traceability-in-normalized-handoff.md`.
+- Wrapper auto-attachment was evaluated during Task `12 / 23`; the initial issue
+  `#15` implementation correctly avoided raw structural rediscovery and recorded
+  hotfix `#8` as the required handoff fix.
+- Hotfix `#8` is now implemented and supplies `StructuralTypeEvidence` through
+  the normalized and semantic handoff.
 - Domain generation execution decisions have been recorded in this document,
   including output architecture, test cadence, IR records, grouping, naming,
   base type mapping, enum handling, non-enum controlled-reference components,
@@ -990,8 +1001,8 @@ File-modification rule:
   `models.cvn.generated.manual_only`.
 - The implementation preserves CVN traceability through `cvn_trace` inheritance
   on generated domain models.
-- Wrapper-aware automatic field attachment remains intentionally deferred to
-  hotfix `#8` rather than being reconstructed from raw structural sources.
+- Wrapper-aware automatic field attachment now consumes hotfix `#8` structural
+  type evidence and shared wrapper value components.
 
 ## Verification
 
@@ -1019,9 +1030,9 @@ File-modification rule:
   emission of scalar, enum, and non-enum controlled-reference shapes.
 - Final Python artifact shapes can be decided inside the generator without
   redefining upstream semantic classification.
-- Wrapper-aware field attachment still needs an explicit upstream handoff.
-  Current normalized metadata does not expose wrapper type names, so issue `#15`
-  must not scan raw XSD files or generated structural bindings to recover them.
+- Wrapper-aware field attachment now uses the explicit upstream handoff from
+  hotfix `#8`; issue `#15` still must not scan raw XSD files or generated
+  structural bindings inside generator logic.
 - Generated class-name collisions can occur across CVN item groups and need
   deterministic global resolution rather than per-file local cleanup.
 - Generated-output cleanup must account for Python cache directories such as
@@ -1029,10 +1040,8 @@ File-modification rule:
 
 ## Known Limitations
 
-- Automatic wrapper-aware field attachment for `FlexibleDatesType`,
-  `OfficialIdType`, `EntityTypeType`, and `EntityNameType` is blocked until
-  hotfix `#8` provides typed wrapper evidence in the normalized or semantic
-  handoff.
+- Wrapper-aware field attachment requires normalization output enriched with
+  `CVN.xsd` and `Common.xsd`; canonical generation provides those inputs.
 - `DATE_LIKE` and `DURATION_LIKE` currently emit traced `str` values instead of
   stronger domain-specific wrapper components.
 - Unknown semantic base kinds still fall back to `object` instead of a stronger
@@ -1043,11 +1052,11 @@ File-modification rule:
 - Issue `#16` must test generator behavior against `SemanticPolicyBundle`
   outputs rather than raw source classifications.
 - Issue `#16` should add regression coverage for canonical generated output,
-  importability, determinism, and wrapper-handoff-dependent future behavior.
+  importability, determinism, and the hotfix `#8` wrapper handoff.
 - Issue `#17` must document `SemanticPolicyBundle` as the semantic source of
   truth for domain generation and the canonical command
   `uv run python -m cvn_codegen.domain_model_generator`.
-- Hotfix `#8` remains the planned corrective path for future wrapper-aware field
+- Hotfix `#8` is now the implemented corrective path for wrapper-aware field
   attachment without raw structural rediscovery.
 
 ## Status

--- a/src/cvn_codegen/domain_model_generator.py
+++ b/src/cvn_codegen/domain_model_generator.py
@@ -160,8 +160,26 @@ def get_python_type_for_controlled_reference(policy: SemanticFieldPolicy) -> str
         return "UnderTracedReference"
     return "str"
 
+
+def get_python_type_for_wrapper(policy: SemanticFieldPolicy) -> str | None:
+    wrapper_type_by_structural_name = {
+        "FlexibleDatesType": "FlexibleDateValue",
+        "OfficialIdType": "OfficialIdValue",
+        "EntityTypeType": "EntityTypeValue",
+        "EntityNameType": "EntityNameValue",
+    }
+    for wrapper_type_name in policy.wrapper_type_names:
+        python_type = wrapper_type_by_structural_name.get(wrapper_type_name)
+        if python_type is not None:
+            return python_type
+    return None
+
+
 def resolve_python_type_for_policy(policy: SemanticFieldPolicy) -> str:
-    if is_controlled_reference_field(policy):
+    wrapper_type = get_python_type_for_wrapper(policy)
+    if wrapper_type is not None:
+        base_type = wrapper_type
+    elif is_controlled_reference_field(policy):
         base_type = get_python_type_for_controlled_reference(policy)
     else:
         base_type = get_python_type_for_base_kind(policy)
@@ -182,12 +200,18 @@ def build_domain_field_spec(
         repeated=is_repeated_field(policy),
         domain_shape_kind=policy.domain_shape_kind.value,
         enum_eligibility=policy.enum_eligibility.value,
+        wrapper_type_names=policy.wrapper_type_names,
         trace={
             "code": policy.code,
             "xml_paths": policy.xml_paths,
             "base_kind": policy.base_kind.value,
             "domain_shape_kind": policy.domain_shape_kind.value,
             "enum_eligibility": policy.enum_eligibility.value,
+            "wrapper_type_names": policy.wrapper_type_names,
+            "wrapper_policy_kinds": tuple(
+                wrapper_policy_kind.value
+                for wrapper_policy_kind in policy.wrapper_policy_kinds
+            ),
         },
     )
 
@@ -484,6 +508,10 @@ def collect_unit_import_types(
         "VocabularyReference",
         "UnresolvedReference",
         "UnderTracedReference",
+        "FlexibleDateValue",
+        "OfficialIdValue",
+        "EntityTypeValue",
+        "EntityNameValue",
     }
 
     for field in unit.fields:
@@ -683,7 +711,9 @@ def write_rendered_domain_files(
 
 
 def get_canonical_generation_paths() -> dict[str, Path]:
-    xml_dir = Path("docs/CvnXML_v1.4.3_2.1_17012025/XML")
+    source_package_dir = Path("docs/CvnXML_v1.4.3_2.1_17012025")
+    xml_dir = source_package_dir / "XML"
+    xsd_dir = source_package_dir / "XSD"
 
     return {
         "specification_manual": xml_dir / "SpecificationManual.xml",
@@ -692,6 +722,8 @@ def get_canonical_generation_paths() -> dict[str, Path]:
         "subtypes": xml_dir / "Subtype_Spa.xml",
         "entity": xml_dir / "Entity.xml",
         "thesaurus": xml_dir / "Thesaurus.xml",
+        "cvn_xsd": xsd_dir / "CVN.xsd",
+        "common_xsd": xsd_dir / "Common.xsd",
     }
 
 
@@ -714,6 +746,8 @@ def generate_domain_models(
         subtypes_path=canonical_paths["subtypes"],
         entity_path=canonical_paths["entity"],
         thesaurus_path=canonical_paths["thesaurus"],
+        cvn_xsd_path=canonical_paths["cvn_xsd"],
+        common_xsd_path=canonical_paths["common_xsd"],
     )
 
     policy_index = build_semantic_policy_index(

--- a/src/cvn_codegen/domain_model_types.py
+++ b/src/cvn_codegen/domain_model_types.py
@@ -19,6 +19,7 @@ class DomainFieldSpec:
     domain_shape_kind: str
     enum_eligibility: str
     trace: dict[str, object]
+    wrapper_type_names: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -51,4 +52,3 @@ class DomainGenerationResult:
     enums: tuple[DomainEnumSpec, ...]
     normalized_entries: tuple[NormalizedCodeEntry, ...]
     semantic_policies: tuple[SemanticFieldPolicy, ...]
-

--- a/src/cvn_codegen/normalization.py
+++ b/src/cvn_codegen/normalization.py
@@ -22,6 +22,10 @@ from cvn_codegen.normalization_types import (
     TreePathEntry,
 )
 from cvn_codegen.normalization_report import collect_normalization_mismatches
+from cvn_codegen.structural_type_trace import (
+    build_structural_type_index,
+    enrich_tree_entries_with_structural_type_evidence,
+)
 
 from cvn_codegen.auxiliary_sources import build_auxiliary_source_bundle
 from cvn_codegen.auxiliary_sources.bundle import AuxiliarySourceBundle
@@ -109,12 +113,18 @@ def build_normalized_code(
             auxiliary_bundle=auxiliary_bundle,
             manual_code=manual_entry.code,
         )
+    structural_type_evidence = tuple(
+        entry.structural_type_evidence
+        for entry in tree_paths
+        if entry.structural_type_evidence is not None
+    )
     return NormalizedCodeEntry(
         code=normalized_code,
         manual=manual_entry,
         tree_paths=tree_paths,
         source_files=tuple(sorted(source_files_set)),
         reference_resolution=reference_resolution,
+        structural_type_evidence=structural_type_evidence,
     )
 
 def build_normalized_code_index(
@@ -157,6 +167,8 @@ def build_normalization_result(
     subtypes_path: Path | None = None,
     entity_path: Path | None = None,
     thesaurus_path: Path | None = None,
+    cvn_xsd_path: Path | None = None,
+    common_xsd_path: Path | None = None,
 ) -> NormalizationResult:
 
     """Run the normalization orchestration for the canonical metadata sources.
@@ -181,6 +193,16 @@ def build_normalization_result(
     manual_entries_by_code = extract_manual_entries(specification_manual)
 
     tree_entries = load_and_extract_tree_entries(tree_model_path)
+
+    if cvn_xsd_path is not None and common_xsd_path is not None:
+        structural_type_index = build_structural_type_index(
+            cvn_xsd_path=cvn_xsd_path,
+            common_xsd_path=common_xsd_path,
+        )
+        tree_entries = enrich_tree_entries_with_structural_type_evidence(
+            tree_entries=tree_entries,
+            structural_type_index=structural_type_index,
+        )
 
     tree_entries_by_code = index_tree_entries_by_code(tree_entries)
 

--- a/src/cvn_codegen/normalization_types.py
+++ b/src/cvn_codegen/normalization_types.py
@@ -110,6 +110,19 @@ class ReferenceTableEnumEvidence:
 
 
 @dataclass(frozen=True)
+class StructuralTypeEvidence:
+    """Store structural XSD type evidence for one normalized tree path."""
+
+    element_name: str
+    declaring_type_name: str | None
+    structural_type_name: str | None
+    xml_path: str
+    source_xsd_file: str
+    terminal_wrapper_type_name: str | None = None
+    ancestor_wrapper_type_names: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class ReferenceResolution:
     """Represent resolved auxiliary-reference metadata for one manual reference."""
     raw_reference: str | None
@@ -176,6 +189,8 @@ class TreePathEntry:
         tree_value (str | None): Optional ``Value`` content found in the tree.
         xml_path (str): Stable XML-like path of the current tree node.
         trace (SourceTrace): Traceability back to the source XML element.
+        structural_type_evidence (StructuralTypeEvidence | None): Optional XSD
+            type evidence resolved upstream for this tree path.
     """
 
     code: str
@@ -185,6 +200,7 @@ class TreePathEntry:
     tree_value: str | None
     xml_path: str
     trace: SourceTrace
+    structural_type_evidence: StructuralTypeEvidence | None = None
 
 
 @dataclass(frozen=True)
@@ -201,6 +217,8 @@ class NormalizedCodeEntry:
             aggregate entry.
         reference_resolution (ReferenceResolution | None): Resolved auxiliary
             reference metadata attached to the aggregate entry when available.
+        structural_type_evidence (tuple[StructuralTypeEvidence, ...]): XSD type
+            evidence aggregated from tree paths.
     """
 
     code: str
@@ -208,6 +226,7 @@ class NormalizedCodeEntry:
     tree_paths: tuple[TreePathEntry, ...]
     source_files: tuple[str, ...]
     reference_resolution: ReferenceResolution | None = None
+    structural_type_evidence: tuple[StructuralTypeEvidence, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/cvn_codegen/semantic_policy.py
+++ b/src/cvn_codegen/semantic_policy.py
@@ -27,9 +27,9 @@ PRESERVED_ACRONYMS = frozenset(
 
 
 WRAPPER_AUTO_APPLICATION_LIMITATION = (
-    "NormalizedCodeEntry does not expose structural wrapper type names yet; "
-    "wrapper policy is currently validated by wrapper-name cases and not "
-    "automatically attached to field policies."
+    "Wrapper policy auto-attachment depends on normalized "
+    "structural_type_evidence. Normalization results built without structural "
+    "XSD enrichment preserve wrapper policies but cannot attach them to fields."
 )
 
 class SemanticBaseKind(str, Enum):
@@ -126,6 +126,8 @@ class SemanticDecisionTrace:
     serialization_pattern: SerializationPattern | None
     semantic_reference_kind: SemanticReferenceKind | None
     applied_rules: tuple[str, ...]
+    terminal_wrapper_type_names: tuple[str, ...] = ()
+    ancestor_wrapper_type_names: tuple[str, ...] = ()
     diagnostics: tuple[str, ...] = ()
 
 @dataclass(frozen=True)
@@ -236,6 +238,8 @@ class SemanticFieldPolicy:
     naming_policy: NamingPolicy
     structural_limitation_flags: tuple[StructuralLimitationFlag, ...]
     decision_trace: SemanticDecisionTrace
+    wrapper_type_names: tuple[str, ...] = ()
+    wrapper_policy_kinds: tuple[WrapperPolicyKind, ...] = ()
     notes: tuple[str, ...] = ()
 
 @dataclass(frozen=True)
@@ -342,6 +346,75 @@ def get_wrapper_auto_application_limitation() -> str:
     """Return current limitation for automatic wrapper policy application."""
 
     return WRAPPER_AUTO_APPLICATION_LIMITATION
+
+
+def dedupe_preserving_order(values: tuple[str, ...]) -> tuple[str, ...]:
+    """Return unique string values while preserving first-seen order."""
+    seen_values: set[str] = set()
+    deduped_values: list[str] = []
+    for value in values:
+        if value in seen_values:
+            continue
+        seen_values.add(value)
+        deduped_values.append(value)
+    return tuple(deduped_values)
+
+
+def collect_terminal_wrapper_type_names(
+    entry: NormalizedCodeEntry,
+) -> tuple[str, ...]:
+    """Collect terminal wrapper names attached to normalized structural evidence."""
+    return dedupe_preserving_order(
+        tuple(
+            evidence.terminal_wrapper_type_name
+            for evidence in entry.structural_type_evidence
+            if evidence.terminal_wrapper_type_name is not None
+        )
+    )
+
+
+def collect_ancestor_wrapper_type_names(
+    entry: NormalizedCodeEntry,
+) -> tuple[str, ...]:
+    """Collect ancestor wrapper names without using them for field attachment."""
+    return dedupe_preserving_order(
+        tuple(
+            wrapper_type_name
+            for evidence in entry.structural_type_evidence
+            for wrapper_type_name in evidence.ancestor_wrapper_type_names
+        )
+    )
+
+
+def resolve_choice_wrapper_policies(
+    wrapper_type_names: tuple[str, ...],
+    bundle: SemanticPolicyBundle,
+) -> tuple[ChoiceWrapperPolicy, ...]:
+    """Resolve semantic wrapper policies for terminal structural wrapper names."""
+    resolved_policies: list[ChoiceWrapperPolicy] = []
+    for wrapper_type_name in wrapper_type_names:
+        wrapper_policy = get_choice_wrapper_policy(
+            wrapper_name=wrapper_type_name,
+            bundle=bundle,
+        )
+        if wrapper_policy is None:
+            continue
+        resolved_policies.append(wrapper_policy)
+    return tuple(resolved_policies)
+
+
+def merge_structural_limitation_flags(
+    existing_flags: tuple[StructuralLimitationFlag, ...],
+    wrapper_policies: tuple[ChoiceWrapperPolicy, ...],
+) -> tuple[StructuralLimitationFlag, ...]:
+    """Merge existing and wrapper-derived structural limitation flags."""
+    merged_flags: list[StructuralLimitationFlag] = list(existing_flags)
+    for wrapper_policy in wrapper_policies:
+        for limitation_flag in wrapper_policy.structural_limitation_flags:
+            if limitation_flag in merged_flags:
+                continue
+            merged_flags.append(limitation_flag)
+    return tuple(merged_flags)
 
 def build_default_semantic_policy_bundle() -> SemanticPolicyBundle:
     """Build the default semantic policy bundle for issue #14."""
@@ -887,7 +960,20 @@ def build_semantic_field_policy(
     
     naming_policy = build_naming_policy(entry)
 
-    structural_limitation_flags: tuple[StructuralLimitationFlag, ...] = ()
+    terminal_wrapper_type_names = collect_terminal_wrapper_type_names(entry)
+    ancestor_wrapper_type_names = collect_ancestor_wrapper_type_names(entry)
+    wrapper_policies = resolve_choice_wrapper_policies(
+        wrapper_type_names=terminal_wrapper_type_names,
+        bundle=bundle,
+    )
+    wrapper_policy_kinds = tuple(
+        wrapper_policy.wrapper_policy_kind
+        for wrapper_policy in wrapper_policies
+    )
+    structural_limitation_flags = merge_structural_limitation_flags(
+        existing_flags=(),
+        wrapper_policies=wrapper_policies,
+    )
     
     reference_source_family = None
     reference_source_artifact = None
@@ -915,6 +1001,10 @@ def build_semantic_field_policy(
         f"enum_evidence:{reason}"
         for reason in enum_rule_reasons
     )
+    applied_rules = applied_rules + tuple(
+        f"wrapper_type:{wrapper_type_name}"
+        for wrapper_type_name in terminal_wrapper_type_names
+    )
     
     decision_trace = SemanticDecisionTrace(
         code=entry.code,
@@ -925,6 +1015,8 @@ def build_semantic_field_policy(
         serialization_pattern=serialization_pattern,
         semantic_reference_kind=semantic_reference_kind,
         applied_rules=applied_rules,
+        terminal_wrapper_type_names=terminal_wrapper_type_names,
+        ancestor_wrapper_type_names=ancestor_wrapper_type_names,
         diagnostics=diagnostics,
     )
     field_policy = SemanticFieldPolicy(
@@ -940,6 +1032,8 @@ def build_semantic_field_policy(
         naming_policy=naming_policy,
         structural_limitation_flags=structural_limitation_flags,
         decision_trace=decision_trace,
+        wrapper_type_names=terminal_wrapper_type_names,
+        wrapper_policy_kinds=wrapper_policy_kinds,
     )
     override_selection = select_applicable_override(
         entry=entry,
@@ -1060,6 +1154,8 @@ def apply_override_to_field_policy(
             naming_policy=field_policy.naming_policy,
             structural_limitation_flags=field_policy.structural_limitation_flags,
             decision_trace=field_policy.decision_trace,
+            wrapper_type_names=field_policy.wrapper_type_names,
+            wrapper_policy_kinds=field_policy.wrapper_policy_kinds,
             notes=field_policy.notes
             + (
                 "Override conflict detected for matching rule IDs: "
@@ -1126,6 +1222,8 @@ def apply_override_to_field_policy(
             else override.structural_limitation_flags
         ),
         decision_trace=field_policy.decision_trace,
+        wrapper_type_names=field_policy.wrapper_type_names,
+        wrapper_policy_kinds=field_policy.wrapper_policy_kinds,
         notes=field_policy.notes
         + (
             f"Applied override rule '{override.rule_id}'.",

--- a/src/cvn_codegen/structural_type_trace.py
+++ b/src/cvn_codegen/structural_type_trace.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+import re
+import xml.etree.ElementTree as ET
+from xml.etree.ElementTree import Element
+
+from cvn_codegen.normalization_types import (
+    SourceTrace,
+    StructuralTypeEvidence,
+    TreePathEntry,
+)
+
+
+XSD_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
+XSD_ELEMENT = f"{{{XSD_NAMESPACE}}}element"
+XSD_COMPLEX_TYPE = f"{{{XSD_NAMESPACE}}}complexType"
+TARGET_WRAPPER_TYPE_NAMES = frozenset(
+    {
+        "FlexibleDatesType",
+        "OfficialIdType",
+        "EntityTypeType",
+        "EntityNameType",
+    }
+)
+
+
+@dataclass(frozen=True)
+class StructuralElementType:
+    element_name: str
+    declaring_type_name: str | None
+    structural_type_name: str | None
+    source_xsd_file: str
+
+
+@dataclass(frozen=True)
+class StructuralTypeIndex:
+    child_types_by_declaring_type: dict[str, dict[str, StructuralElementType]]
+    root_types_by_element_name: dict[str, StructuralElementType]
+    source_file_by_type_name: dict[str, str]
+    wrapper_type_names: frozenset[str] = TARGET_WRAPPER_TYPE_NAMES
+
+
+def load_xsd_root(xsd_path: Path) -> Element:
+    if not isinstance(xsd_path, Path):
+        raise ValueError(f"xsd_path must be a Path object, got {type(xsd_path)}.")
+    if not xsd_path.is_file():
+        raise FileNotFoundError(f"XSD file not found at path: {xsd_path}")
+    return ET.parse(xsd_path).getroot()
+
+
+def strip_namespace_prefix(type_name: str | None) -> str | None:
+    if type_name is None:
+        return None
+    normalized_type_name = type_name.strip()
+    if not normalized_type_name:
+        return None
+    if ":" in normalized_type_name:
+        return normalized_type_name.split(":", 1)[1]
+    return normalized_type_name
+
+
+def iter_named_complex_types(xsd_root: Element) -> tuple[Element, ...]:
+    return tuple(
+        complex_type
+        for complex_type in xsd_root.findall(XSD_COMPLEX_TYPE)
+        if complex_type.get("name")
+    )
+
+
+def extract_type_source_files(
+    xsd_roots_by_file_name: dict[str, Element],
+) -> dict[str, str]:
+    source_file_by_type_name: dict[str, str] = {}
+    for source_file_name, xsd_root in xsd_roots_by_file_name.items():
+        for complex_type in iter_named_complex_types(xsd_root):
+            type_name = complex_type.get("name")
+            if type_name is None:
+                continue
+            source_file_by_type_name[type_name] = source_file_name
+    return source_file_by_type_name
+
+
+def build_child_type_index(
+    xsd_roots_by_file_name: dict[str, Element],
+    source_file_by_type_name: dict[str, str],
+) -> dict[str, dict[str, StructuralElementType]]:
+    child_types_by_declaring_type: dict[str, dict[str, StructuralElementType]] = {}
+    for source_file_name, xsd_root in xsd_roots_by_file_name.items():
+        for complex_type in iter_named_complex_types(xsd_root):
+            declaring_type_name = complex_type.get("name")
+            if declaring_type_name is None:
+                continue
+            child_types: dict[str, StructuralElementType] = {}
+            for child_element in complex_type.findall(f".//{XSD_ELEMENT}"):
+                element_name = child_element.get("name")
+                if element_name is None:
+                    continue
+                structural_type_name = strip_namespace_prefix(child_element.get("type"))
+                child_source_file = source_file_by_type_name.get(
+                    structural_type_name or "",
+                    source_file_name,
+                )
+                child_types[element_name] = StructuralElementType(
+                    element_name=element_name,
+                    declaring_type_name=declaring_type_name,
+                    structural_type_name=structural_type_name,
+                    source_xsd_file=child_source_file,
+                )
+            child_types_by_declaring_type[declaring_type_name] = child_types
+    return child_types_by_declaring_type
+
+
+def find_global_element(xsd_root: Element, element_name: str) -> Element | None:
+    for child in xsd_root.findall(XSD_ELEMENT):
+        if child.get("name") == element_name:
+            return child
+    return None
+
+
+def build_root_type_index(
+    cvn_xsd_root: Element,
+    source_file_by_type_name: dict[str, str],
+) -> dict[str, StructuralElementType]:
+    cvn_element = find_global_element(cvn_xsd_root, "CVN")
+    if cvn_element is None:
+        return {}
+    root_types_by_element_name: dict[str, StructuralElementType] = {}
+    for child_element in cvn_element.findall(f".//{XSD_ELEMENT}"):
+        element_name = child_element.get("name")
+        if element_name is None:
+            continue
+        structural_type_name = strip_namespace_prefix(child_element.get("type"))
+        if structural_type_name is None:
+            continue
+        root_types_by_element_name[element_name] = StructuralElementType(
+            element_name=element_name,
+            declaring_type_name=None,
+            structural_type_name=structural_type_name,
+            source_xsd_file=source_file_by_type_name.get(
+                structural_type_name,
+                "CVN.xsd",
+            ),
+        )
+    return root_types_by_element_name
+
+
+def build_structural_type_index(
+    cvn_xsd_path: Path,
+    common_xsd_path: Path,
+) -> StructuralTypeIndex:
+    cvn_xsd_root = load_xsd_root(cvn_xsd_path)
+    common_xsd_root = load_xsd_root(common_xsd_path)
+    xsd_roots_by_file_name = {
+        cvn_xsd_path.name: cvn_xsd_root,
+        common_xsd_path.name: common_xsd_root,
+    }
+    source_file_by_type_name = extract_type_source_files(xsd_roots_by_file_name)
+    return StructuralTypeIndex(
+        child_types_by_declaring_type=build_child_type_index(
+            xsd_roots_by_file_name=xsd_roots_by_file_name,
+            source_file_by_type_name=source_file_by_type_name,
+        ),
+        root_types_by_element_name=build_root_type_index(
+            cvn_xsd_root=cvn_xsd_root,
+            source_file_by_type_name=source_file_by_type_name,
+        ),
+        source_file_by_type_name=source_file_by_type_name,
+    )
+
+
+def parse_path_segment(path_segment: str) -> tuple[str, str | None]:
+    match = re.match(r"^(?P<tag>[^[]+)(?:\[@(?:name|code)='(?P<value>[^']+)'\])?$", path_segment)
+    if match is None:
+        return path_segment, None
+    return match.group("tag"), match.group("value")
+
+
+def get_structural_element_name(tag_name: str, segment_value: str | None) -> str | None:
+    if tag_name in {"Property", "Indicator"}:
+        return segment_value
+    if tag_name in {"Version", "Agent"}:
+        return tag_name
+    if tag_name in {"CvnItem", "CVNItem"}:
+        return "CvnItem"
+    return None
+
+
+def build_structural_type_evidence(
+    element_type: StructuralElementType,
+    xml_path: str,
+    ancestor_wrapper_type_names: tuple[str, ...],
+    structural_type_index: StructuralTypeIndex,
+) -> StructuralTypeEvidence:
+    terminal_wrapper_type_name = None
+    if element_type.structural_type_name in structural_type_index.wrapper_type_names:
+        terminal_wrapper_type_name = element_type.structural_type_name
+    return StructuralTypeEvidence(
+        element_name=element_type.element_name,
+        declaring_type_name=element_type.declaring_type_name,
+        structural_type_name=element_type.structural_type_name,
+        xml_path=xml_path,
+        source_xsd_file=element_type.source_xsd_file,
+        terminal_wrapper_type_name=terminal_wrapper_type_name,
+        ancestor_wrapper_type_names=ancestor_wrapper_type_names,
+    )
+
+
+def resolve_structural_type_evidence(
+    xml_path: str,
+    structural_type_index: StructuralTypeIndex,
+) -> StructuralTypeEvidence | None:
+    path_segments = tuple(
+        segment for segment in xml_path.split("/") if segment
+    )
+    current_type_name: str | None = None
+    active_wrapper_type_names: tuple[str, ...] = ()
+    last_evidence: StructuralTypeEvidence | None = None
+
+    for raw_segment in path_segments:
+        tag_name, segment_value = parse_path_segment(raw_segment)
+        if tag_name == "Node":
+            continue
+
+        element_name = get_structural_element_name(tag_name, segment_value)
+        if element_name is None:
+            continue
+
+        if current_type_name is None:
+            root_element_type = structural_type_index.root_types_by_element_name.get(
+                element_name,
+            )
+            if root_element_type is None:
+                continue
+            last_evidence = build_structural_type_evidence(
+                element_type=root_element_type,
+                xml_path=xml_path,
+                ancestor_wrapper_type_names=active_wrapper_type_names,
+                structural_type_index=structural_type_index,
+            )
+            current_type_name = root_element_type.structural_type_name
+            continue
+
+        if tag_name in {"CvnItem", "CVNItem"} and current_type_name == "CvnItemType":
+            continue
+
+        child_types = structural_type_index.child_types_by_declaring_type.get(
+            current_type_name,
+            {},
+        )
+        child_type = child_types.get(element_name)
+        if child_type is None:
+            continue
+
+        last_evidence = build_structural_type_evidence(
+            element_type=child_type,
+            xml_path=xml_path,
+            ancestor_wrapper_type_names=active_wrapper_type_names,
+            structural_type_index=structural_type_index,
+        )
+        current_type_name = child_type.structural_type_name
+        if child_type.structural_type_name in structural_type_index.wrapper_type_names:
+            active_wrapper_type_names = (
+                *active_wrapper_type_names,
+                child_type.structural_type_name,
+            )
+
+    return last_evidence
+
+
+def enrich_tree_entry_with_structural_type_evidence(
+    tree_entry: TreePathEntry,
+    structural_type_index: StructuralTypeIndex,
+) -> TreePathEntry:
+    structural_type_evidence = resolve_structural_type_evidence(
+        xml_path=tree_entry.xml_path,
+        structural_type_index=structural_type_index,
+    )
+    if structural_type_evidence is None:
+        return tree_entry
+    return replace(
+        tree_entry,
+        structural_type_evidence=structural_type_evidence,
+        trace=SourceTrace(
+            source_file=tree_entry.trace.source_file,
+            xml_path=tree_entry.trace.xml_path,
+            source_code=tree_entry.trace.source_code,
+        ),
+    )
+
+
+def enrich_tree_entries_with_structural_type_evidence(
+    tree_entries: list[TreePathEntry],
+    structural_type_index: StructuralTypeIndex,
+) -> list[TreePathEntry]:
+    return [
+        enrich_tree_entry_with_structural_type_evidence(
+            tree_entry=tree_entry,
+            structural_type_index=structural_type_index,
+        )
+        for tree_entry in tree_entries
+    ]

--- a/src/cvn_codegen/tree_metadata.py
+++ b/src/cvn_codegen/tree_metadata.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from cvn_codegen.normalization_types import (
+    StructuralTypeEvidence,
     TreePathEntry,
     SourceTrace,
 )
@@ -87,6 +88,7 @@ def build_tree_path_entry(
     tree_indicator_name: str | None,
     tree_value: str | None,
     xml_path: str,
+    structural_type_evidence: StructuralTypeEvidence | None = None,
 ) -> TreePathEntry:
     """Create a normalized tree-path entry from extracted tree metadata.
 
@@ -101,6 +103,8 @@ def build_tree_path_entry(
         tree_value (str | None): Optional ``Value`` content associated with the
             current indicator.
         xml_path (str): Stable XML-like path of the current node.
+        structural_type_evidence (StructuralTypeEvidence | None): Optional XSD
+            type evidence resolved by an upstream structural trace step.
 
     Returns:
         TreePathEntry: Normalized tree-model metadata entry.
@@ -127,6 +131,7 @@ def build_tree_path_entry(
             xml_path=xml_path,
             source_code=normalized_code,
         ),
+        structural_type_evidence=structural_type_evidence,
     )
 
 

--- a/src/models/cvn/components.py
+++ b/src/models/cvn/components.py
@@ -66,3 +66,32 @@ class UnresolvedReference(BaseControlledReferenceValue):
 
 class UnderTracedReference(BaseControlledReferenceValue):
     raw_reference: str | None = None
+
+
+class FlexibleDateValue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    day: str | None = None
+    month: str | None = None
+    year: str | None = None
+    raw_value: str | None = None
+
+
+class OfficialIdValue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dni: str | None = None
+    passport: str | None = None
+    nie: str | None = None
+    others: str | None = None
+
+
+class EntityTypeValue(BaseControlledReferenceValue):
+    others: str | None = None
+
+
+class EntityNameValue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    others: str | None = None

--- a/src/models/cvn/generated/cvn_item_010_010_000_000.py
+++ b/src/models/cvn/generated/cvn_item_010_010_000_000.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class SituacionProfesionalActual(BaseCvnDomainModel):
     situacion_profesional_actual: list[str] = Field(default_factory=list)
     direccion_y_gestion: bool | None = Field(default=None)
-    entidad_empleadora: RegistryReference = Field(...)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_empleadora: EntityNameValue = Field(...)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    facultad_escuela_unidad_centro_hospital_o_instituto: RegistryReference | None = Field(default=None)
-    departamento_servicio_seccion_unidad_etc: RegistryReference | None = Field(default=None)
+    facultad_escuela_unidad_centro_hospital_o_instituto: EntityNameValue | None = Field(default=None)
+    departamento_servicio_seccion_unidad_etc: EntityNameValue | None = Field(default=None)
     ciudad_entidad_empleadora: str | None = Field(default=None)
     pais_entidad_empleadora: str | None = Field(default=None)
     comunidad_autonoma_region_entidad_empleadora: HierarchicalCodeReference | None = Field(default=None)
@@ -21,7 +21,7 @@ class SituacionProfesionalActual(BaseCvnDomainModel):
     fax: str | None = Field(default=None)
     correo_electronico: list[str] = Field(default_factory=list)
     categoria_profesional_puesto_o_cargo: str = Field(...)
-    fecha_de_inicio: str = Field(...)
+    fecha_de_inicio: FlexibleDateValue = Field(...)
     modalidad_de_contrato: str = Field(...)
     modalidad_de_contrato_otros: str | None = Field(default=None)
     regimen_de_dedicacion: str = Field(...)

--- a/src/models/cvn/generated/cvn_item_010_020_000_000.py
+++ b/src/models/cvn/generated/cvn_item_010_020_000_000.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class CargosYActividadesDesempenadosConAnterioridad(BaseCvnDomainModel):
     cargos_y_actividades_desempenados_con_anterioridad: list[str] = Field(default_factory=list)
     direccion_y_gestion: bool | None = Field(default=None)
-    entidad_empleadora: RegistryReference = Field(...)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_empleadora: EntityNameValue = Field(...)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    facultad_escuela_unidad_centro_hospital_o_instituto: RegistryReference | None = Field(default=None)
-    departamento_servicio_seccion_unidad_etc: RegistryReference | None = Field(default=None)
+    facultad_escuela_unidad_centro_hospital_o_instituto: EntityNameValue | None = Field(default=None)
+    departamento_servicio_seccion_unidad_etc: EntityNameValue | None = Field(default=None)
     ciudad_entidad_empleadora: str | None = Field(default=None)
     pais_entidad_empleadora: str | None = Field(default=None)
     comunidad_autonoma_region_entidad_empleadora: HierarchicalCodeReference | None = Field(default=None)
@@ -21,7 +21,7 @@ class CargosYActividadesDesempenadosConAnterioridad(BaseCvnDomainModel):
     fax: str | None = Field(default=None)
     correo_electronico: list[str] = Field(default_factory=list)
     categoria_profesional_puesto_o_cargo: str = Field(...)
-    fecha_de_inicio: str = Field(...)
+    fecha_de_inicio: FlexibleDateValue = Field(...)
     duracion: str = Field(...)
     modalidad_de_contrato: str | None = Field(default=None)
     modalidad_de_contrato_otros: str | None = Field(default=None)
@@ -34,4 +34,4 @@ class CargosYActividadesDesempenadosConAnterioridad(BaseCvnDomainModel):
     interes_para_la_docencia_y_o_investigacion: str | None = Field(default=None)
     ambito_actividad_de_direccion_y_o_gestion: str = Field(...)
     ambito_de_la_actividad_de_direccion_y_o_gestion_otros: str | None = Field(default=None)
-    fecha_de_finalizacion: str = Field(...)
+    fecha_de_finalizacion: FlexibleDateValue = Field(...)

--- a/src/models/cvn/generated/cvn_item_020_010_010_000.py
+++ b/src/models/cvn/generated/cvn_item_020_010_010_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, MeasureOrScaleValue, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, MeasureOrScaleValue
 
 
 class EstudiosDe1oY2oCicloYAntiguosCiclosLicenciadosDiplomadosIngenierosSuperioresIngenierosTecnicosArquitectos(BaseCvnDomainModel):
@@ -14,13 +14,13 @@ class EstudiosDe1oY2oCicloYAntiguosCiclosLicenciadosDiplomadosIngenierosSuperior
     pais_entidad_titulacion: str | None = Field(default=None)
     comunidad_autonoma_region_entidad_titulacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_entidad_titulacion: str | None = Field(default=None)
-    entidad_de_titulacion: RegistryReference = Field(...)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_de_titulacion: EntityNameValue = Field(...)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    fecha_de_titulacion: str = Field(...)
+    fecha_de_titulacion: FlexibleDateValue = Field(...)
     nota_media_del_expediente: MeasureOrScaleValue | None = Field(default=None)
     titulo_extranjero: HierarchicalCodeReference | None = Field(default=None)
-    titulo_homologado_fecha_de_homologacion: str | None = Field(default=None)
+    titulo_homologado_fecha_de_homologacion: FlexibleDateValue | None = Field(default=None)
     titulo_homologado: bool | None = Field(default=None)
     premio: str | None = Field(default=None)
     premio_otros: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_020_010_020_000.py
+++ b/src/models/cvn/generated/cvn_item_020_010_020_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class Doctorados(BaseCvnDomainModel):
@@ -12,15 +12,15 @@ class Doctorados(BaseCvnDomainModel):
     pais_entidad_de_la_titulacion: str | None = Field(default=None)
     comunidad_autonoma_region_entidad_de_la_titulacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_entidad_de_la_titulacion: str | None = Field(default=None)
-    entidad_de_titulacion: RegistryReference = Field(...)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_de_titulacion: EntityNameValue = Field(...)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    fecha_de_titulacion: str = Field(...)
-    doctorado_europeo_internacional_fecha_de_mencion: str | None = Field(default=None)
+    fecha_de_titulacion: FlexibleDateValue = Field(...)
+    doctorado_europeo_internacional_fecha_de_mencion: FlexibleDateValue | None = Field(default=None)
     titulo_de_la_tesis: str | None = Field(default=None)
     doctorado_europeo_internacional: bool = Field(...)
     mencion_de_calidad: bool = Field(...)
     premio_extraordinario_del_doctorado: bool = Field(...)
-    fecha_de_obtencion: str = Field(...)
+    fecha_de_obtencion: FlexibleDateValue = Field(...)
     titulo_homologado: bool = Field(...)
-    titulo_homologado_fecha_de_homologacion: str = Field(...)
+    titulo_homologado_fecha_de_homologacion: FlexibleDateValue = Field(...)

--- a/src/models/cvn/generated/cvn_item_020_010_020_160.py
+++ b/src/models/cvn/generated/cvn_item_020_010_020_160.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, FlexibleDateValue
 
 
 class SuficienciaInvestigadoraDeaEntidad(BaseCvnDomainModel):
-    suficiencia_investigadora_dea_entidad: RegistryReference | None = Field(default=None)
-    suficiencia_investigadora_dea_fecha: str | None = Field(default=None)
+    suficiencia_investigadora_dea_entidad: EntityNameValue | None = Field(default=None)
+    suficiencia_investigadora_dea_fecha: FlexibleDateValue | None = Field(default=None)
     titulo_de_la_tesis: str | None = Field(default=None)
     director_a_de_tesis: str | None = Field(default=None)
     codirector_a_de_tesis: list[str] = Field(default_factory=list)

--- a/src/models/cvn/generated/cvn_item_020_010_030_000.py
+++ b/src/models/cvn/generated/cvn_item_020_010_030_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, SubtypeBackedValue
 
 
 class OtraFormacionUniversitariaDePosgrado(BaseCvnDomainModel):
@@ -13,11 +13,11 @@ class OtraFormacionUniversitariaDePosgrado(BaseCvnDomainModel):
     pais_entidad_titulacion: str | None = Field(default=None)
     comunidad_autonoma_region_entidad_titulacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_entidad_titulacion: str | None = Field(default=None)
-    entidad_de_titulacion: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_de_titulacion: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    fecha_de_titulacion: str | None = Field(default=None)
+    fecha_de_titulacion: FlexibleDateValue | None = Field(default=None)
     calificacion_obtenida: str | None = Field(default=None)
-    facultad_escuela_unidad_centro_hospital_o_instituto: RegistryReference | None = Field(default=None)
+    facultad_escuela_unidad_centro_hospital_o_instituto: EntityNameValue | None = Field(default=None)
     titulo_homologado: bool | None = Field(default=None)
-    titulo_homologado_fecha_de_homologacion: str | None = Field(default=None)
+    titulo_homologado_fecha_de_homologacion: FlexibleDateValue | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_020_020_000_000.py
+++ b/src/models/cvn/generated/cvn_item_020_020_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, SubtypeBackedValue
 
 
 class FormacionEspecializadaContinuadaTecnicaProfesionalizadaDeReciclajeYActualizacionDistintaALaFormacionAcademicaRegladaYALaSanitaria(BaseCvnDomainModel):
@@ -14,10 +14,10 @@ class FormacionEspecializadaContinuadaTecnicaProfesionalizadaDeReciclajeYActuali
     pais_entidad_titulacion: str | None = Field(default=None)
     comunidad_autonoma_region_entidad_titulacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_entidad_titulacion: str | None = Field(default=None)
-    entidad_de_titulacion: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_de_titulacion: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     objetivos_de_la_entidad: str | None = Field(default=None)
     nombre_del_responsable_de_la_formacion: str | None = Field(default=None)
     duracion_en_horas: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_formacion: str | None = Field(default=None)
+    fecha_de_finalizacion_de_la_formacion: FlexibleDateValue | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_020_030_000_000.py
+++ b/src/models/cvn/generated/cvn_item_020_030_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class FormacionSanitariaEspecializada(BaseCvnDomainModel):
@@ -13,16 +13,16 @@ class FormacionSanitariaEspecializada(BaseCvnDomainModel):
     pais_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_entidad_de_realizacion: str | None = Field(default=None)
-    entidad_donde_se_llevo_a_cabo_la_especialidad: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_donde_se_llevo_a_cabo_la_especialidad: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    entidad_que_expide_el_titulo_de_especialista: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_que_expide_el_titulo_de_especialista: str | None = Field(default=None)
+    entidad_que_expide_el_titulo_de_especialista: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_que_expide_el_titulo_de_especialista: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_que_expide_el_titulo_de_especialista_otros: str | None = Field(default=None)
-    fecha_inicio_de_la_formacion: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_formacion: str | None = Field(default=None)
+    fecha_inicio_de_la_formacion: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion_de_la_formacion: FlexibleDateValue | None = Field(default=None)
     tiempo_de_permanencia_en_la_entidad: str | None = Field(default=None)
-    fecha_de_convalidacion: str | None = Field(default=None)
+    fecha_de_convalidacion: FlexibleDateValue | None = Field(default=None)
     pais_de_la_entidad_que_expide_el_titulo: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_que_expide_el_titulo: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_que_expide_el_titulo: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_020_040_000_000.py
+++ b/src/models/cvn/generated/cvn_item_020_040_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class FormacionSanitariaEnID(BaseCvnDomainModel):
@@ -12,19 +12,19 @@ class FormacionSanitariaEnID(BaseCvnDomainModel):
     pais_entidad_de_titulacion: str | None = Field(default=None)
     c_auton_reg_de_la_entidad_de_titulacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_titulacion: str | None = Field(default=None)
-    entidad_donde_se_llevo_a_cabo: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_donde_se_llevo_a_cabo: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    entidad_a_la_que_pertenece_el_programa: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_a_la_que_pertenece_el_programa: str | None = Field(default=None)
+    entidad_a_la_que_pertenece_el_programa: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_a_la_que_pertenece_el_programa: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_a_la_que_pertenece_el_programa_otros: str | None = Field(default=None)
-    departamento: str | None = Field(default=None)
-    servicio: str | None = Field(default=None)
-    seccion: str | None = Field(default=None)
-    unidad: str | None = Field(default=None)
+    departamento: EntityNameValue | None = Field(default=None)
+    servicio: EntityNameValue | None = Field(default=None)
+    seccion: EntityNameValue | None = Field(default=None)
+    unidad: EntityNameValue | None = Field(default=None)
     duracion_efectiva: str | None = Field(default=None)
-    fecha_inicio_de_la_formacion: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_formacion: str | None = Field(default=None)
+    fecha_inicio_de_la_formacion: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion_de_la_formacion: FlexibleDateValue | None = Field(default=None)
     calificacion_obtenida: str | None = Field(default=None)
     pais_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_020_050_000_000.py
+++ b/src/models/cvn/generated/cvn_item_020_050_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class CursosYSeminariosRecibidosDePerfeccionamientoInnovacionYMejoraDocenteNuevasTecnologiasEtcCuyoObjetivoSeaLaMejoraDeLaDocencia(BaseCvnDomainModel):
@@ -13,14 +13,14 @@ class CursosYSeminariosRecibidosDePerfeccionamientoInnovacionYMejoraDocenteNueva
     pais_de_la_entidad_organizadora: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_organizadora: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_organizadora: str | None = Field(default=None)
-    entidad_organizadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_organizadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     duracion_en_horas: str | None = Field(default=None)
-    fecha_de_finalizacion: str | None = Field(default=None)
+    fecha_de_finalizacion: FlexibleDateValue | None = Field(default=None)
     perfil_de_destinatarios_as: str = Field(...)
-    fecha_de_inicio: str = Field(...)
-    facultad_escuela_unidad_centro_hospital_o_instituto: RegistryReference | None = Field(default=None)
+    fecha_de_inicio: FlexibleDateValue = Field(...)
+    facultad_escuela_unidad_centro_hospital_o_instituto: EntityNameValue | None = Field(default=None)
     meses: str = Field(...)
     programa_por_el_que_se_ha_financiado_la_estancia: str | None = Field(default=None)
     tareas_contrastables: str = Field(...)

--- a/src/models/cvn/generated/cvn_item_030_010_000_000.py
+++ b/src/models/cvn/generated/cvn_item_030_010_000_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference, SubtypeBackedValue
 
 
 class FormacionAcademicaImpartida(BaseCvnDomainModel):
@@ -15,10 +15,10 @@ class FormacionAcademicaImpartida(BaseCvnDomainModel):
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
-    entidad_de_realizacion: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_030_010_000_110: str | None = Field(default=None)
+    entidad_de_realizacion: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_030_010_000_110: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_030_010_000_120: str | None = Field(default=None)
-    departamento: str | None = Field(default=None)
+    departamento: EntityNameValue | None = Field(default=None)
     tipo_de_programa: str | None = Field(default=None)
     tipo_de_programa_otros: str | None = Field(default=None)
     nombre_de_asignatura_nombre_del_curso: str | None = Field(default=None)
@@ -30,16 +30,16 @@ class FormacionAcademicaImpartida(BaseCvnDomainModel):
     numero_de_horas_creditos_ects: Decimal | None = Field(default=None)
     idioma_en_el_que_impartio_la_asignatura: str | None = Field(default=None)
     frecuencia_de_imparticion_de_la_asignatura: Decimal | None = Field(default=None)
-    field_030_010_000_250: object | None = Field(default=None)
+    field_030_010_000_250: FlexibleDateValue | None = Field(default=None)
     competencias_relacionadas_con_la_asignatura_impartida: str | None = Field(default=None)
     categoria_profesional_del_de_la_solicitante_en_el_momento_en_el_que_desempeno_la_docencia_senalada: str | None = Field(default=None)
     evaluacion_sobre_la_calidad_de_la_docencia_calificacion_obtenida: str | None = Field(default=None)
     evaluacion_sobre_la_calidad_de_la_docencia_calificacion_maxima_posible: str | None = Field(default=None)
-    evaluacion_sobre_la_calidad_de_la_docencia_entidad_de_evaluacion: RegistryReference | None = Field(default=None)
+    evaluacion_sobre_la_calidad_de_la_docencia_entidad_de_evaluacion: EntityNameValue | None = Field(default=None)
     tipo_de_evaluacion: str | None = Field(default=None)
     tipo_de_evaluacion_otros: str | None = Field(default=None)
-    financiacion_obtenida_entidad: RegistryReference | None = Field(default=None)
-    financiacion_obtenida_tipo_de_entidad: str | None = Field(default=None)
+    financiacion_obtenida_entidad: EntityNameValue | None = Field(default=None)
+    financiacion_obtenida_tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     financiacion_obtenida_tipo_de_entidad_otros: str | None = Field(default=None)
     financiacion_obtenida_tipo_de_convocatoria: str | None = Field(default=None)
     financiacion_obtenida_tipo_de_convocatoria_otros: str | None = Field(default=None)
@@ -52,8 +52,8 @@ class FormacionAcademicaImpartida(BaseCvnDomainModel):
     pais_de_la_entidad_financiadora: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_financiadora: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_financiadora: str | None = Field(default=None)
-    tipo_de_entidad_030_010_000_520: str | None = Field(default=None)
+    tipo_de_entidad_030_010_000_520: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_030_010_000_530: str | None = Field(default=None)
-    facultad_escuela_unidad_centro_hospital_o_instituto: RegistryReference | None = Field(default=None)
-    fecha_de_inicio: str = Field(...)
-    fecha_de_finalizacion: str = Field(...)
+    facultad_escuela_unidad_centro_hospital_o_instituto: EntityNameValue | None = Field(default=None)
+    fecha_de_inicio: FlexibleDateValue = Field(...)
+    fecha_de_finalizacion: FlexibleDateValue = Field(...)

--- a/src/models/cvn/generated/cvn_item_030_020_000_000.py
+++ b/src/models/cvn/generated/cvn_item_030_020_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class FormacionSanitariaEspecializadaImpartida(BaseCvnDomainModel):
@@ -15,18 +15,18 @@ class FormacionSanitariaEspecializadaImpartida(BaseCvnDomainModel):
     pais_donde_impartio_la_formacion: str | None = Field(default=None)
     comunidad_autonoma_region_donde_ha_impartido_la_formacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_formacion_impartida: str | None = Field(default=None)
-    entidad_donde_se_llevo_a_cabo: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_030_020_000_120: str | None = Field(default=None)
+    entidad_donde_se_llevo_a_cabo: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_030_020_000_120: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_030_020_000_130: str | None = Field(default=None)
-    entidad_que_expide_el_titulo: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_030_020_000_160: str | None = Field(default=None)
+    entidad_que_expide_el_titulo: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_030_020_000_160: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_030_020_000_170: str | None = Field(default=None)
-    departamento: str | None = Field(default=None)
-    servicio: str | None = Field(default=None)
-    seccion: str | None = Field(default=None)
-    unidad: str | None = Field(default=None)
-    fecha_de_inicio_de_la_formacion: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_formacion: str | None = Field(default=None)
+    departamento: EntityNameValue | None = Field(default=None)
+    servicio: EntityNameValue | None = Field(default=None)
+    seccion: EntityNameValue | None = Field(default=None)
+    unidad: EntityNameValue | None = Field(default=None)
+    fecha_de_inicio_de_la_formacion: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion_de_la_formacion: FlexibleDateValue | None = Field(default=None)
     duracion: str | None = Field(default=None)
     titulacion_de_los_as_destinatarios_as_en_palabras_clave: list[VocabularyReference] = Field(default_factory=list)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_030_030_000_000.py
+++ b/src/models/cvn/generated/cvn_item_030_030_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class FormacionSanitariaEnIDYOPosformacionSanitariaEspecializadaEnIDImpartida(BaseCvnDomainModel):
@@ -12,18 +12,18 @@ class FormacionSanitariaEnIDYOPosformacionSanitariaEspecializadaEnIDImpartida(Ba
     pais_donde_ha_impartido_la_formacion: str | None = Field(default=None)
     comunidad_autonoma_region_donde_ha_impartido_la_formacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_formacion_impartida: str | None = Field(default=None)
-    entidad_de_la_que_depende_el_programa: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_030_030_000_080: str | None = Field(default=None)
+    entidad_de_la_que_depende_el_programa: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_030_030_000_080: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_030_030_000_090: str | None = Field(default=None)
-    entidad_donde_se_imparte_la_formacion: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_030_030_000_120: str | None = Field(default=None)
+    entidad_donde_se_imparte_la_formacion: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_030_030_000_120: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_030_030_000_130: str | None = Field(default=None)
-    departamento: str | None = Field(default=None)
-    servicio: str | None = Field(default=None)
-    seccion: str | None = Field(default=None)
-    unidad: str | None = Field(default=None)
-    fecha_de_inicio_de_la_formacion: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_formacion: str | None = Field(default=None)
+    departamento: EntityNameValue | None = Field(default=None)
+    servicio: EntityNameValue | None = Field(default=None)
+    seccion: EntityNameValue | None = Field(default=None)
+    unidad: EntityNameValue | None = Field(default=None)
+    fecha_de_inicio_de_la_formacion: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion_de_la_formacion: FlexibleDateValue | None = Field(default=None)
     duracion: str | None = Field(default=None)
     destinatarios_as_en_palabras_clave: list[VocabularyReference] = Field(default_factory=list)
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_030_040_000_000.py
+++ b/src/models/cvn/generated/cvn_item_030_040_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, SubtypeBackedValue, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, SubtypeBackedValue, VocabularyReference
 
 
 class DireccionDeTesisDoctoralesYOTrabajosFinDeEstudios(BaseCvnDomainModel):
@@ -14,16 +14,16 @@ class DireccionDeTesisDoctoralesYOTrabajosFinDeEstudios(BaseCvnDomainModel):
     pais_de_direccion_td: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_direccion_td: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_direccion_td: str | None = Field(default=None)
-    entidad_de_la_direccion_td: RegistryReference = Field(...)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_de_la_direccion_td: EntityNameValue = Field(...)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     alumno_a: str | None = Field(default=None)
     palabras_clave: list[VocabularyReference] = Field(default_factory=list)
-    fecha_de_defensa: str | None = Field(default=None)
+    fecha_de_defensa: FlexibleDateValue | None = Field(default=None)
     calificacion_obtenida: str | None = Field(default=None)
-    si_es_doctorado_europeo_internacional_fecha_de_mencion: str | None = Field(default=None)
+    si_es_doctorado_europeo_internacional_fecha_de_mencion: FlexibleDateValue | None = Field(default=None)
     mencion_de_calidad_del_programa: bool | None = Field(default=None)
     codirector_a_de_tesis: list[str] = Field(default_factory=list)
     doctorado_europeo_internacional: bool = Field(...)
-    fecha_mencion_de_calidad: str | None = Field(default=None)
+    fecha_mencion_de_calidad: FlexibleDateValue | None = Field(default=None)
     explicacion_narrativa_de_la_aportacion: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_030_050_000_000.py
+++ b/src/models/cvn/generated/cvn_item_030_050_000_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, HierarchicalCodeReference
 
 
 class TutoriasAcademicasDeEstudiantes(BaseCvnDomainModel):
@@ -15,8 +15,8 @@ class TutoriasAcademicasDeEstudiantes(BaseCvnDomainModel):
     pais_de_la_tutoria: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_tutoria: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_tutoria: str | None = Field(default=None)
-    entidad_donde_se_ejerce_la_tutoria: RegistryReference | None = Field(default=None)
-    entidad_donde_se_ejerce_la_tutoria_tipo: str | None = Field(default=None)
+    entidad_donde_se_ejerce_la_tutoria: EntityNameValue | None = Field(default=None)
+    entidad_donde_se_ejerce_la_tutoria_tipo: EntityTypeValue | None = Field(default=None)
     entidad_donde_se_presta_la_tutoria_tipo_otros: str | None = Field(default=None)
     numero_total_de_alumnos_as_tutelados_as: Decimal | None = Field(default=None)
     frecuencia_de_la_actividad: Decimal | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_030_060_000_000.py
+++ b/src/models/cvn/generated/cvn_item_030_060_000_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, SubtypeBackedValue
 
 
 class CursosYSeminariosImpartidos(BaseCvnDomainModel):
@@ -16,13 +16,13 @@ class CursosYSeminariosImpartidos(BaseCvnDomainModel):
     pais_entidad_organizadora: str | None = Field(default=None)
     comunidad_autonoma_region_entidad_organizadora: HierarchicalCodeReference | None = Field(default=None)
     ciudad_entidad_organizadora: str | None = Field(default=None)
-    entidad_organizadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_organizadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     objetivos_del_curso: str | None = Field(default=None)
     perfil_de_los_as_destinatarios_as: str | None = Field(default=None)
     idioma_en_que_se_impartio: str | None = Field(default=None)
-    fecha_de_imparticion: str | None = Field(default=None)
+    fecha_de_imparticion: FlexibleDateValue | None = Field(default=None)
     horas_impartidas: Decimal | None = Field(default=None)
     tipo_de_participacion: str | None = Field(default=None)
     tipo_de_participacion_otros: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_030_070_000_000.py
+++ b/src/models/cvn/generated/cvn_item_030_070_000_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, IdentifierReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, FlexibleDateValue, IdentifierReference, SubtypeBackedValue
 
 
 class MaterialYOtrasPublicacionesDocentesODeCaracterPedagogico(BaseCvnDomainModel):
@@ -14,7 +14,7 @@ class MaterialYOtrasPublicacionesDocentesODeCaracterPedagogico(BaseCvnDomainMode
     perfil_de_los_as_destinatarios_as: str | None = Field(default=None)
     autores_as_p_o_de_firma_nombres: list[str] = Field(default_factory=list)
     posicion_del_de_la_solicitante_sobre_el_total: Decimal | None = Field(default=None)
-    fecha_de_elaboracion: str | None = Field(default=None)
+    fecha_de_elaboracion: FlexibleDateValue | None = Field(default=None)
     tipologia_libro_articulo_manual_apuntes_etc: SubtypeBackedValue | None = Field(default=None)
     tipologia_otros: str | None = Field(default=None)
     publicacion_titulo: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_030_070_000_080.py
+++ b/src/models/cvn/generated/cvn_item_030_070_000_080.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class PublicacionTitulo030070000080(BaseCvnDomainModel):
     publicacion_titulo: str | None = Field(default=None)
     publicacion_volumen: str | None = Field(default=None)
     publicacion_pagina_inicial_final: str | None = Field(default=None)
-    publicacion_editorial: str | None = Field(default=None)
+    publicacion_editorial: EntityNameValue | None = Field(default=None)
     publicacion_pais: str | None = Field(default=None)
     publicacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
-    publicacion_fecha: str | None = Field(default=None)
+    publicacion_fecha: FlexibleDateValue | None = Field(default=None)
     publicacion_direccion_electronica: str | None = Field(default=None)
     publicacion_isbn_issn: list[str] = Field(default_factory=list)
     publicacion_deposito_legal: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_030_080_000_000.py
+++ b/src/models/cvn/generated/cvn_item_030_080_000_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference
 
 
 class ProyectosDeInnovacionDocente(BaseCvnDomainModel):
@@ -17,21 +17,21 @@ class ProyectosDeInnovacionDocente(BaseCvnDomainModel):
     tipo_de_participacion_otros: str | None = Field(default=None)
     aportacion_del_titular_al_proyecto: str | None = Field(default=None)
     regimen_de_dedicacion: str | None = Field(default=None)
-    entidad_financiadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_financiadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     tipo_de_convocatoria: str | None = Field(default=None)
     tipo_de_convocatoria_otros: str | None = Field(default=None)
-    entidad_es_participante_s: list[RegistryReference] = Field(default_factory=list)
-    tipo_de_entidad_participante: list[str] = Field(default_factory=list)
+    entidad_es_participante_s: list[EntityNameValue] = Field(default_factory=list)
+    tipo_de_entidad_participante: list[EntityTypeValue] = Field(default_factory=list)
     tipo_de_entidad_participante_otros: list[str] = Field(default_factory=list)
     tipo_de_duracion_de_la_relacion_laboral: str | None = Field(default=None)
     duracion_de_la_participacion: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_participacion: str | None = Field(default=None)
+    fecha_de_finalizacion_de_la_participacion: FlexibleDateValue | None = Field(default=None)
     nombre_del_de_la_investigador_a_principal_ip: str | None = Field(default=None)
     numero_de_participantes: Decimal | None = Field(default=None)
     importe_concedido: Decimal | None = Field(default=None)
     ciudad_de_realizacion: str | None = Field(default=None)
     ambito_del_proyecto: ScopeReference = Field(...)
     ambito_del_proyecto_otros: str | None = Field(default=None)
-    fecha_de_inicio: str = Field(...)
+    fecha_de_inicio: FlexibleDateValue = Field(...)

--- a/src/models/cvn/generated/cvn_item_030_090_000_000.py
+++ b/src/models/cvn/generated/cvn_item_030_090_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, SubtypeBackedValue
 
 
 class EventosConIntervencionesOrientadasALaFormacionDocente(BaseCvnDomainModel):
@@ -14,13 +14,13 @@ class EventosConIntervencionesOrientadasALaFormacionDocente(BaseCvnDomainModel):
     pais_de_celebracion: str | None = Field(default=None)
     comunidad_autonoma_region_de_celebracion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_celebracion: str | None = Field(default=None)
-    entidad_organizadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_organizadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     objetivos_del_evento: str | None = Field(default=None)
     perfil_de_los_as_destinatarios_as: str | None = Field(default=None)
     idioma_de_la_presentacion: str | None = Field(default=None)
-    fecha_de_presentacion: str | None = Field(default=None)
+    fecha_de_presentacion: FlexibleDateValue | None = Field(default=None)
     tipo_de_participacion: str | None = Field(default=None)
     tipo_de_participacion_otros: str | None = Field(default=None)
     pais_de_la_entidad_organizadora: str | None = Field(default=None)
@@ -28,5 +28,5 @@ class EventosConIntervencionesOrientadasALaFormacionDocente(BaseCvnDomainModel):
     ciudad_de_la_entidad_organizadora: str | None = Field(default=None)
     publicacion_tipo: SubtypeBackedValue | None = Field(default=None)
     numero_de_horas: str = Field(...)
-    fecha_de_inicio: str = Field(...)
-    fecha_de_finalizacion: str = Field(...)
+    fecha_de_inicio: FlexibleDateValue = Field(...)
+    fecha_de_finalizacion: FlexibleDateValue = Field(...)

--- a/src/models/cvn/generated/cvn_item_030_090_000_220.py
+++ b/src/models/cvn/generated/cvn_item_030_090_000_220.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, IdentifierReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, FlexibleDateValue, HierarchicalCodeReference, IdentifierReference, SubtypeBackedValue
 
 
 class PublicacionISBNISSN(BaseCvnDomainModel):
@@ -12,10 +12,10 @@ class PublicacionISBNISSN(BaseCvnDomainModel):
     publicacion_titulo: str | None = Field(default=None)
     publicacion_volumen: str | None = Field(default=None)
     publicacion_pagina_inicial_final: str | None = Field(default=None)
-    publicacion_editorial: str | None = Field(default=None)
+    publicacion_editorial: EntityNameValue | None = Field(default=None)
     publicacion_pais: str | None = Field(default=None)
     publicacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
-    publicacion_fecha: str | None = Field(default=None)
+    publicacion_fecha: FlexibleDateValue | None = Field(default=None)
     publicacion_direccion_electronica: str | None = Field(default=None)
     publicacion_deposito_legal: str | None = Field(default=None)
     publicacion_nombre: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_030_100_000_000.py
+++ b/src/models/cvn/generated/cvn_item_030_100_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior030100000000(BaseCvnDomainModel):
@@ -13,7 +13,7 @@ class OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior030100000000(BaseCvn
     pais_de_realizacion_de_la_actividad: str | None = Field(default=None)
     comunidad_autonoma_region_de_realizacion_de_la_actividad: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_realizacion_de_la_actividad: str | None = Field(default=None)
-    entidad_organizadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_organizadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_actividad: str | None = Field(default=None)
+    fecha_de_finalizacion_de_la_actividad: FlexibleDateValue | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_030_110_000_000.py
+++ b/src/models/cvn/generated/cvn_item_030_110_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class AportacionesMasRelevantesDeSuCvDeDocencia(BaseCvnDomainModel):
@@ -13,7 +13,7 @@ class AportacionesMasRelevantesDeSuCvDeDocencia(BaseCvnDomainModel):
     pais_de_realizacion_de_la_actividad: str | None = Field(default=None)
     comunidad_autonoma_region_de_realizacion_de_la_actividad: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_realizacion_de_la_actividad: str | None = Field(default=None)
-    entidad_organizadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_organizadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_actividad: str | None = Field(default=None)
+    fecha_de_finalizacion_de_la_actividad: FlexibleDateValue | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_010_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_010_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class ActividadSanitariaEnInstitucionesDeLaUe(BaseCvnDomainModel):
@@ -13,10 +13,10 @@ class ActividadSanitariaEnInstitucionesDeLaUe(BaseCvnDomainModel):
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
-    institucion_de_la_ue_de_la_que_depende_la_experiencia: str | None = Field(default=None)
-    entidad_donde_realizo_la_experiencia: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    institucion_de_la_ue_de_la_que_depende_la_experiencia: EntityNameValue | None = Field(default=None)
+    entidad_donde_realizo_la_experiencia: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    fecha_de_inicio_de_la_experiencia: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_experiencia: str | None = Field(default=None)
+    fecha_de_inicio_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
     duracion_de_la_experiencia: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_020_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_020_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class ActividadSanitariaEnLaOms(BaseCvnDomainModel):
@@ -13,10 +13,10 @@ class ActividadSanitariaEnLaOms(BaseCvnDomainModel):
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
-    departamento_de_la_oms_del_que_dependio_la_experiencia: str | None = Field(default=None)
-    entidad_donde_realizo_la_experiencia: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    departamento_de_la_oms_del_que_dependio_la_experiencia: EntityNameValue | None = Field(default=None)
+    entidad_donde_realizo_la_experiencia: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    fecha_de_inicio_de_la_experiencia: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_experiencia: str | None = Field(default=None)
+    fecha_de_inicio_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
     duracion_de_la_experiencia: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_030_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_030_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class ActividadSanitariaEnOrganizacionesInternacionalesIntergubernamentales(BaseCvnDomainModel):
@@ -13,11 +13,11 @@ class ActividadSanitariaEnOrganizacionesInternacionalesIntergubernamentales(Base
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
-    organizacion_intergubernamental: str | None = Field(default=None)
-    organismo_internacional_departamento: str | None = Field(default=None)
-    entidad_donde_realizo_la_experiencia: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    organizacion_intergubernamental: EntityNameValue | None = Field(default=None)
+    organismo_internacional_departamento: EntityNameValue | None = Field(default=None)
+    entidad_donde_realizo_la_experiencia: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    fecha_de_inicio_de_la_experiencia: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_experiencia: str | None = Field(default=None)
+    fecha_de_inicio_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
     duracion_de_la_experiencia: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_040_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_040_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class ActividadEnCooperacionPracticandoLaAtencionDeSaludEnPaisesEnDesarrollo(BaseCvnDomainModel):
@@ -13,14 +13,14 @@ class ActividadEnCooperacionPracticandoLaAtencionDeSaludEnPaisesEnDesarrollo(Bas
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
-    entidad_donde_realizo_la_experiencia: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_040_000_090: str | None = Field(default=None)
+    entidad_donde_realizo_la_experiencia: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_040_000_090: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_040_000_100: str | None = Field(default=None)
-    entidad_financiadora_de_la_experiencia: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_040_000_130: str | None = Field(default=None)
+    entidad_financiadora_de_la_experiencia: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_040_000_130: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_040_000_140: str | None = Field(default=None)
-    fecha_de_inicio_de_la_experiencia: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_experiencia: str | None = Field(default=None)
+    fecha_de_inicio_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
     duracion_de_la_experiencia: str | None = Field(default=None)
     pais_de_la_entidad_financiadora: str | None = Field(default=None)
     ciudad_de_la_entidad_financiadora: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_050_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_050_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class ActividadEnCooperacionSanitariaEnPaisesEnDesarrollo(BaseCvnDomainModel):
@@ -13,15 +13,15 @@ class ActividadEnCooperacionSanitariaEnPaisesEnDesarrollo(BaseCvnDomainModel):
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
-    entidad_donde_realizo_la_experiencia: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_050_000_090: str | None = Field(default=None)
+    entidad_donde_realizo_la_experiencia: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_050_000_090: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_050_000_100: str | None = Field(default=None)
     pais_de_la_entidad_financiadora: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_financiadora: HierarchicalCodeReference | None = Field(default=None)
-    entidad_financiadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_050_000_160: str | None = Field(default=None)
+    entidad_financiadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_050_000_160: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_050_000_170: str | None = Field(default=None)
-    fecha_inicio_de_la_experiencia: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_experiencia: str | None = Field(default=None)
+    fecha_inicio_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
     duracion_de_la_experiencia: str | None = Field(default=None)
     ciudad_de_la_entidad_financiadora: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_060_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_060_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class ActividadDeAtencionDeSaludEnOtrosPaisesExtranjeros(BaseCvnDomainModel):
@@ -13,15 +13,15 @@ class ActividadDeAtencionDeSaludEnOtrosPaisesExtranjeros(BaseCvnDomainModel):
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
-    entidad_donde_realizo_la_experiencia: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_060_000_090: str | None = Field(default=None)
+    entidad_donde_realizo_la_experiencia: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_060_000_090: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_060_000_100: str | None = Field(default=None)
     pais_de_la_entidad_financiadora: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_financiadora: HierarchicalCodeReference | None = Field(default=None)
-    entidad_financiadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_060_000_160: str | None = Field(default=None)
+    entidad_financiadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_060_000_160: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_060_000_170: str | None = Field(default=None)
-    fecha_de_inicio_de_la_experiencia: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_experiencia: str | None = Field(default=None)
+    fecha_de_inicio_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
     duracion_de_la_experiencia: str | None = Field(default=None)
     ciudad_de_la_entidad_financiadora: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_070_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_070_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class ActividadSanitariaEnPaisesExtranjeros(BaseCvnDomainModel):
@@ -13,15 +13,15 @@ class ActividadSanitariaEnPaisesExtranjeros(BaseCvnDomainModel):
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
-    entidad_donde_realizo_la_experiencia: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_070_000_090: str | None = Field(default=None)
+    entidad_donde_realizo_la_experiencia: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_070_000_090: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_070_000_100: str | None = Field(default=None)
     pais_de_la_entidad_financiadora: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_financiadora: HierarchicalCodeReference | None = Field(default=None)
-    entidad_financiadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_070_000_160: str | None = Field(default=None)
+    entidad_financiadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_070_000_160: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_070_000_170: str | None = Field(default=None)
-    fecha_de_inicio_de_la_experiencia: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_experiencia: str | None = Field(default=None)
+    fecha_de_inicio_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
     duracion_de_la_experiencia: str | None = Field(default=None)
     ciudad_de_la_entidad_financiadora: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_080_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_080_000_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, HierarchicalCodeReference
 
 
 class TutoriasSupervisionDeActividadesDeAtencionDeSalud(BaseCvnDomainModel):
@@ -19,11 +19,11 @@ class TutoriasSupervisionDeActividadesDeAtencionDeSalud(BaseCvnDomainModel):
     pais_de_la_entidad_de_realizacion_de_la_tutoria: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion_de_la_tutoria: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion_de_la_tutoria: str | None = Field(default=None)
-    entidad_donde_realizo_la_tutoria: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_080_000_130: str | None = Field(default=None)
+    entidad_donde_realizo_la_tutoria: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_080_000_130: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_080_000_140: str | None = Field(default=None)
-    entidad_organizadora_de_la_que_depende_el_programa: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_080_000_170: str | None = Field(default=None)
+    entidad_organizadora_de_la_que_depende_el_programa: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_080_000_170: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_080_000_180: str | None = Field(default=None)
     pais_de_la_entidad_organizadora_de_la_que_depende_el_programa: str | None = Field(default=None)
     ciudad_de_la_entidad_organizadora_de_la_que_depende_el_programa: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_090_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_090_000_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, SubtypeBackedValue
 
 
 class CursosYSeminariosImpartidosOrientadosALaMejoraDeLaAtencionDeSaludParaProfesionalesSanitarios(BaseCvnDomainModel):
@@ -16,16 +16,16 @@ class CursosYSeminariosImpartidosOrientadosALaMejoraDeLaAtencionDeSaludParaProfe
     ciudad_de_la_entidad_organizadora: str | None = Field(default=None)
     objetivos_del_curso: str | None = Field(default=None)
     perfil_de_los_as_destinatarios_as: str | None = Field(default=None)
-    fecha_de_inicio: str | None = Field(default=None)
-    fecha_de_finalizacion: str | None = Field(default=None)
+    fecha_de_inicio: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion: FlexibleDateValue | None = Field(default=None)
     horas_impartidas: Decimal | None = Field(default=None)
     tipo_de_participacion: str | None = Field(default=None)
     tipo_de_participacion_otros: str | None = Field(default=None)
-    entidad_responsable_de_la_formacion: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_090_000_150: str | None = Field(default=None)
+    entidad_responsable_de_la_formacion: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_090_000_150: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_090_000_160: str | None = Field(default=None)
-    entidad_de_realizacion: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_090_000_190: str | None = Field(default=None)
+    entidad_de_realizacion: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_090_000_190: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_090_000_200: str | None = Field(default=None)
     idioma: str | None = Field(default=None)
     publicacion_tipo: SubtypeBackedValue | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_090_000_230.py
+++ b/src/models/cvn/generated/cvn_item_040_090_000_230.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, IdentifierReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, FlexibleDateValue, HierarchicalCodeReference, IdentifierReference, SubtypeBackedValue
 
 
 class NODeISBNISSN(BaseCvnDomainModel):
@@ -12,10 +12,10 @@ class NODeISBNISSN(BaseCvnDomainModel):
     publicacion_titulo: str | None = Field(default=None)
     publicacion_volumen: str | None = Field(default=None)
     publicacion_pagina_inicial_final: str | None = Field(default=None)
-    publicacion_editorial: str | None = Field(default=None)
+    publicacion_editorial: EntityNameValue | None = Field(default=None)
     publicacion_pais: str | None = Field(default=None)
     publicacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
-    publicacion_fecha: str | None = Field(default=None)
+    publicacion_fecha: FlexibleDateValue | None = Field(default=None)
     publicacion_direccion_electronica: str | None = Field(default=None)
     publicacion_deposito_legal: str | None = Field(default=None)
     publicacion_nombre: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_100_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_100_000_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, FlexibleDateValue, SubtypeBackedValue
 
 
 class ProtocolosYOtrosMaterialesDeAtencionDeSalud(BaseCvnDomainModel):
@@ -13,7 +13,7 @@ class ProtocolosYOtrosMaterialesDeAtencionDeSalud(BaseCvnDomainModel):
     nombre_del_protocolo_material: str | None = Field(default=None)
     autores_as_p_o_de_firma_nombres: list[str] = Field(default_factory=list)
     posicion_del_de_la_solicitante_sobre_el_total: Decimal | None = Field(default=None)
-    fecha_de_elaboracion: str | None = Field(default=None)
+    fecha_de_elaboracion: FlexibleDateValue | None = Field(default=None)
     tipologia: SubtypeBackedValue | None = Field(default=None)
     tipologia_otros: str | None = Field(default=None)
     publicacion_titulo: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_100_000_070.py
+++ b/src/models/cvn/generated/cvn_item_040_100_000_070.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, IdentifierReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, FlexibleDateValue, HierarchicalCodeReference, IdentifierReference
 
 
 class PublicacionTitulo040100000070(BaseCvnDomainModel):
     publicacion_titulo: str | None = Field(default=None)
     publicacion_volumen: str | None = Field(default=None)
     publicacion_pagina_inicial_final: str | None = Field(default=None)
-    publicacion_editorial: str | None = Field(default=None)
+    publicacion_editorial: EntityNameValue | None = Field(default=None)
     publicacion_pais: str | None = Field(default=None)
     publicacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
-    publicacion_fecha: str | None = Field(default=None)
+    publicacion_fecha: FlexibleDateValue | None = Field(default=None)
     publicacion_direccion_electronica: str | None = Field(default=None)
     publicacion_isbn_issn: list[str] = Field(default_factory=list)
     publicacion_deposito_legal: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_110_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_110_000_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class ProyectosDeInnovacionSanitaria(BaseCvnDomainModel):
@@ -24,15 +24,15 @@ class ProyectosDeInnovacionSanitaria(BaseCvnDomainModel):
     tipo_de_convocatoria: str | None = Field(default=None)
     tipo_de_convocatoria_otros: str | None = Field(default=None)
     nombre_del_de_la_investigador_a_principal_ip: str | None = Field(default=None)
-    entidad_financiadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_040_110_000_180: str | None = Field(default=None)
+    entidad_financiadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_040_110_000_180: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_040_110_000_190: str | None = Field(default=None)
     importe_concedido: Decimal | None = Field(default=None)
-    fecha_de_inicio: str | None = Field(default=None)
+    fecha_de_inicio: FlexibleDateValue | None = Field(default=None)
     duracion: str | None = Field(default=None)
     ciudad_de_la_entidad_financiadora: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_financiadora: HierarchicalCodeReference | None = Field(default=None)
     pais_de_la_entidad_financiadora: str | None = Field(default=None)
     tipo_de_entidad_otros_040_110_000_260: str | None = Field(default=None)
-    tipo_de_entidad_040_110_000_270: str | None = Field(default=None)
-    entidad_de_realizacion: RegistryReference | None = Field(default=None)
+    tipo_de_entidad_040_110_000_270: EntityTypeValue | None = Field(default=None)
+    entidad_de_realizacion: EntityNameValue | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_120_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_120_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class ProyectosParaLaPlanificacionMejoraDeLaSanidad(BaseCvnDomainModel):
@@ -15,17 +15,17 @@ class ProyectosParaLaPlanificacionMejoraDeLaSanidad(BaseCvnDomainModel):
     tipo_de_participacion: str | None = Field(default=None)
     tipo_de_participacion_otros: str | None = Field(default=None)
     regimen_de_dedicacion: str | None = Field(default=None)
-    entidad_financiadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_financiadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    entidad_de_realizacion: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_de_realizacion: str | None = Field(default=None)
+    entidad_de_realizacion: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_de_realizacion: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_de_realizacion_otros: str | None = Field(default=None)
     tipo_de_convocatoria: str | None = Field(default=None)
     tipo_de_convocatoria_otros: str | None = Field(default=None)
     nombre_de_la_convocatoria: str | None = Field(default=None)
     referencia_de_la_convocatoria: str | None = Field(default=None)
-    fecha_de_inicio: str | None = Field(default=None)
+    fecha_de_inicio: FlexibleDateValue | None = Field(default=None)
     duracion: str | None = Field(default=None)
     nombre_del_de_la_investigador_a_principal_ip: str | None = Field(default=None)
     grado_de_responsabilidad: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_130_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_130_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference, SubtypeBackedValue
 
 
 class CongresosCursosYSeminariosOrientadosALaAtencionDeSalud(BaseCvnDomainModel):
@@ -14,14 +14,14 @@ class CongresosCursosYSeminariosOrientadosALaAtencionDeSalud(BaseCvnDomainModel)
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
-    entidad_organizadora: RegistryReference | None = Field(default=None)
+    entidad_organizadora: EntityNameValue | None = Field(default=None)
     ambito_del_evento: ScopeReference | None = Field(default=None)
     ambito_del_evento_otros: str | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     tipo_de_participacion: str | None = Field(default=None)
     tipo_de_participacion_otros: str | None = Field(default=None)
-    fecha_de_presentacion: str | None = Field(default=None)
+    fecha_de_presentacion: FlexibleDateValue | None = Field(default=None)
     idioma_de_la_ponencia: str | None = Field(default=None)
     publicacion_titulo: str | None = Field(default=None)
     pais_de_la_entidad_financiadora: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_130_000_180.py
+++ b/src/models/cvn/generated/cvn_item_040_130_000_180.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, IdentifierReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, FlexibleDateValue, HierarchicalCodeReference, IdentifierReference
 
 
 class PublicacionTitulo040130000180(BaseCvnDomainModel):
@@ -11,10 +11,10 @@ class PublicacionTitulo040130000180(BaseCvnDomainModel):
     publicacion_nombre: str | None = Field(default=None)
     publicacion_volumen: str | None = Field(default=None)
     publicacion_pagina_inicial_final: str | None = Field(default=None)
-    publicacion_editorial: str | None = Field(default=None)
+    publicacion_editorial: EntityNameValue | None = Field(default=None)
     publicacion_pais: str | None = Field(default=None)
     publicacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
-    publicacion_fecha: str | None = Field(default=None)
+    publicacion_fecha: FlexibleDateValue | None = Field(default=None)
     publicacion_direccion_electronica: str | None = Field(default=None)
     publicacion_isbn_issn: list[str] = Field(default_factory=list)
     publicacion_deposito_legal: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_040_140_000_000.py
+++ b/src/models/cvn/generated/cvn_item_040_140_000_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior040140000000(BaseCvnDomainModel):
@@ -13,14 +13,14 @@ class OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior040140000000(BaseCvn
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
-    entidad_de_la_experiencia: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_de_la_experiencia: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    entidad_de_concesion_del_merito: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_de_concesion_del_merito: str | None = Field(default=None)
+    entidad_de_concesion_del_merito: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_de_concesion_del_merito: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_de_concesion_del_merito_otros: str | None = Field(default=None)
-    fecha_de_finalizacion_de_la_experiencia: str | None = Field(default=None)
-    fecha_de_la_concesion: str | None = Field(default=None)
+    fecha_de_finalizacion_de_la_experiencia: FlexibleDateValue | None = Field(default=None)
+    fecha_de_la_concesion: FlexibleDateValue | None = Field(default=None)
     pais_de_la_entidad_financiadora: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_financiadora: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_financiadora: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_050_010_000_000.py
+++ b/src/models/cvn/generated/cvn_item_050_010_000_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class GruposEquiposDeInvestigacionDesarrolloOInnovacion(BaseCvnDomainModel):
@@ -17,11 +17,11 @@ class GruposEquiposDeInvestigacionDesarrolloOInnovacion(BaseCvnDomainModel):
     comunidad_autonoma_region_de_radicacion_del_grupo: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_radicacion_del_grupo: str | None = Field(default=None)
     nombre_del_de_la_investigador_a_principal_ip: str | None = Field(default=None)
-    entidad_a_la_que_pertenece: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_a_la_que_pertenece: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     numero_de_componentes_del_grupo: Decimal | None = Field(default=None)
-    fecha_de_inicio: str | None = Field(default=None)
+    fecha_de_inicio: FlexibleDateValue | None = Field(default=None)
     duracion: str | None = Field(default=None)
     clases_de_colaboracion: str | None = Field(default=None)
     resultados_numero_de_tesis_dirigidas: Decimal | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_050_020_010_000.py
+++ b/src/models/cvn/generated/cvn_item_050_020_010_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference, VocabularyReference
 
 
 class ProyectosDeIDIFinanciadosEnConvocatoriasCompetitivasDeAdministracionesOEntidadesPublicasYPrivadas(BaseCvnDomainModel):
@@ -18,20 +18,20 @@ class ProyectosDeIDIFinanciadosEnConvocatoriasCompetitivasDeAdministracionesOEnt
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
-    entidad_donde_se_desarrolla: RegistryReference = Field(...)
-    tipo_de_entidad_050_020_010_120: str | None = Field(default=None)
+    entidad_donde_se_desarrolla: EntityNameValue = Field(...)
+    tipo_de_entidad_050_020_010_120: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     nombre_del_de_la_investigador_a_principal_ip_co_ip: list[str] = Field(default_factory=list)
     numero_de_investigadores_as_participantes: Decimal = Field(...)
     numero_de_personas_ano: Decimal | None = Field(default=None)
     grado_de_contribucion: str | None = Field(default=None)
     calidad_en_que_ha_participado_otros: str | None = Field(default=None)
-    tipo_de_entidad_050_020_010_210: list[str] = Field(default_factory=list)
+    tipo_de_entidad_050_020_010_210: list[EntityTypeValue] = Field(default_factory=list)
     tipo_de_participacion: str | None = Field(default=None)
     tipo_de_participacion_otros: str | None = Field(default=None)
     nombre_del_programa_de_financiacion: str | None = Field(default=None)
     codigo_de_proyecto_segun_la_entidad_financiadora: str | None = Field(default=None)
-    fecha_de_inicio_del_proyecto: str = Field(...)
+    fecha_de_inicio_del_proyecto: FlexibleDateValue = Field(...)
     duracion_del_proyecto: str | None = Field(default=None)
     financiacion_del_proyecto_cuantia_total: Decimal | None = Field(default=None)
     financiacion_del_proyecto_cuantia_del_subproyecto: Decimal | None = Field(default=None)
@@ -40,7 +40,7 @@ class ProyectosDeIDIFinanciadosEnConvocatoriasCompetitivasDeAdministracionesOEnt
     financiacion_del_proyecto_mixto: Decimal | None = Field(default=None)
     resultados_mas_relevantes: str | None = Field(default=None)
     palabras_clave_050_020_010_350: list[VocabularyReference] = Field(default_factory=list)
-    entidades_participantes: list[RegistryReference] = Field(default_factory=list)
-    fecha_de_finalizacion: str = Field(...)
+    entidades_participantes: list[EntityNameValue] = Field(default_factory=list)
+    fecha_de_finalizacion: FlexibleDateValue = Field(...)
     explicacion_narrativa_de_la_aportacion_del_solicitante_al_proyecto: str = Field(...)
     regimen_de_dedicacion: str = Field(...)

--- a/src/models/cvn/generated/cvn_item_050_020_010_210.py
+++ b/src/models/cvn/generated/cvn_item_050_020_010_210.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, HierarchicalCodeReference
 
 
 class EntidadEsFinanciadoraS(BaseCvnDomainModel):
-    entidad_es_financiadora_s: list[RegistryReference] = Field(default_factory=list)
-    tipo_de_entidad: list[str] = Field(default_factory=list)
+    entidad_es_financiadora_s: list[EntityNameValue] = Field(default_factory=list)
+    tipo_de_entidad: list[EntityTypeValue] = Field(default_factory=list)
     tipo_de_entidad_otros: list[str] = Field(default_factory=list)
     pais_de_la_entidad_financiadora: list[str] = Field(default_factory=list)
     comunidad_autonoma_region_de_la_entidad_financiadora: list[HierarchicalCodeReference] = Field(default_factory=list)

--- a/src/models/cvn/generated/cvn_item_050_020_020_000.py
+++ b/src/models/cvn/generated/cvn_item_050_020_020_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference, VocabularyReference
 
 
 class ContratosConveniosOProyectosDeIDINoCompetitivosConAdministracionesOEntidadesPublicasOPrivadas(BaseCvnDomainModel):
@@ -19,10 +19,10 @@ class ContratosConveniosOProyectosDeIDINoCompetitivosConAdministracionesOEntidad
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
     codigo_de_proyecto_segun_la_entidad_financiadora: str | None = Field(default=None)
-    tipo_de_entidad_050_020_020_140: list[str] = Field(default_factory=list)
+    tipo_de_entidad_050_020_020_140: list[EntityTypeValue] = Field(default_factory=list)
     tipo_de_proyecto_asociado_al_proyecto: str | None = Field(default=None)
     nombre_del_programa_asociado_al_proyecto: str | None = Field(default=None)
-    fecha_de_inicio_del_proyecto: str | None = Field(default=None)
+    fecha_de_inicio_del_proyecto: FlexibleDateValue | None = Field(default=None)
     duracion_del_proyecto: str | None = Field(default=None)
     financiacion_del_proyecto_cuantia_total: Decimal = Field(...)
     financiacion_del_proyecto_cuantia_del_subproyecto: Decimal | None = Field(default=None)
@@ -36,8 +36,8 @@ class ContratosConveniosOProyectosDeIDINoCompetitivosConAdministracionesOEntidad
     calidad_en_que_ha_participado_otros: str | None = Field(default=None)
     resultados_mas_relevantes: str | None = Field(default=None)
     palabras_clave_050_020_020_310: list[VocabularyReference] = Field(default_factory=list)
-    entidades_participantes: list[RegistryReference] = Field(default_factory=list)
-    tipo_de_entidad_050_020_020_330: str | None = Field(default=None)
-    entidad_donde_se_desarrolla: RegistryReference | None = Field(default=None)
+    entidades_participantes: list[EntityNameValue] = Field(default_factory=list)
+    tipo_de_entidad_050_020_020_330: EntityTypeValue | None = Field(default=None)
+    entidad_donde_se_desarrolla: EntityNameValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     explicacion_narrativa_de_la_aportacion: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_050_020_020_140.py
+++ b/src/models/cvn/generated/cvn_item_050_020_020_140.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, HierarchicalCodeReference
 
 
 class NombreSEntidadEsFinanciadoraS(BaseCvnDomainModel):
-    nombre_s_entidad_es_financiadora_s: list[RegistryReference] = Field(default_factory=list)
-    tipo_de_entidad: list[str] = Field(default_factory=list)
+    nombre_s_entidad_es_financiadora_s: list[EntityNameValue] = Field(default_factory=list)
+    tipo_de_entidad: list[EntityTypeValue] = Field(default_factory=list)
     tipo_de_entidad_otros: list[str] = Field(default_factory=list)
     ciudad_de_la_entidad_financiadora: list[str] = Field(default_factory=list)
     pais_de_la_entidad_financiadora: list[str] = Field(default_factory=list)

--- a/src/models/cvn/generated/cvn_item_050_020_030_000.py
+++ b/src/models/cvn/generated/cvn_item_050_020_030_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference
+from models.cvn.components import BaseCvnDomainModel, FlexibleDateValue, HierarchicalCodeReference
 
 
 class ObrasArtisticasYProfesionales(BaseCvnDomainModel):
@@ -18,7 +18,7 @@ class ObrasArtisticasYProfesionales(BaseCvnDomainModel):
     caracteristicas_monografica: bool | None = Field(default=None)
     caracteristicas_catalogo: bool | None = Field(default=None)
     caracteristicas_comisario_de_exposicion: bool | None = Field(default=None)
-    caracteristicas_fecha: str | None = Field(default=None)
+    caracteristicas_fecha: FlexibleDateValue | None = Field(default=None)
     reconocimiento_y_repercusion_catalogacion: str | None = Field(default=None)
     reconocimiento_y_repercusion_premio: str | None = Field(default=None)
     reconocimiento_y_repercusion_publicacion: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_050_030_010_000.py
+++ b/src/models/cvn/generated/cvn_item_050_030_010_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, SubtypeBackedValue, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, FlexibleDateValue, HierarchicalCodeReference, SubtypeBackedValue, VocabularyReference
 
 
 class PropiedadIndustrialEIntelectual(BaseCvnDomainModel):
@@ -21,7 +21,7 @@ class PropiedadIndustrialEIntelectual(BaseCvnDomainModel):
     numero_de_solicitud: str | None = Field(default=None)
     pais_de_prioridad: str | None = Field(default=None)
     comunidad_autonoma_region_de_prioridad: HierarchicalCodeReference | None = Field(default=None)
-    fecha_de_registro: str | None = Field(default=None)
+    fecha_de_registro: FlexibleDateValue | None = Field(default=None)
     ambito_geografico_espana: bool | None = Field(default=None)
     ambito_geografico_patente_europea: bool | None = Field(default=None)
     ambito_geografico_internacional_no_ue: bool | None = Field(default=None)
@@ -30,12 +30,12 @@ class PropiedadIndustrialEIntelectual(BaseCvnDomainModel):
     explotacion_licencias_de_explotacion: bool | None = Field(default=None)
     explotacion_paises_en_los_que_se_ha_extendido_formalizado_separados_por: list[str] = Field(default_factory=list)
     explotacion_comunidad_autonoma_region_en_las_que_se_ha_extendido_formalizado: list[HierarchicalCodeReference] = Field(default_factory=list)
-    explotacion_empresas_entidades_que_estan_explotando_la_licencia: list[RegistryReference] = Field(default_factory=list)
+    explotacion_empresas_entidades_que_estan_explotando_la_licencia: list[EntityNameValue] = Field(default_factory=list)
     explotacion_en_exclusiva: bool | None = Field(default=None)
     generacion_de_una_empresa_innovadora: bool | None = Field(default=None)
     en_este_caso_el_resultado_en_relacion_con_la_empresa_es_de: str | None = Field(default=None)
     nombre_de_los_productos_a_los_que_ha_dado_lugar: list[str] = Field(default_factory=list)
-    entidad_titular_de_derechos: RegistryReference | None = Field(default=None)
+    entidad_titular_de_derechos: EntityNameValue | None = Field(default=None)
     numero_de_patente: str | None = Field(default=None)
-    fecha_de_concesion: str | None = Field(default=None)
+    fecha_de_concesion: FlexibleDateValue | None = Field(default=None)
     patente_pct: bool = Field(...)

--- a/src/models/cvn/generated/cvn_item_050_030_020_000.py
+++ b/src/models/cvn/generated/cvn_item_050_030_020_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, ScopeReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference, VocabularyReference
 
 
 class ResultadosDerivadosDeActividadesEspecializadasYDeTransferenciaNoIncluidosEnApartadosAnteriores(BaseCvnDomainModel):
@@ -24,9 +24,9 @@ class ResultadosDerivadosDeActividadesEspecializadasYDeTransferenciaNoIncluidosE
     clave_de_actividad_convenios_de_colaboracion: bool | None = Field(default=None)
     ambito_de_la_actividad: ScopeReference | None = Field(default=None)
     ambito_de_la_actividad_otros: str | None = Field(default=None)
-    tipo_de_entidad_es_050_030_020_190: list[str] = Field(default_factory=list)
-    tipo_de_entidad_es_050_030_020_230: list[str] = Field(default_factory=list)
-    fecha_de_inicio_de_la_actividad: str | None = Field(default=None)
+    tipo_de_entidad_es_050_030_020_190: list[EntityTypeValue] = Field(default_factory=list)
+    tipo_de_entidad_es_050_030_020_230: list[EntityTypeValue] = Field(default_factory=list)
+    fecha_de_inicio_de_la_actividad: FlexibleDateValue | None = Field(default=None)
     duracion: str | None = Field(default=None)
     resultados_mas_relevantes: str | None = Field(default=None)
     palabras_clave: list[VocabularyReference] = Field(default_factory=list)

--- a/src/models/cvn/generated/cvn_item_050_030_020_190.py
+++ b/src/models/cvn/generated/cvn_item_050_030_020_190.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, HierarchicalCodeReference
 
 
 class EntidadEsColaboradoraS(BaseCvnDomainModel):
-    entidad_es_colaboradora_s: list[RegistryReference] = Field(default_factory=list)
-    tipo_de_entidad_es: list[str] = Field(default_factory=list)
+    entidad_es_colaboradora_s: list[EntityNameValue] = Field(default_factory=list)
+    tipo_de_entidad_es: list[EntityTypeValue] = Field(default_factory=list)
     tipo_de_entidad_es_otros: list[str] = Field(default_factory=list)
     pais_de_la_entidad_colaboradora: list[str] = Field(default_factory=list)
     comunidad_autonoma_region_de_la_entidad_colaboradora: list[HierarchicalCodeReference] = Field(default_factory=list)

--- a/src/models/cvn/generated/cvn_item_050_030_020_230.py
+++ b/src/models/cvn/generated/cvn_item_050_030_020_230.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, HierarchicalCodeReference
 
 
 class EntidadEsDestinatariaSDeLaActividad(BaseCvnDomainModel):
-    entidad_es_destinataria_s_de_la_actividad: list[RegistryReference] = Field(default_factory=list)
-    tipo_de_entidad_es: list[str] = Field(default_factory=list)
+    entidad_es_destinataria_s_de_la_actividad: list[EntityNameValue] = Field(default_factory=list)
+    tipo_de_entidad_es: list[EntityTypeValue] = Field(default_factory=list)
     tipo_de_entidad_es_otros: list[str] = Field(default_factory=list)
     pais_de_la_entidad_destinataria: list[str] = Field(default_factory=list)
     comunidad_autonoma_region_de_la_entidad_destinataria: list[HierarchicalCodeReference] = Field(default_factory=list)

--- a/src/models/cvn/generated/cvn_item_060_010_000_000.py
+++ b/src/models/cvn/generated/cvn_item_060_010_000_000.py
@@ -5,12 +5,12 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, UnresolvedReference
+from models.cvn.components import BaseCvnDomainModel, FlexibleDateValue, UnresolvedReference
 
 
 class ProduccionCientifica(BaseCvnDomainModel):
     produccion_cientifica: list[str] = Field(default_factory=list)
     indice_h_valor: Decimal | None = Field(default=None)
-    indice_h_fecha_de_aplicacion: str | None = Field(default=None)
+    indice_h_fecha_de_aplicacion: FlexibleDateValue | None = Field(default=None)
     fuente_de_indice_h: UnresolvedReference | None = Field(default=None)
     fuente_de_indice_h_otros: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_010_010_000.py
+++ b/src/models/cvn/generated/cvn_item_060_010_010_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, IdentifierReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, FlexibleDateValue, HierarchicalCodeReference, IdentifierReference, SubtypeBackedValue
 
 
 class PublicacionesDocumentosCientificosYTecnicos(BaseCvnDomainModel):
@@ -19,10 +19,10 @@ class PublicacionesDocumentosCientificosYTecnicos(BaseCvnDomainModel):
     soporte: SubtypeBackedValue | None = Field(default=None)
     publicacion_volumen_revista_capitulo_libro: str | None = Field(default=None)
     publicacion_pagina_inicial_final: str | None = Field(default=None)
-    publicacion_editorial: str | None = Field(default=None)
+    publicacion_editorial: EntityNameValue | None = Field(default=None)
     publicacion_pais: str | None = Field(default=None)
     publicacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
-    publicacion_fecha: str | None = Field(default=None)
+    publicacion_fecha: FlexibleDateValue | None = Field(default=None)
     publicacion_direccion_electronica: str | None = Field(default=None)
     publicacion_isbn_issn: list[str] = Field(default_factory=list)
     publicacion_deposito_legal: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_010_020_100.py
+++ b/src/models/cvn/generated/cvn_item_060_010_020_100.py
@@ -3,18 +3,18 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference
 
 
 class AmbitoDelCongreso(BaseCvnDomainModel):
     ambito_del_congreso: ScopeReference | None = Field(default=None)
     ambito_del_congreso_otros: str | None = Field(default=None)
     localizacion_nombre_del_congreso: str | None = Field(default=None)
-    localizacion_entidad_organizadora: RegistryReference | None = Field(default=None)
-    localizacion_tipo_de_entidad: str | None = Field(default=None)
+    localizacion_entidad_organizadora: EntityNameValue | None = Field(default=None)
+    localizacion_tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     localizacion_tipo_de_entidad_otros: str | None = Field(default=None)
     localizacion_pais: str | None = Field(default=None)
     localizacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
     localizacion_ciudad: str | None = Field(default=None)
-    localizacion_fecha: str | None = Field(default=None)
-    fecha_de_finalizacion: str = Field(...)
+    localizacion_fecha: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion: FlexibleDateValue = Field(...)

--- a/src/models/cvn/generated/cvn_item_060_010_020_220.py
+++ b/src/models/cvn/generated/cvn_item_060_010_020_220.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, IdentifierReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, FlexibleDateValue, HierarchicalCodeReference, IdentifierReference, SubtypeBackedValue
 
 
 class FormaDeContribucion(BaseCvnDomainModel):
@@ -11,10 +11,10 @@ class FormaDeContribucion(BaseCvnDomainModel):
     publicacion_titulo: str | None = Field(default=None)
     publicacion_volumen: str | None = Field(default=None)
     publicacion_pagina_inicial_final: str | None = Field(default=None)
-    publicacion_editorial: str | None = Field(default=None)
+    publicacion_editorial: EntityNameValue | None = Field(default=None)
     publicacion_pais: str | None = Field(default=None)
     publicacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
-    publicacion_fecha: str | None = Field(default=None)
+    publicacion_fecha: FlexibleDateValue | None = Field(default=None)
     publicacion_direccion_electronica: str | None = Field(default=None)
     publicacion_isbn_issn: list[str] = Field(default_factory=list)
     publicacion_deposito_legal: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_010_030_070.py
+++ b/src/models/cvn/generated/cvn_item_060_010_030_070.py
@@ -3,18 +3,18 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference
 
 
 class AmbitoDelEvento060010030070(BaseCvnDomainModel):
     ambito_del_evento: ScopeReference | None = Field(default=None)
     ambito_del_evento_otros: str | None = Field(default=None)
     localizacion_nombre_del_evento: str | None = Field(default=None)
-    localizacion_entidad_organizadora: RegistryReference | None = Field(default=None)
-    localizacion_tipo_de_entidad: str | None = Field(default=None)
+    localizacion_entidad_organizadora: EntityNameValue | None = Field(default=None)
+    localizacion_tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     localizacion_tipo_de_entidad_otros: str | None = Field(default=None)
     localizacion_pais: str | None = Field(default=None)
     localizacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
     localizacion_ciudad: str | None = Field(default=None)
-    localizacion_fecha: str | None = Field(default=None)
-    fecha_de_finalizacion: str = Field(...)
+    localizacion_fecha: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion: FlexibleDateValue = Field(...)

--- a/src/models/cvn/generated/cvn_item_060_010_030_190.py
+++ b/src/models/cvn/generated/cvn_item_060_010_030_190.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, IdentifierReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, FlexibleDateValue, HierarchicalCodeReference, IdentifierReference, SubtypeBackedValue
 
 
 class PublicacionTipo060010030190(BaseCvnDomainModel):
@@ -11,10 +11,10 @@ class PublicacionTipo060010030190(BaseCvnDomainModel):
     publicacion_titulo: str | None = Field(default=None)
     publicacion_volumen: str | None = Field(default=None)
     publicacion_pagina_inicial_final: str | None = Field(default=None)
-    publicacion_editorial: str | None = Field(default=None)
+    publicacion_editorial: EntityNameValue | None = Field(default=None)
     publicacion_pais: str | None = Field(default=None)
     publicacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
-    publicacion_fecha: str | None = Field(default=None)
+    publicacion_fecha: FlexibleDateValue | None = Field(default=None)
     publicacion_direccion_electronica: str | None = Field(default=None)
     publicacion_isbn_issn: list[str] = Field(default_factory=list)
     publicacion_deposito_legal: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_010_040_080.py
+++ b/src/models/cvn/generated/cvn_item_060_010_040_080.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference
 
 
 class AmbitoDelEvento060010040080(BaseCvnDomainModel):
     ambito_del_evento: ScopeReference | None = Field(default=None)
     ambito_del_evento_otros: str | None = Field(default=None)
     localizacion_nombre_del_evento: str | None = Field(default=None)
-    localizacion_entidad_organizadora: RegistryReference | None = Field(default=None)
-    localizacion_tipo_de_entidad: str | None = Field(default=None)
+    localizacion_entidad_organizadora: EntityNameValue | None = Field(default=None)
+    localizacion_tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     localizacion_tipo_de_entidad_otros: str | None = Field(default=None)
     localizacion_pais: str | None = Field(default=None)
     localizacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
     localizacion_ciudad: str | None = Field(default=None)
-    localizacion_fecha: str | None = Field(default=None)
+    localizacion_fecha: FlexibleDateValue | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_010_040_200.py
+++ b/src/models/cvn/generated/cvn_item_060_010_040_200.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, IdentifierReference, SubtypeBackedValue
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, FlexibleDateValue, HierarchicalCodeReference, IdentifierReference, SubtypeBackedValue
 
 
 class PublicacionTipo060010040200(BaseCvnDomainModel):
@@ -11,10 +11,10 @@ class PublicacionTipo060010040200(BaseCvnDomainModel):
     publicacion_titulo: str | None = Field(default=None)
     publicacion_volumen: str | None = Field(default=None)
     publicacion_pagina_inicial_final: str | None = Field(default=None)
-    publicacion_editorial: str | None = Field(default=None)
+    publicacion_editorial: EntityNameValue | None = Field(default=None)
     publicacion_pais: str | None = Field(default=None)
     publicacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
-    publicacion_fecha: str | None = Field(default=None)
+    publicacion_fecha: FlexibleDateValue | None = Field(default=None)
     publicacion_direccion_electronica: str | None = Field(default=None)
     publicacion_isbn_issn: list[str] = Field(default_factory=list)
     publicacion_deposito_legal: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_010_050_000.py
+++ b/src/models/cvn/generated/cvn_item_060_010_050_000.py
@@ -3,27 +3,27 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class EstanciasEnCentrosPublicosOPrivados(BaseCvnDomainModel):
     estancias_en_centros_publicos_o_privados: list[str] = Field(default_factory=list)
-    centro_entidad_de_realizacion: RegistryReference = Field(...)
+    centro_entidad_de_realizacion: EntityNameValue = Field(...)
     tipo_de_estancia_en_centro_de_realizacion: str = Field(...)
-    tipo_de_entidad_060_010_050_030: str | None = Field(default=None)
+    tipo_de_entidad_060_010_050_030: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_060_010_050_040: str | None = Field(default=None)
     localizacion_pais: str = Field(...)
     localizacion_comunidad_autonoma_region: HierarchicalCodeReference | None = Field(default=None)
     localizacion_localidad: str = Field(...)
-    localizacion_fecha_inicio: str = Field(...)
+    localizacion_fecha_inicio: FlexibleDateValue = Field(...)
     localizacion_duracion: str = Field(...)
     objetivo_de_la_estancia: str = Field(...)
     objetivo_de_la_estancia_otros: str | None = Field(default=None)
     codigo_unesco_especializacion_primaria: list[HierarchicalCodeReference] = Field(default_factory=list)
     codigo_unesco_especializacion_secundaria: list[HierarchicalCodeReference] = Field(default_factory=list)
     codigo_unesco_especializacion_terciaria: list[HierarchicalCodeReference] = Field(default_factory=list)
-    entidad_fuente_de_la_financiacion: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_060_010_050_180: str | None = Field(default=None)
+    entidad_fuente_de_la_financiacion: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_060_010_050_180: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_060_010_050_190: str | None = Field(default=None)
     nombre_del_programa: str | None = Field(default=None)
     tareas_contrastables_desarrolladas: str = Field(...)
@@ -33,5 +33,5 @@ class EstanciasEnCentrosPublicosOPrivados(BaseCvnDomainModel):
     pais_de_la_entidad_financiadora: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_financiadora: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_financiadora: str | None = Field(default=None)
-    facultad_escuela_unidad_centro_hospital_o_instituto: RegistryReference | None = Field(default=None)
-    fecha_de_finalizacion: str = Field(...)
+    facultad_escuela_unidad_centro_hospital_o_instituto: EntityNameValue | None = Field(default=None)
+    fecha_de_finalizacion: FlexibleDateValue = Field(...)

--- a/src/models/cvn/generated/cvn_item_060_020_010_000.py
+++ b/src/models/cvn/generated/cvn_item_060_020_010_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference
 
 
 class ComitesCientificosTecnicosYOAsesores(BaseCvnDomainModel):
@@ -12,16 +12,16 @@ class ComitesCientificosTecnicosYOAsesores(BaseCvnDomainModel):
     pais_de_radicacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_radicacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_radicacion: str | None = Field(default=None)
-    entidad_de_la_que_depende: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_de_la_que_depende: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     ambito_de_la_actividad: ScopeReference | None = Field(default=None)
     ambito_de_la_actividad_otros: str | None = Field(default=None)
     codigo_unesco_especializacion_primaria: list[HierarchicalCodeReference] = Field(default_factory=list)
     codigo_unesco_especializacion_secundaria: list[HierarchicalCodeReference] = Field(default_factory=list)
     codigo_unesco_especializacion_terciaria: list[HierarchicalCodeReference] = Field(default_factory=list)
-    fecha_inicio: str | None = Field(default=None)
-    fecha_de_finalizacion: str | None = Field(default=None)
+    fecha_inicio: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion: FlexibleDateValue | None = Field(default=None)
     ciudad_de_la_entidad_de_la_que_depende_el_programa: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_la_que_depende_el_programa: HierarchicalCodeReference | None = Field(default=None)
     pais_de_la_entidad_de_la_que_depende_el_programa: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_020_020_000.py
+++ b/src/models/cvn/generated/cvn_item_060_020_020_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class OtrosModosDeColaboracionConInvestigadoresAsOTecnologosAs(BaseCvnDomainModel):
@@ -14,8 +14,8 @@ class OtrosModosDeColaboracionConInvestigadoresAsOTecnologosAs(BaseCvnDomainMode
     comunidad_autonoma_region_de_radicacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_radicacion: str | None = Field(default=None)
     nombres_de_los_investigadores_principales_ip_co_ip: list[str] = Field(default_factory=list)
-    tipo_de_entidad: list[str] = Field(default_factory=list)
-    fecha_de_inicio: str | None = Field(default=None)
+    tipo_de_entidad: list[EntityTypeValue] = Field(default_factory=list)
+    fecha_de_inicio: FlexibleDateValue | None = Field(default=None)
     duracion: str | None = Field(default=None)
     descripcion_del_objeto_de_la_colaboracion: str | None = Field(default=None)
     resultados_mas_relevantes: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_020_020_100.py
+++ b/src/models/cvn/generated/cvn_item_060_020_020_100.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, HierarchicalCodeReference
 
 
 class EntidadesParticipantes(BaseCvnDomainModel):
-    entidades_participantes: list[RegistryReference] = Field(default_factory=list)
-    tipo_de_entidad: list[str] = Field(default_factory=list)
+    entidades_participantes: list[EntityNameValue] = Field(default_factory=list)
+    tipo_de_entidad: list[EntityTypeValue] = Field(default_factory=list)
     tipo_de_entidad_otros: list[str] = Field(default_factory=list)
     pais_de_la_entidad_participante: list[str] = Field(default_factory=list)
     comunidad_autonoma_region_de_la_entidad_participante: list[HierarchicalCodeReference] = Field(default_factory=list)

--- a/src/models/cvn/generated/cvn_item_060_020_030_000.py
+++ b/src/models/cvn/generated/cvn_item_060_020_030_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference
 
 
 class OrganizacionDeActividadesDeIDI(BaseCvnDomainModel):
@@ -15,17 +15,17 @@ class OrganizacionDeActividadesDeIDI(BaseCvnDomainModel):
     pais_de_la_actividad: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_actividad: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_actividad: str | None = Field(default=None)
-    entidad_convocante: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_convocante: str | None = Field(default=None)
+    entidad_convocante: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_convocante: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_convocante_otros: str | None = Field(default=None)
     modo_de_participacion: str | None = Field(default=None)
     modo_de_participacion_otros: str | None = Field(default=None)
     ambito_de_la_reunion: ScopeReference | None = Field(default=None)
     ambito_de_la_reunion_otros: str | None = Field(default=None)
     numero_de_asistentes: Decimal | None = Field(default=None)
-    fecha_de_inicio: str | None = Field(default=None)
+    fecha_de_inicio: FlexibleDateValue | None = Field(default=None)
     duracion: str | None = Field(default=None)
     pais_de_la_entidad_convocante: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_convocante: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_convocante: str | None = Field(default=None)
-    fecha_de_finalizacion: str = Field(...)
+    fecha_de_finalizacion: FlexibleDateValue = Field(...)

--- a/src/models/cvn/generated/cvn_item_060_020_040_000.py
+++ b/src/models/cvn/generated/cvn_item_060_020_040_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference, VocabularyReference
 
 
 class GestionDeIDI(BaseCvnDomainModel):
@@ -17,10 +17,10 @@ class GestionDeIDI(BaseCvnDomainModel):
     nombre_de_la_actividad: str | None = Field(default=None)
     tipologia_de_la_gestion: str | None = Field(default=None)
     tipologia_de_la_gestion_otros: str | None = Field(default=None)
-    entorno_entidad_donde_se_ejercio_la_responsabilidad: RegistryReference | None = Field(default=None)
-    entorno_tipo_de_entidad: str | None = Field(default=None)
+    entorno_entidad_donde_se_ejercio_la_responsabilidad: EntityNameValue | None = Field(default=None)
+    entorno_tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     entorno_tipo_de_entidad_otros: str | None = Field(default=None)
-    entorno_fecha_de_inicio: str | None = Field(default=None)
+    entorno_fecha_de_inicio: FlexibleDateValue | None = Field(default=None)
     entorno_duracion: str | None = Field(default=None)
     sistema_de_acceso: str | None = Field(default=None)
     sistema_de_acceso_otros: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_020_050_000.py
+++ b/src/models/cvn/generated/cvn_item_060_020_050_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class ForosYComitesNacionalesEInternacionales(BaseCvnDomainModel):
@@ -12,15 +12,15 @@ class ForosYComitesNacionalesEInternacionales(BaseCvnDomainModel):
     pais_de_la_entidad_de_realizacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_realizacion: str | None = Field(default=None)
-    entidad_organizadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_organizadora: str | None = Field(default=None)
+    entidad_organizadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_organizadora: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_organizadora_otros: str | None = Field(default=None)
     categoria_profesional: str | None = Field(default=None)
-    organismo_que_representa: RegistryReference | None = Field(default=None)
-    tipo_de_organismo_que_representa: str | None = Field(default=None)
+    organismo_que_representa: EntityNameValue | None = Field(default=None)
+    tipo_de_organismo_que_representa: EntityTypeValue | None = Field(default=None)
     tipo_de_organismo_que_representa_otros: str | None = Field(default=None)
-    fecha_de_inicio: str | None = Field(default=None)
-    fecha_de_finalizacion: str | None = Field(default=None)
+    fecha_de_inicio: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion: FlexibleDateValue | None = Field(default=None)
     pais_de_la_entidad_organizadora: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_organizadora: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_organizadora: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_020_060_000.py
+++ b/src/models/cvn/generated/cvn_item_060_020_060_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference
 
 
 class EvaluacionYRevisionDeProyectosYArticulosDeIDI(BaseCvnDomainModel):
@@ -16,11 +16,11 @@ class EvaluacionYRevisionDeProyectosYArticulosDeIDI(BaseCvnDomainModel):
     comunidad_autonoma_region_de_la_entidad_de_realizacion: HierarchicalCodeReference | None = Field(default=None)
     modalidad_de_la_actividad: str | None = Field(default=None)
     modalidad_de_la_actividad_otros: str | None = Field(default=None)
-    entidad_organizadora: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_organizadora: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    fecha_de_inicio: str | None = Field(default=None)
-    fecha_de_finalizacion: str | None = Field(default=None)
+    fecha_de_inicio: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion: FlexibleDateValue | None = Field(default=None)
     frecuencia_de_la_actividad: Decimal | None = Field(default=None)
     sistema_de_acceso: str | None = Field(default=None)
     sistema_de_acceso_otros: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_030_010_000.py
+++ b/src/models/cvn/generated/cvn_item_060_030_010_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class AyudasYBecasObtenidas(BaseCvnDomainModel):
@@ -16,13 +16,13 @@ class AyudasYBecasObtenidas(BaseCvnDomainModel):
     palabras_clave: list[VocabularyReference] = Field(default_factory=list)
     finalidad: str | None = Field(default=None)
     finalidad_otros: str | None = Field(default=None)
-    entidad_que_la_concede: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_que_la_concede: str | None = Field(default=None)
+    entidad_que_la_concede: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_que_la_concede: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_que_la_concede_otros: str | None = Field(default=None)
     importe: Decimal | None = Field(default=None)
-    fecha: str | None = Field(default=None)
+    fecha: FlexibleDateValue | None = Field(default=None)
     duracion_de_la_ayuda: str | None = Field(default=None)
     ciudad_de_la_entidad_que_la_concede: str | None = Field(default=None)
-    fecha_de_finalizacion: str = Field(...)
-    facultad_escuela_unidad_centro_hospital_o_instituto: RegistryReference | None = Field(default=None)
-    entidad_de_realizacion: RegistryReference = Field(...)
+    fecha_de_finalizacion: FlexibleDateValue = Field(...)
+    facultad_escuela_unidad_centro_hospital_o_instituto: EntityNameValue | None = Field(default=None)
+    entidad_de_realizacion: EntityNameValue = Field(...)

--- a/src/models/cvn/generated/cvn_item_060_030_020_000.py
+++ b/src/models/cvn/generated/cvn_item_060_030_020_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, VocabularyReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, VocabularyReference
 
 
 class SociedadesCientificasYAsociacionesProfesionales(BaseCvnDomainModel):
@@ -13,14 +13,14 @@ class SociedadesCientificasYAsociacionesProfesionales(BaseCvnDomainModel):
     nombre_de_la_sociedad: str | None = Field(default=None)
     pais_de_radicacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_radicacion: HierarchicalCodeReference | None = Field(default=None)
-    entidad_de_afiliacion: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_de_afiliacion: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     palabras_clave: list[VocabularyReference] = Field(default_factory=list)
     categoria_profesional: str | None = Field(default=None)
     tamano_de_la_sociedad: Decimal | None = Field(default=None)
-    fecha_de_inicio: str | None = Field(default=None)
-    fecha_de_finalizacion: str | None = Field(default=None)
+    fecha_de_inicio: FlexibleDateValue | None = Field(default=None)
+    fecha_de_finalizacion: FlexibleDateValue | None = Field(default=None)
     pais_de_la_entidad_de_afiliacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_de_afiliacion: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_la_entidad_de_afiliacion: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_030_030_000.py
+++ b/src/models/cvn/generated/cvn_item_060_030_030_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference
 
 
 class ConsejosEditoriales(BaseCvnDomainModel):
@@ -13,15 +13,15 @@ class ConsejosEditoriales(BaseCvnDomainModel):
     nombre_del_consejo_editorial: str | None = Field(default=None)
     pais_de_radicacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_radicacion: HierarchicalCodeReference | None = Field(default=None)
-    entidad_de_afiliacion: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_de_afiliacion: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     tareas_desarrolladas: str | None = Field(default=None)
     categoria_profesional: str | None = Field(default=None)
     tamano_de_la_sociedad: Decimal | None = Field(default=None)
     ambito: ScopeReference | None = Field(default=None)
     ambito_otros: str | None = Field(default=None)
-    fecha_de_inicio: str | None = Field(default=None)
+    fecha_de_inicio: FlexibleDateValue | None = Field(default=None)
     duracion: str | None = Field(default=None)
     ciudad_de_radicacion: str | None = Field(default=None)
     pais_de_la_entidad_de_afiliacion: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_030_040_000.py
+++ b/src/models/cvn/generated/cvn_item_060_030_040_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class RedesDeCooperacion(BaseCvnDomainModel):
@@ -15,14 +15,14 @@ class RedesDeCooperacion(BaseCvnDomainModel):
     numero_de_investigadores_as: Decimal | None = Field(default=None)
     pais_de_radicacion: str | None = Field(default=None)
     comunidad_autonoma_region_de_radicacion: HierarchicalCodeReference | None = Field(default=None)
-    entidad_es_participante_s: list[RegistryReference] = Field(default_factory=list)
-    tipo_de_entidad_060_030_040_090: list[str] = Field(default_factory=list)
+    entidad_es_participante_s: list[EntityNameValue] = Field(default_factory=list)
+    tipo_de_entidad_060_030_040_090: list[EntityTypeValue] = Field(default_factory=list)
     tipo_de_entidad_otros_060_030_040_100: list[str] = Field(default_factory=list)
-    entidad_que_realizo_la_seleccion: RegistryReference | None = Field(default=None)
-    tipo_de_entidad_060_030_040_130: str | None = Field(default=None)
+    entidad_que_realizo_la_seleccion: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad_060_030_040_130: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros_060_030_040_140: str | None = Field(default=None)
     tareas_desarrolladas: str | None = Field(default=None)
-    fecha_de_inicio: str | None = Field(default=None)
+    fecha_de_inicio: FlexibleDateValue | None = Field(default=None)
     duracion: str | None = Field(default=None)
     ciudad_de_radicacion: str | None = Field(default=None)
     pais_de_la_entidad_de_afiliacion: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_030_050_000.py
+++ b/src/models/cvn/generated/cvn_item_060_030_050_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class PremiosMencionesYDistinciones(BaseCvnDomainModel):
@@ -11,9 +11,9 @@ class PremiosMencionesYDistinciones(BaseCvnDomainModel):
     breve_descripcion_del_titulo_o_premio: str | None = Field(default=None)
     pais_de_la_entidad_que_lo_concede: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_que_lo_concede: HierarchicalCodeReference | None = Field(default=None)
-    entidad_que_lo_concede: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_que_lo_concede: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     reconocimientos_ligados_a_su_concesion: str | None = Field(default=None)
-    fecha_de_concesion: str | None = Field(default=None)
+    fecha_de_concesion: FlexibleDateValue | None = Field(default=None)
     ciudad_de_la_entidad_que_lo_concede: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_030_060_000.py
+++ b/src/models/cvn/generated/cvn_item_060_030_060_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference
 
 
 class OtrasDistincionesCarreraProfesionalYOEmpresarial(BaseCvnDomainModel):
@@ -11,10 +11,10 @@ class OtrasDistincionesCarreraProfesionalYOEmpresarial(BaseCvnDomainModel):
     breve_descripcion_del_ambito_de_capacidades_cientificas_o_tecnologicas_del_ascenso_y_cambios_de_responsabilidad: str | None = Field(default=None)
     pais_de_la_entidad_que_concede_el_reconocimiento: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_que_concede_el_reconocimiento: HierarchicalCodeReference | None = Field(default=None)
-    entidad_que_lo_concede: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_que_lo_concede: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     ambito: ScopeReference | None = Field(default=None)
     ambito_otros: str | None = Field(default=None)
-    fecha_de_concesion: str | None = Field(default=None)
+    fecha_de_concesion: FlexibleDateValue | None = Field(default=None)
     ciudad_de_la_entidad_que_concede_el_reconocimiento: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_030_070_000.py
+++ b/src/models/cvn/generated/cvn_item_060_030_070_000.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference, ScopeReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference, ScopeReference
 
 
 class PeriodosDeActividadInvestigadoraDocenteYDeTransferenciaDelConocimiento(BaseCvnDomainModel):
     periodos_de_actividad_investigadora_docente_y_de_transferencia_del_conocimiento: list[str] = Field(default_factory=list)
     pais_de_la_entidad_que_acredita: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_que_acredita: HierarchicalCodeReference | None = Field(default=None)
-    entidad_que_concede: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_que_concede: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     ambito: ScopeReference | None = Field(default=None)
     ambito_otros: str | None = Field(default=None)
-    fecha_de_obtencion: str | None = Field(default=None)
+    fecha_de_obtencion: FlexibleDateValue | None = Field(default=None)
     ciudad_de_la_entidad_que_acredita: str | None = Field(default=None)
     nombre_de_la_actuacion: str | None = Field(default=None)
     tipo_de_actividad: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_030_080_000.py
+++ b/src/models/cvn/generated/cvn_item_060_030_080_000.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class PremiosDeInnovacionDocente(BaseCvnDomainModel):
@@ -11,10 +11,10 @@ class PremiosDeInnovacionDocente(BaseCvnDomainModel):
     nombre_del_premio: str | None = Field(default=None)
     pais_de_la_entidad_que_concede_el_premio: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_que_concede_el_premio: HierarchicalCodeReference | None = Field(default=None)
-    entidad_que_concede: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    entidad_que_concede: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     a_propuesta_de: str | None = Field(default=None)
-    fecha_de_concesion: str | None = Field(default=None)
+    fecha_de_concesion: FlexibleDateValue | None = Field(default=None)
     ciudad_de_la_entidad_que_concede_el_premio: str | None = Field(default=None)
     explicacion_narrativa_del_merito: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_030_090_000.py
+++ b/src/models/cvn/generated/cvn_item_060_030_090_000.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class AcreditacionesReconocimientosObtenidos(BaseCvnDomainModel):
@@ -13,10 +13,10 @@ class AcreditacionesReconocimientosObtenidos(BaseCvnDomainModel):
     nombre_descripcion: str | None = Field(default=None)
     pais_de_la_entidad_que_acredita: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_que_acredita: HierarchicalCodeReference | None = Field(default=None)
-    fecha_de_obtencion: str | None = Field(default=None)
-    entidad_que_acredita: RegistryReference | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    fecha_de_obtencion: FlexibleDateValue | None = Field(default=None)
+    entidad_que_acredita: EntityNameValue | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
     numero_de_tramos_de_docencia_reconocidos: Decimal | None = Field(default=None)
-    fecha_del_reconocimiento: str | None = Field(default=None)
+    fecha_del_reconocimiento: FlexibleDateValue | None = Field(default=None)
     ciudad_de_la_entidad_que_acredita: str | None = Field(default=None)

--- a/src/models/cvn/generated/cvn_item_060_030_100_000.py
+++ b/src/models/cvn/generated/cvn_item_060_030_100_000.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, RegistryReference
+from models.cvn.components import BaseCvnDomainModel, EntityNameValue, EntityTypeValue, FlexibleDateValue, HierarchicalCodeReference
 
 
 class ResumenDeOtrosMeritos(BaseCvnDomainModel):
     resumen_de_otros_meritos: list[str] = Field(default_factory=list)
     resumen_de_otros_meritos_en_texto_libre: str | None = Field(default=None)
-    entidad_que_acredita: RegistryReference | None = Field(default=None)
-    fecha_de_concesion: str | None = Field(default=None)
+    entidad_que_acredita: EntityNameValue | None = Field(default=None)
+    fecha_de_concesion: FlexibleDateValue | None = Field(default=None)
     tipo_de_entidad_otros: str | None = Field(default=None)
-    tipo_de_entidad: str | None = Field(default=None)
+    tipo_de_entidad: EntityTypeValue | None = Field(default=None)
     pais_de_la_entidad_que_acredita: str | None = Field(default=None)
     ciudad_de_la_entidad_que_acredita: str | None = Field(default=None)
     comunidad_autonoma_region_de_la_entidad_que_acredita: HierarchicalCodeReference | None = Field(default=None)

--- a/src/models/cvn/generated/tree_without_item.py
+++ b/src/models/cvn/generated/tree_without_item.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, IdentifierReference
+from models.cvn.components import BaseCvnDomainModel, HierarchicalCodeReference, IdentifierReference, OfficialIdValue
 
 
 class Apellidos(BaseCvnDomainModel):
@@ -15,7 +15,7 @@ class Apellidos(BaseCvnDomainModel):
     pais_de_nacimiento: str | None = Field(default=None)
     comunidad_autonoma_region_de_nacimiento: HierarchicalCodeReference | None = Field(default=None)
     ciudad_de_nacimiento: str | None = Field(default=None)
-    dni: str | None = Field(default=None)
+    dni: OfficialIdValue | None = Field(default=None)
     nie: str | None = Field(default=None)
     pasaporte: str | None = Field(default=None)
     fotografia_digital: str | None = Field(default=None)

--- a/tests/test_domain_model_generator_unit.py
+++ b/tests/test_domain_model_generator_unit.py
@@ -24,6 +24,7 @@ from cvn_codegen.domain_model_generator import (
     get_field_name_from_policy,
     get_python_type_for_base_kind,
     get_python_type_for_controlled_reference,
+    get_python_type_for_wrapper,
     group_entries_by_cvn_item_code,
     is_controlled_reference_field,
     is_repeated_field,
@@ -55,6 +56,7 @@ from cvn_codegen.normalization_types import (
     SemanticReferenceKind,
     SerializationPattern,
     SourceTrace,
+    StructuralTypeEvidence,
     TreePathEntry,
 )
 from cvn_codegen.domain_model_types import (
@@ -74,9 +76,13 @@ from models.cvn.components import (
     BaseCvnDomainModel,
     BaseControlledReferenceValue,
     CvnTrace,
+    EntityNameValue,
+    EntityTypeValue,
+    FlexibleDateValue,
     HierarchicalCodeReference,
     IdentifierReference,
     MeasureOrScaleValue,
+    OfficialIdValue,
     OpenCodedValue,
     RegistryReference,
     ScopeReference,
@@ -97,6 +103,7 @@ def build_normalized_entry(
     manual_name: str | None = "Nombre de prueba",
     manual_short_name: str | None = "Prueba",
     xml_path: str | None = None,
+    structural_type_evidence: tuple[StructuralTypeEvidence, ...] = (),
 ) -> NormalizedCodeEntry:
     manual_entry = None
     if manual_type is not None:
@@ -136,6 +143,7 @@ def build_normalized_entry(
         tree_paths=tree_paths,
         source_files=source_files,
         reference_resolution=reference_resolution,
+        structural_type_evidence=structural_type_evidence,
     )
 
 
@@ -625,6 +633,30 @@ def test_resolve_python_type_for_policy_maps_scalar_and_repeated_shapes():
     assert resolve_python_type_for_policy(scalar_policy) == "bool"
     assert resolve_python_type_for_policy(repeated_scalar_policy) == "list[Decimal]"
     assert resolve_python_type_for_policy(repeated_controlled_policy) == "list[RegistryReference]"
+
+
+def test_resolve_python_type_for_policy_prefers_wrapper_type():
+    bundle = build_default_semantic_policy_bundle()
+    structural_type_evidence = StructuralTypeEvidence(
+        element_name="OfficialId",
+        declaring_type_name="PersonalIdentificationType",
+        structural_type_name="OfficialIdType",
+        xml_path="/Node/Agent/Property[@name='Identification']/Indicator[@name='OfficialId']",
+        source_xsd_file="CVN.xsd",
+        terminal_wrapper_type_name="OfficialIdType",
+    )
+    policy = build_semantic_field_policy(
+        build_normalized_entry(
+            code="000.010.000.100",
+            structural_type_evidence=(structural_type_evidence,),
+        ),
+        bundle,
+    )
+
+    assert get_python_type_for_wrapper(policy) == "OfficialIdValue"
+    assert resolve_python_type_for_policy(policy) == "OfficialIdValue"
+
+
 def test_build_domain_field_spec_builds_expected_spec():
     bundle = build_default_semantic_policy_bundle()
     policy = build_semantic_field_policy(
@@ -653,6 +685,40 @@ def test_build_domain_field_spec_builds_expected_spec():
     assert spec.trace["base_kind"] == policy.base_kind.value
     assert spec.trace["domain_shape_kind"] == policy.domain_shape_kind.value
     assert spec.trace["enum_eligibility"] == policy.enum_eligibility.value
+    assert spec.wrapper_type_names == ()
+    assert spec.trace["wrapper_type_names"] == ()
+    assert spec.trace["wrapper_policy_kinds"] == ()
+
+
+def test_build_domain_field_spec_includes_wrapper_trace():
+    bundle = build_default_semantic_policy_bundle()
+    structural_type_evidence = StructuralTypeEvidence(
+        element_name="StartDate",
+        declaring_type_name="DateType",
+        structural_type_name="FlexibleDatesType",
+        xml_path="/Node/CVNItem[@code='010.010.000.000']/Property[@name='Date']/Indicator[@name='StartDate']",
+        source_xsd_file="Common.xsd",
+        terminal_wrapper_type_name="FlexibleDatesType",
+    )
+    policy = build_semantic_field_policy(
+        build_normalized_entry(
+            code="010.010.000.180",
+            structural_type_evidence=(structural_type_evidence,),
+        ),
+        bundle,
+    )
+
+    spec = build_domain_field_spec(
+        policy=policy,
+        resolved_field_name="fecha_inicio",
+    )
+
+    assert spec.python_type == "FlexibleDateValue"
+    assert spec.wrapper_type_names == ("FlexibleDatesType",)
+    assert spec.trace["wrapper_type_names"] == ("FlexibleDatesType",)
+    assert spec.trace["wrapper_policy_kinds"] == ("choice_object_candidate",)
+
+
 def test_build_domain_generation_unit_builds_sorted_field_specs():
     bundle = build_default_semantic_policy_bundle()
     policy_a = build_semantic_field_policy(
@@ -1164,6 +1230,25 @@ def test_specialized_controlled_reference_components_expose_expected_extra_field
     assert vocabulary.vocabulary_source == "THESAURUS"
     assert unresolved.raw_reference == "CVN_AGENCY_C"
     assert under_traced.raw_reference == "CVN_PRUEBA"
+
+
+def test_wrapper_value_components_expose_expected_fields():
+    flexible_date = FlexibleDateValue(year="2026", month="06", day="29")
+    official_id = OfficialIdValue(dni="12345678Z")
+    entity_type = EntityTypeValue(code="000", label="Entidad", others="Otra")
+    entity_name = EntityNameValue(name="Universidad", others="Otro nombre")
+
+    assert flexible_date.year == "2026"
+    assert flexible_date.month == "06"
+    assert flexible_date.day == "29"
+    assert official_id.dni == "12345678Z"
+    assert entity_type.code == "000"
+    assert entity_type.label == "Entidad"
+    assert entity_type.others == "Otra"
+    assert entity_name.name == "Universidad"
+    assert entity_name.others == "Otro nombre"
+
+
 def test_resolve_python_type_for_policy_returns_component_names_backed_by_real_components():
     bundle = build_default_semantic_policy_bundle()
     policies_and_expected_types = (
@@ -1455,18 +1540,34 @@ def test_collect_unit_import_types_collects_stdlib_shared_and_enum_types():
         enum_eligibility="ineligible",
         trace={},
     )
+    field_e = DomainFieldSpec(
+        field_name="identificador",
+        python_type="OfficialIdValue",
+        code="005",
+        xml_paths=(),
+        required=False,
+        repeated=False,
+        domain_shape_kind="plain_value",
+        enum_eligibility="ineligible",
+        trace={},
+        wrapper_type_names=("OfficialIdType",),
+    )
 
     unit = DomainGenerationUnit(
         module_name="cvn_item_060_010_000_000",
         class_name="DatosPersonales",
         source_group_key="060.010.000.000",
-        fields=(field_a, field_b, field_c, field_d),
+        fields=(field_a, field_b, field_c, field_d, field_e),
     )
 
     stdlib_types, shared_types, enum_types = collect_unit_import_types(unit)
 
     assert stdlib_types == ("Decimal",)
-    assert shared_types == ("BaseCvnDomainModel", "RegistryReference")
+    assert shared_types == (
+        "BaseCvnDomainModel",
+        "OfficialIdValue",
+        "RegistryReference",
+    )
     assert enum_types == ("SexoEnum",)
 
 
@@ -1892,6 +1993,8 @@ def test_get_canonical_generation_paths_returns_expected_keys_and_paths():
         "subtypes",
         "entity",
         "thesaurus",
+        "cvn_xsd",
+        "common_xsd",
     }
     assert paths["specification_manual"] == Path(
         "docs/CvnXML_v1.4.3_2.1_17012025/XML/SpecificationManual.xml"
@@ -1910,6 +2013,12 @@ def test_get_canonical_generation_paths_returns_expected_keys_and_paths():
     )
     assert paths["thesaurus"] == Path(
         "docs/CvnXML_v1.4.3_2.1_17012025/XML/Thesaurus.xml"
+    )
+    assert paths["cvn_xsd"] == Path(
+        "docs/CvnXML_v1.4.3_2.1_17012025/XSD/CVN.xsd"
+    )
+    assert paths["common_xsd"] == Path(
+        "docs/CvnXML_v1.4.3_2.1_17012025/XSD/Common.xsd"
     )
 
 
@@ -1997,6 +2106,12 @@ def test_generate_domain_models_orchestrates_pipeline_with_defaults(monkeypatch)
     assert cast(tuple[Path, dict[str, str]], recorded["write_args"]) == (
         Path("src/models/cvn/generated"),
         fake_rendered_files,
+    )
+    assert recorded["normalization_kwargs"]["cvn_xsd_path"] == Path(
+        "docs/CvnXML_v1.4.3_2.1_17012025/XSD/CVN.xsd"
+    )
+    assert recorded["normalization_kwargs"]["common_xsd_path"] == Path(
+        "docs/CvnXML_v1.4.3_2.1_17012025/XSD/Common.xsd"
     )
 
 
@@ -2113,6 +2228,12 @@ def test_generate_domain_models_passes_canonical_paths_to_normalization(monkeypa
         ),
         "thesaurus_path": Path(
             "docs/CvnXML_v1.4.3_2.1_17012025/XML/Thesaurus.xml"
+        ),
+        "cvn_xsd_path": Path(
+            "docs/CvnXML_v1.4.3_2.1_17012025/XSD/CVN.xsd"
+        ),
+        "common_xsd_path": Path(
+            "docs/CvnXML_v1.4.3_2.1_17012025/XSD/Common.xsd"
         ),
     }
 

--- a/tests/test_normalization_unit.py
+++ b/tests/test_normalization_unit.py
@@ -54,6 +54,8 @@ ENTITY_XML = (
 THESAURUS_XML = (
     REPO_ROOT / "docs" / "CvnXML_v1.4.3_2.1_17012025" / "XML" / "Thesaurus.xml"
 )
+CVN_XSD = REPO_ROOT / "docs" / "CvnXML_v1.4.3_2.1_17012025" / "XSD" / "CVN.xsd"
+COMMON_XSD = REPO_ROOT / "docs" / "CvnXML_v1.4.3_2.1_17012025" / "XSD" / "Common.xsd"
 
 def test_collect_all_code_raises_for_invalid_manual_entries_type():
     # Arrange
@@ -217,6 +219,30 @@ def test_build_normalization_result_returns_expected_shape():
     assert isinstance(normalization_result.tree_only_codes, tuple)
     assert isinstance(normalization_result.mismatches, tuple)
     assert len(normalization_result.mismatches) >= 2
+
+
+def test_build_normalization_result_exposes_structural_wrapper_evidence():
+    normalization_result = build_normalization_result(
+        specification_manual_path=SPECIFICATION_MANUAL_XML,
+        tree_model_path=TREE_MODEL_XML,
+        cvn_xsd_path=CVN_XSD,
+        common_xsd_path=COMMON_XSD,
+    )
+    expected_wrappers_by_code = {
+        "000.010.000.100": "OfficialIdType",
+        "010.010.000.040": "EntityTypeType",
+        "010.010.000.020": "EntityNameType",
+        "010.010.000.180": "FlexibleDatesType",
+    }
+
+    for code, expected_wrapper_type_name in expected_wrappers_by_code.items():
+        normalized_entry = normalization_result.by_code[code]
+        terminal_wrapper_type_names = tuple(
+            evidence.terminal_wrapper_type_name
+            for evidence in normalized_entry.structural_type_evidence
+            if evidence.terminal_wrapper_type_name is not None
+        )
+        assert expected_wrapper_type_name in terminal_wrapper_type_names
 
 
 def test_build_normalization_result_contains_known_code_and_expected_overlap_examples():

--- a/tests/test_semantic_policy_unit.py
+++ b/tests/test_semantic_policy_unit.py
@@ -10,6 +10,7 @@ from cvn_codegen.normalization_types import (
     SemanticReferenceKind,
     SerializationPattern,
     SourceTrace,
+    StructuralTypeEvidence,
     TreePathEntry,
     ReferenceTableEnumEvidence,
 )
@@ -58,6 +59,7 @@ def build_normalized_entry(
     manual_name: str | None = "Nombre de prueba",
     manual_short_name: str | None = "Prueba",
     xml_path: str | None = None,
+    structural_type_evidence: tuple[StructuralTypeEvidence, ...] = (),
 ) -> NormalizedCodeEntry:
     manual_entry = None
     if manual_type is not None:
@@ -97,6 +99,7 @@ def build_normalized_entry(
         tree_paths=tree_paths,
         source_files=source_files,
         reference_resolution=reference_resolution,
+        structural_type_evidence=structural_type_evidence,
     )
 
 def build_reference_resolution(
@@ -838,13 +841,76 @@ def test_validate_wrapper_case_resolves_wrapper_validation_cases():
         assert wrapper_policy.confidence == validation_case.expected_confidence
 
 
+def test_build_semantic_field_policy_attaches_terminal_wrapper_policy():
+    # Arrange
+    bundle = build_default_semantic_policy_bundle()
+    structural_type_evidence = StructuralTypeEvidence(
+        element_name="OfficialId",
+        declaring_type_name="PersonalIdentificationType",
+        structural_type_name="OfficialIdType",
+        xml_path="/Node/Agent/Property[@name='Identification']/Indicator[@name='OfficialId']",
+        source_xsd_file="CVN.xsd",
+        terminal_wrapper_type_name="OfficialIdType",
+    )
+    entry = build_normalized_entry(
+        code="000.010.000.100",
+        structural_type_evidence=(structural_type_evidence,),
+    )
+
+    # Act
+    field_policy = build_semantic_field_policy(entry, bundle)
+
+    # Assert
+    assert field_policy.wrapper_type_names == ("OfficialIdType",)
+    assert field_policy.wrapper_policy_kinds == (
+        WrapperPolicyKind.CHOICE_OBJECT_CANDIDATE,
+    )
+    assert (
+        StructuralLimitationFlag.CHOICE_NOT_ENFORCED
+        in field_policy.structural_limitation_flags
+    )
+    assert "wrapper_type:OfficialIdType" in field_policy.decision_trace.applied_rules
+    assert field_policy.decision_trace.terminal_wrapper_type_names == (
+        "OfficialIdType",
+    )
+
+
+def test_build_semantic_field_policy_does_not_attach_ancestor_only_wrapper():
+    # Arrange
+    bundle = build_default_semantic_policy_bundle()
+    structural_type_evidence = StructuralTypeEvidence(
+        element_name="DNI",
+        declaring_type_name="OfficialIdType",
+        structural_type_name="CVN_string",
+        xml_path="/Node/Agent/Property[@name='Identification']/Indicator[@name='OfficialId']/Indicator[@name='DNI']",
+        source_xsd_file="Common.xsd",
+        ancestor_wrapper_type_names=("OfficialIdType",),
+    )
+    entry = build_normalized_entry(
+        code="000.010.000.100",
+        structural_type_evidence=(structural_type_evidence,),
+    )
+
+    # Act
+    field_policy = build_semantic_field_policy(entry, bundle)
+
+    # Assert
+    assert field_policy.wrapper_type_names == ()
+    assert field_policy.wrapper_policy_kinds == ()
+    assert field_policy.decision_trace.terminal_wrapper_type_names == ()
+    assert field_policy.decision_trace.ancestor_wrapper_type_names == (
+        "OfficialIdType",
+    )
+    assert "wrapper_type:OfficialIdType" not in field_policy.decision_trace.applied_rules
+
+
 def test_get_wrapper_auto_application_limitation_documents_current_limit():
     # Act
     limitation = get_wrapper_auto_application_limitation()
 
     # Assert
-    assert "NormalizedCodeEntry" in limitation
-    assert "does not expose structural wrapper type names" in limitation
+    assert "structural_type_evidence" in limitation
+    assert "without structural XSD enrichment" in limitation
 
 def test_validation_inventory_has_required_case_ids():
     # Arrange

--- a/tests/test_structural_type_trace_unit.py
+++ b/tests/test_structural_type_trace_unit.py
@@ -1,0 +1,124 @@
+from pathlib import Path
+
+from cvn_codegen.normalization_types import SourceTrace, TreePathEntry
+from cvn_codegen.structural_type_trace import (
+    build_structural_type_index,
+    enrich_tree_entries_with_structural_type_evidence,
+    resolve_structural_type_evidence,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CANONICAL_PACKAGE_DIR = REPO_ROOT / "docs" / "CvnXML_v1.4.3_2.1_17012025"
+CVN_XSD = CANONICAL_PACKAGE_DIR / "XSD" / "CVN.xsd"
+COMMON_XSD = CANONICAL_PACKAGE_DIR / "XSD" / "Common.xsd"
+
+
+def build_test_index():
+    return build_structural_type_index(
+        cvn_xsd_path=CVN_XSD,
+        common_xsd_path=COMMON_XSD,
+    )
+
+
+def test_build_structural_type_index_extracts_root_and_child_mappings():
+    structural_type_index = build_test_index()
+
+    assert structural_type_index.root_types_by_element_name["Agent"].structural_type_name == "AgentType"
+    assert (
+        structural_type_index.child_types_by_declaring_type["PersonalIdentificationType"]["OfficialId"].structural_type_name
+        == "OfficialIdType"
+    )
+    assert (
+        structural_type_index.child_types_by_declaring_type["EntityType"]["EntityName"].structural_type_name
+        == "EntityNameType"
+    )
+
+
+def test_resolve_structural_type_evidence_detects_official_id_wrapper():
+    structural_type_index = build_test_index()
+    xml_path = "/Node/Agent/Property[@name='Identification']/Indicator[@name='PersonalIdentification']/Indicator[@name='OfficialId']"
+
+    evidence = resolve_structural_type_evidence(xml_path, structural_type_index)
+
+    assert evidence is not None
+    assert evidence.element_name == "OfficialId"
+    assert evidence.structural_type_name == "OfficialIdType"
+    assert evidence.terminal_wrapper_type_name == "OfficialIdType"
+    assert evidence.ancestor_wrapper_type_names == ()
+
+
+def test_resolve_structural_type_evidence_detects_entity_type_wrapper():
+    structural_type_index = build_test_index()
+    xml_path = "/Node/CVNItem[@code='010.010.000.000']/Property[@name='Entity']/Indicator[@name='Type']"
+
+    evidence = resolve_structural_type_evidence(xml_path, structural_type_index)
+
+    assert evidence is not None
+    assert evidence.element_name == "Type"
+    assert evidence.structural_type_name == "EntityTypeType"
+    assert evidence.terminal_wrapper_type_name == "EntityTypeType"
+
+
+def test_resolve_structural_type_evidence_detects_entity_name_wrapper():
+    structural_type_index = build_test_index()
+    xml_path = "/Node/CVNItem[@code='010.010.000.000']/Property[@name='Entity']/Indicator[@name='EntityName']"
+
+    evidence = resolve_structural_type_evidence(xml_path, structural_type_index)
+
+    assert evidence is not None
+    assert evidence.element_name == "EntityName"
+    assert evidence.structural_type_name == "EntityNameType"
+    assert evidence.terminal_wrapper_type_name == "EntityNameType"
+
+
+def test_resolve_structural_type_evidence_detects_flexible_dates_wrapper():
+    structural_type_index = build_test_index()
+    xml_path = "/Node/CVNItem[@code='010.010.000.000']/Property[@name='Date']/Indicator[@name='StartDate']"
+
+    evidence = resolve_structural_type_evidence(xml_path, structural_type_index)
+
+    assert evidence is not None
+    assert evidence.element_name == "StartDate"
+    assert evidence.structural_type_name == "FlexibleDatesType"
+    assert evidence.terminal_wrapper_type_name == "FlexibleDatesType"
+
+
+def test_resolve_structural_type_evidence_preserves_ancestor_wrapper_only_for_child_choice():
+    structural_type_index = build_test_index()
+    xml_path = "/Node/Agent/Property[@name='Identification']/Indicator[@name='PersonalIdentification']/Indicator[@name='OfficialId']/Indicator[@name='DNI']"
+
+    evidence = resolve_structural_type_evidence(xml_path, structural_type_index)
+
+    assert evidence is not None
+    assert evidence.element_name == "DNI"
+    assert evidence.structural_type_name == "CVN_string"
+    assert evidence.terminal_wrapper_type_name is None
+    assert evidence.ancestor_wrapper_type_names == ("OfficialIdType",)
+
+
+def test_enrich_tree_entries_with_structural_type_evidence_attaches_evidence():
+    structural_type_index = build_test_index()
+    xml_path = "/Node/Agent/Property[@name='Identification']/Indicator[@name='PersonalIdentification']/Indicator[@name='OfficialId']"
+    entry = TreePathEntry(
+        code="000.010.000.100",
+        tree_cvn_item_code=None,
+        tree_property_name="Identification",
+        tree_indicator_name="OfficialId",
+        tree_value=None,
+        xml_path=xml_path,
+        trace=SourceTrace(
+            source_file="CVNTreeModel.xml",
+            xml_path=xml_path,
+            source_code="000.010.000.100",
+        ),
+    )
+
+    enriched_entries = enrich_tree_entries_with_structural_type_evidence(
+        tree_entries=[entry],
+        structural_type_index=structural_type_index,
+    )
+
+    assert len(enriched_entries) == 1
+    assert enriched_entries[0].structural_type_evidence is not None
+    assert enriched_entries[0].structural_type_evidence.terminal_wrapper_type_name == "OfficialIdType"


### PR DESCRIPTION
Summary
- Adds an upstream structural trace bridge from CVN.xsd and Common.xsd into normalized CVN metadata.
- Exposes wrapper type evidence for FlexibleDatesType, OfficialIdType, EntityTypeType, and EntityNameType without generator-side raw XSD rediscovery.
- Updates semantic policy and domain generation so wrapper-aware fields map to shared value components.
Changes
- Added StructuralTypeEvidence to normalized handoff contracts.
- Added src/cvn_codegen/structural_type_trace.py.
- Enriched normalization with optional cvn_xsd_path and common_xsd_path.
- Added wrapper policy attachment to semantic field policies.
- Added wrapper-aware domain field specs and generated wrapper field types.
- Added shared components:
  - FlexibleDateValue
  - OfficialIdValue
  - EntityTypeValue
  - EntityNameValue
- Regenerated canonical domain models under src/models/cvn/generated/.
- Updated roadmap, current status, known limitations, pipeline docs, and issue #15.
Verification
- uv run pytest -n auto tests/test_structural_type_trace_unit.py tests/test_normalization_unit.py tests/test_semantic_policy_unit.py tests/test_domain_model_generator_unit.py
  - 152 passed
- uv run python -m cvn_codegen.domain_model_generator
  - Generated 105 files
- Generated import smoke:
  - models.cvn.generated
  - models.cvn.generated.enums
  - models.cvn.generated.manual_only
- uv run pytest -n auto tests
  - 228 passed in 189.76s
  closes #38 