### PR TITLE
test(cvn): cover generation pipeline

### DIFF
--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -2,7 +2,7 @@
 
 ## Status Date
 
-- Last updated: 2026-06-30
+- Last updated: 2026-07-01
 
 ## Completed Or Stabilized Work
 
@@ -327,6 +327,36 @@
 - latest full-suite verification passed with `uv run pytest -n auto tests`
   and result `228 passed in 189.76s (0:03:09)`
 
+### Issue `#16`
+
+- automated generation pipeline tests are implemented under `tests/`
+- shared canonical test fixtures now exist in `tests/conftest.py` for canonical
+  XML/XSD paths, auxiliary bundles, XSD-enriched normalization, and temporary
+  domain output
+- new pipeline coverage includes:
+  - core and auxiliary structural generation targets
+  - real XML parse smoke behavior for specification manual and auxiliary sources
+  - documented `CVNTreeModel.xml` parse mismatch behavior
+  - canonical normalization baseline and enriched auxiliary-reference resolution
+  - representative reference regressions for direct, subtype-backed,
+    side-package, hierarchical, unresolved, and under-traced references
+  - semantic policy integration, override precedence, Spanish-first naming, trace
+    preservation, and wrapper handoff behavior
+  - canonical domain generator behavior, importability, rendered-output
+    determinism, ASCII output, and end-to-end generation
+  - explicit source coverage for manual items, tree codes, auxiliary catalog
+    items, normalized entries, semantic policies, domain generation, and core
+    `AuxTable.xsd` structural enums
+- xsdata generation tests now use a test-only file lock in
+  `tests/xsdata_generation_lock.py` so shared `src/generated/*` regeneration is
+  serialized under `pytest -n auto`
+- targeted issue `#16` verification passed with:
+  `uv run pytest -n auto tests/test_generation_pipeline_structural.py tests/test_generation_pipeline_parse_smoke.py tests/test_generation_pipeline_normalization_integration.py tests/test_generation_pipeline_reference_regressions.py tests/test_generation_pipeline_semantic_integration.py tests/test_generation_pipeline_wrapper_handoff.py tests/test_generation_pipeline_domain_generation.py tests/test_generation_pipeline_e2e.py -v`
+  and result `61 passed in 146.76s (0:02:26)`
+- final full-suite verification passed with `uv run pytest -n auto tests`
+- final full-suite verification after the source-coverage audit passed with
+  `uv run pytest -n auto tests` and result `294 passed in 277.77s (0:04:37)`
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -338,21 +368,22 @@
 
 ## Next Planned Work
 
-- Next work item: implement issue `#16` generation pipeline tests
-- Required corrective references before starting:
+- Next work item: implement issue `#17` workflow documentation
+- Relevant corrective references before starting:
   - `docs/roadmap/hotfixes/hotfix-4-structural-scope-correction-for-auxiliary-source-package-artifacts.md`
   - `docs/roadmap/hotfixes/hotfix-5-normalization-resolution-layer-for-auxiliary-reference-sources.md`
   - `docs/roadmap/hotfixes/hotfix-6-roadmap-realignment-for-auxiliary-catalog-semantic-integration.md`
   - `docs/roadmap/hotfixes/hotfix-7-dynamic-reference-table-enum-eligibility-evaluation.md`
   - `docs/roadmap/hotfixes/hotfix-8-wrapper-type-traceability-in-normalized-handoff.md`
 - Issue document to read first:
-  - `docs/roadmap/issues/issue-16-generation-pipeline-tests.md`
-- Corrected starting assumption for issue `#16`:
-  - tests should treat `SemanticPolicyBundle` as the semantic source of truth for
-    domain generation behavior
-  - tests should cover canonical generated output, importability, determinism,
-    and representative controlled-reference families
-  - tests should cover the wrapper-handoff boundary implemented by hotfix `#8`
+  - `docs/roadmap/issues/issue-17-workflow-documentation.md`
+- Corrected starting assumption for issue `#17`:
+  - workflow documentation must cover the implemented structural, normalization,
+    semantic-policy, domain-generation, wrapper-handoff, and test layers
+  - `SemanticPolicyBundle` is the source-of-truth handoff between normalization
+    and domain generation
+  - full-suite verification uses `uv run pytest -n auto tests`, with xsdata
+    regeneration tests serialized internally by a test-only lock
 
 ## Blocking Or Relevant Limitations
 

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -31,8 +31,8 @@ Goal:
 | `#13` | Parse and normalize `SpecificationManual.xml` and `CVNTreeModel.xml` | Completed | Core normalization and auxiliary-reference resolution enrichment implemented; baseline overlap counts preserved |
 | `#14` | Define semantic mapping rules and override policy | Completed | Semantic policy bundle, resolver, overrides, naming, wrapper policies, validation inventory, and tests implemented |
 | `#15` | Implement the domain Pydantic model generator | Completed | Generator, shared components, wrapper-aware handoff, generated output, and verification are implemented |
-| `#16` | Add automated tests for the generation pipeline | Next | Must cover both core pipeline and auxiliary enrichment path |
-| `#17` | Document and automate the complete workflow | Pending | Must document corrected full workflow including auxiliary stages |
+| `#16` | Add automated tests for the generation pipeline | Completed | Pipeline, source coverage, wrapper, generator, importability, determinism, and E2E tests implemented |
+| `#17` | Document and automate the complete workflow | Next | Must document corrected full workflow including auxiliary stages |
 | `#25` | GitHub Actions CI pipeline for PR testing on main and development | Completed | PRs to `main` and `development` now run the `tests` check |
 
 Corrective planning after hotfixes `#4`, `#5`, and `#6`:
@@ -309,6 +309,15 @@ Authoritative record:
   - end-to-end pipeline coverage
   - regression coverage for auxiliary structural targets and reference-resolution
     behavior
+- Implemented outcome:
+  - shared canonical test fixtures cover source-package paths, auxiliary bundles,
+    enriched normalization, and temporary generated domain output
+  - pipeline tests now cover structural generation, parse smoke behavior,
+    normalization integration, reference regressions, semantic policy,
+    wrapper handoff, domain generation, source coverage, importability,
+    determinism, and E2E flow
+  - xsdata regeneration tests are serialized under xdist with a test-only lock
+  - full repository verification passed with `uv run pytest -n auto tests`
 
 ### Issue `#17`
 

--- a/docs/roadmap/issues/issue-16-generation-pipeline-tests.md
+++ b/docs/roadmap/issues/issue-16-generation-pipeline-tests.md
@@ -2,21 +2,25 @@
 
 ## Summary
 
-Issue `#16` will expand the current smoke tests into a reproducible test suite
-for the structural and semantic generation workflow.
+Issue `#16` expands the current smoke and unit tests into a reproducible test
+suite for the full structural, normalization, semantic-policy, domain-generator,
+and end-to-end CVN generation workflow.
 
 ## Corrected Prerequisite Chain
 
-Issue `#16` must test pipeline stages that are already broader than the
-original core-only roadmap assumed.
+Issue `#16` starts from completed upstream work, not from the older core-only
+roadmap assumption.
 
-The corrected test scope begins from these implemented upstream realities:
+Implemented upstream prerequisites are:
 
-1. auxiliary structural generation targets were added by hotfix `#4`
-2. enriched normalization with deterministic auxiliary-reference resolution was
-   added by hotfix `#5`
-3. issue `#14` and issue `#15` are expected to consume those layers rather than
-   rediscover them
+1. auxiliary structural generation targets from hotfix `#4`
+2. enriched normalization with deterministic auxiliary-reference resolution from
+   hotfix `#5`
+3. dynamic reference-table enum evidence from hotfix `#7`
+4. semantic policy from issue `#14`
+5. wrapper type traceability in normalized handoff from hotfix `#8`
+6. domain model generator and generated domain artifacts from issue `#15`
+7. CI test execution under `tests/` from issue `#25`
 
 ## Original Goal
 
@@ -32,8 +36,28 @@ The corrected test scope begins from these implemented upstream realities:
 6. add at least one end-to-end generation test
 7. cover known mismatches and special cases
 
-<<<<<<< Updated upstream
-=======
+## Accepted Execution Protocol
+
+The user accepted this execution plan before implementation starts.
+
+At every execution step, the implementer must report:
+
+1. current task number and task name
+2. current subtask number and subtask name, when a subtask is being executed
+3. short initial summary of what the task or subtask will do
+4. short final result for the task or subtask
+5. whether the user must modify any file manually
+6. next step to follow
+
+File-modification rule:
+
+- documentation changes may be performed when explicitly requested
+- code changes should be left for the user unless the user explicitly authorizes
+  the agent to edit code
+- generated code under `src/generated/` must not be edited manually
+- generated domain output under `src/models/cvn/generated/` must be changed only
+  by the generator, not by manual edits
+
 ## Corrected Minimum Coverage Matrix
 
 The corrected test plan must include:
@@ -50,52 +74,477 @@ The corrected test plan must include:
 9. generator tests proving distinct domain shapes per semantic class
 10. end-to-end tests proving semantic generation consumes enriched normalization
     metadata correctly
+11. wrapper-handoff tests for hotfix `#8`
+12. generated-output importability and determinism tests
 
-## Semantic Policy Coverage From Issue `#14`
+## Accepted Execution Plan
 
-Issue `#16` must test the semantic policy contract as a first-class pipeline
-stage, not only the final generated models.
+### Task `1 / 18` - Register Plan In Issue Documentation
 
-Required semantic-policy coverage includes:
+- Task summary:
+  - record the accepted issue `#16` execution plan and remove stale conflict
+    markers from the issue document
+- Files involved:
+  - `docs/roadmap/issues/issue-16-generation-pipeline-tests.md`
+- Subtask `1.1 / 18`:
+  - remove `<<<<<<<`, `=======`, and `>>>>>>>` markers and duplicated sections
+- Subtask `1.2 / 18`:
+  - preserve the corrected prerequisite chain and minimum coverage matrix
+- Subtask `1.3 / 18`:
+  - insert the accepted execution protocol and task list
+- User manual modifications needed:
+  - none expected for this documentation update
+- Next step:
+  - verify baseline before test implementation
 
-1. `SemanticPolicyBundle` construction and deterministic lookup behavior
-2. override precedence for `code + xml_path`, `code`, `xml_path`,
-   `reference_resolution.semantic_kind`, `reference_resolution.serialization_pattern`,
-   `manual_type`, wrapper policy, presence/cardinality policy, and defaults
-3. same-priority override conflicts producing
-   `PolicyConfidence.REQUIRES_REVIEW`
-4. base type mapping for `Alphanumeric`, controlled `Alphanumeric`, `Date`,
-   `Double`, `Boolean`, `Duration`, missing, and unknown manual types
-5. enum eligibility decisions for strict, open, registry, thesaurus,
-   hierarchical, subtype-backed, unresolved, and under-traced references
-6. wrapper policy decisions for `FlexibleDatesType`, `OfficialIdType`,
-   `EntityTypeType`, and `EntityNameType`
-7. Spanish-first naming normalization, including ASCII normalization,
-   `snake_case`, `PascalCase`, acronym preservation, and deterministic collision
-   fallback
-8. trace preservation through CVN `code`, `xml_path`,
-   `reference_resolution.trace`, and `SemanticDecisionTrace`
+### Task `2 / 18` - Verify Baseline
 
-The test suite should verify semantic policy outputs before generator tests so
-generator failures can be separated from semantic-policy failures.
+- Task summary:
+  - prove the current repository test suite is stable before adding issue `#16`
+    coverage
+- Commands:
+  - `uv run pytest -n auto tests`
+- Subtask `2.1 / 18`:
+  - run the full repository test suite with the documented command
+- Subtask `2.2 / 18`:
+  - record exact failures if the baseline fails
+- Subtask `2.3 / 18`:
+  - fix or defer baseline failures only after user approval if code changes are
+    required
+- User manual modifications needed:
+  - none unless verification exposes required code changes
+- Next step:
+  - create reusable canonical pipeline fixtures
 
->>>>>>> Stashed changes
+### Task `3 / 18` - Create Pipeline Fixtures
+
+- Task summary:
+  - define reusable test helpers for canonical package paths, auxiliary bundles,
+    normalization runs, and temporary generated output
+- Expected test location:
+  - `tests/conftest.py` when helpers are shared across multiple files
+- Subtask `3.1 / 18`:
+  - expose canonical XML and XSD paths under
+    `docs/CvnXML_v1.4.3_2.1_17012025/`
+- Subtask `3.2 / 18`:
+  - expose `ReferenceTables.xml`, `Subtype_Spa.xml`, `Entity.xml`, and
+    `Thesaurus.xml` paths
+- Subtask `3.3 / 18`:
+  - add helper for `build_auxiliary_source_bundle(...)`
+- Subtask `3.4 / 18`:
+  - add helper for canonical `build_normalization_result(...)` with auxiliary
+    sources and optional structural type evidence
+- Subtask `3.5 / 18`:
+  - add helper for temporary domain-generation output paths
+- User manual modifications needed:
+  - test helper file should be edited by the user unless explicit code-edit
+    approval is given
+- Next step:
+  - add structural generation tests
+
+### Task `4 / 18` - Add Structural Generation Tests
+
+- Task summary:
+  - verify every structural generation target can generate importable Python
+    packages
+- Expected test location:
+  - `tests/test_generation_pipeline_structural.py`
+- Subtask `4.1 / 18`:
+  - test core targets: `cvn`, `specification_manual`, and `tree_model`
+- Subtask `4.2 / 18`:
+  - test auxiliary targets: `reference_tables`, `subtypes`, `entity`, and
+    `thesaurus`
+- Subtask `4.3 / 18`:
+  - assert generated output directories contain Python files
+- Subtask `4.4 / 18`:
+  - assert generated packages import after generation
+- Subtask `4.5 / 18`:
+  - ensure tests never manually edit `src/generated/`
+- User manual modifications needed:
+  - test file should be created by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - add real parse smoke tests
+
+### Task `5 / 18` - Add Real Parse Smoke Tests
+
+- Task summary:
+  - verify generated bindings can parse real canonical XML inputs or report known
+    documented mismatches
+- Expected test location:
+  - `tests/test_generation_pipeline_parse_smoke.py`
+- Subtask `5.1 / 18`:
+  - parse `SpecificationManual.xml` successfully
+- Subtask `5.2 / 18`:
+  - parse `ReferenceTables.xml`, `Subtype_Spa.xml`, `Entity.xml`, and
+    `Thesaurus.xml` successfully
+- Subtask `5.3 / 18`:
+  - assert `CVNTreeModel.xml` behavior as a known XML/XSD mismatch, not an
+    unexpected failure
+- Subtask `5.4 / 18`:
+  - connect expected mismatch text to `docs/pipeline/known_limitations.md`
+- User manual modifications needed:
+  - test file should be created by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - add normalization integration tests
+
+### Task `6 / 18` - Add Real Normalization Integration Tests
+
+- Task summary:
+  - verify canonical normalization outputs remain stable when auxiliary sources
+    and structural type evidence are provided
+- Expected test location:
+  - `tests/test_generation_pipeline_normalization_integration.py`
+- Subtask `6.1 / 18`:
+  - assert normalized count baseline: total `1457`, manual-only `27`, tree-only
+    `1`, overlap `1429`
+- Subtask `6.2 / 18`:
+  - assert documented mismatch categories remain present
+- Subtask `6.3 / 18`:
+  - assert `reference_resolution` metadata is attached when auxiliary inputs are
+    provided
+- Subtask `6.4 / 18`:
+  - assert `structural_type_evidence` is attached when `CVN.xsd` and `Common.xsd`
+    are provided
+- User manual modifications needed:
+  - test file should be created by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - add auxiliary reference regression tests
+
+### Task `7 / 18` - Add Auxiliary Reference Regression Tests
+
+- Task summary:
+  - lock representative source-package reference classifications used downstream
+    by semantic policy and generator tests
+- Expected test location:
+  - `tests/test_generation_pipeline_reference_regressions.py`
+- Subtask `7.1 / 18`:
+  - test `CVN_SEX_A` as direct compact table with eligible enum evidence
+- Subtask `7.2 / 18`:
+  - test `CVN_ENTITY_TYPE` as direct compact table with delegate/open evidence
+    and enum ineligibility
+- Subtask `7.3 / 18`:
+  - test `CVN_KNOW_A` as subtype-backed and strict-enum ineligible
+- Subtask `7.4 / 18`:
+  - test `ENTITY@Entity.xsd` as side-package registry reference
+- Subtask `7.5 / 18`:
+  - test `THESAURUS@thesaurus.xsd` as side-package vocabulary reference
+- Subtask `7.6 / 18`:
+  - test `UNESCO_CODES` as hierarchical thematic reference
+- Subtask `7.7 / 18`:
+  - test `CVN_AGENCY_C` as unresolved manual-only reference
+- Subtask `7.8 / 18`:
+  - test `CVN_INTERVENTION_A` and `CVN_PRUEBA` as under-traced tables
+- User manual modifications needed:
+  - test file should be created by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - add semantic policy integration tests
+
+### Task `8 / 18` - Add Semantic Policy Integration Tests
+
+- Task summary:
+  - verify real normalized entries become expected `SemanticFieldPolicy` outputs
+    before generator assertions run
+- Expected test location:
+  - `tests/test_generation_pipeline_semantic_integration.py`
+- Subtask `8.1 / 18`:
+  - build semantic policies from canonical normalized entries
+- Subtask `8.2 / 18`:
+  - assert deterministic `SemanticPolicyBundle` lookup behavior
+- Subtask `8.3 / 18`:
+  - assert representative domain shapes and enum decisions for real cases
+- Subtask `8.4 / 18`:
+  - assert trace preservation through CVN `code`, `xml_path`,
+    `reference_resolution.trace`, and `SemanticDecisionTrace`
+- User manual modifications needed:
+  - test file should be created by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - add override policy contract tests
+
+### Task `9 / 18` - Add Override Policy Contract Tests
+
+- Task summary:
+  - protect deterministic override precedence and review behavior independent
+    from generator output
+- Expected test location:
+  - `tests/test_generation_pipeline_semantic_integration.py` or
+    `tests/test_semantic_policy_unit.py` if purely unit-level
+- Subtask `9.1 / 18`:
+  - test precedence for `code + xml_path`, `code`, and `xml_path`
+- Subtask `9.2 / 18`:
+  - test precedence for `reference_resolution.semantic_kind` and
+    `reference_resolution.serialization_pattern`
+- Subtask `9.3 / 18`:
+  - test precedence for `manual_type`, wrapper policy, presence/cardinality, and
+    defaults
+- Subtask `9.4 / 18`:
+  - test same-priority override conflicts produce
+    `PolicyConfidence.REQUIRES_REVIEW`
+- User manual modifications needed:
+  - test file should be edited by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - add naming policy contract tests
+
+### Task `10 / 18` - Add Naming Policy Contract Tests
+
+- Task summary:
+  - protect Spanish-first deterministic naming behavior used by generated domain
+    artifacts
+- Expected test location:
+  - `tests/test_generation_pipeline_semantic_integration.py` or
+    `tests/test_semantic_policy_unit.py` if purely unit-level
+- Subtask `10.1 / 18`:
+  - test ASCII normalization and punctuation removal
+- Subtask `10.2 / 18`:
+  - test `snake_case` field names
+- Subtask `10.3 / 18`:
+  - test `PascalCase` class names
+- Subtask `10.4 / 18`:
+  - test acronym preservation for `CVN`, `UNESCO`, `ORCID`, `DOI`, `ISBN`,
+    `ISSN`, and `H`
+- Subtask `10.5 / 18`:
+  - test deterministic collision fallback
+- Subtask `10.6 / 18`:
+  - assert CVN source identifiers remain literal in trace metadata
+- User manual modifications needed:
+  - test file should be edited by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - add wrapper handoff tests
+
+### Task `11 / 18` - Add Wrapper Handoff Tests
+
+- Task summary:
+  - verify hotfix `#8` wrapper evidence flows from normalization into semantic
+    policy and domain generation without generator-side raw XSD rediscovery
+- Expected test location:
+  - `tests/test_generation_pipeline_wrapper_handoff.py`
+- Subtask `11.1 / 18`:
+  - test terminal `FlexibleDatesType` maps to `FlexibleDateValue`
+- Subtask `11.2 / 18`:
+  - test terminal `OfficialIdType` maps to `OfficialIdValue`
+- Subtask `11.3 / 18`:
+  - test terminal `EntityTypeType` maps to `EntityTypeValue`
+- Subtask `11.4 / 18`:
+  - test terminal `EntityNameType` maps to `EntityNameValue`
+- Subtask `11.5 / 18`:
+  - test ancestor-only wrapper trace does not become terminal wrapper field
+- Subtask `11.6 / 18`:
+  - assert `structural_type_evidence` is the consumed handoff data
+- User manual modifications needed:
+  - test file should be created by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - add canonical generator contract tests
+
+### Task `12 / 18` - Add Generator Canonical Contract Tests
+
+- Task summary:
+  - verify the domain generator consumes `SemanticPolicyBundle` outputs and emits
+    distinct shapes per semantic class
+- Expected test location:
+  - `tests/test_generation_pipeline_domain_generation.py`
+- Subtask `12.1 / 18`:
+  - build canonical normalization and semantic policy index
+- Subtask `12.2 / 18`:
+  - call `build_domain_generation_result(...)`
+- Subtask `12.3 / 18`:
+  - assert eligible strict enum cases produce enum specs
+- Subtask `12.4 / 18`:
+  - assert ineligible or reviewed controlled references do not produce strict
+    enums
+- Subtask `12.5 / 18`:
+  - assert non-enum controlled references map to the correct shared components
+- Subtask `12.6 / 18`:
+  - assert `cvn_trace` metadata is preserved in field specs
+- User manual modifications needed:
+  - test file should be created by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - add generated output importability tests
+
+### Task `13 / 18` - Add Generated Output Importability Tests
+
+- Task summary:
+  - prove generated Python output can be written to a temporary directory,
+    imported, and instantiated
+- Expected test location:
+  - `tests/test_generation_pipeline_domain_generation.py` or
+    `tests/test_generation_pipeline_e2e.py`
+- Subtask `13.1 / 18`:
+  - generate rendered domain files into a temporary output directory
+- Subtask `13.2 / 18`:
+  - import the generated package from the temporary directory
+- Subtask `13.3 / 18`:
+  - import `enums`, `manual_only`, and at least one `cvn_item_*` module
+- Subtask `13.4 / 18`:
+  - instantiate a representative generated model
+- Subtask `13.5 / 18`:
+  - assert trace metadata includes `code`, `xml_paths`, `domain_shape_kind`, and
+    `enum_eligibility`
+- User manual modifications needed:
+  - test file should be edited by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - add determinism tests
+
+### Task `14 / 18` - Add Determinism Tests
+
+- Task summary:
+  - prove repeated generation from identical inputs produces identical files
+- Expected test location:
+  - `tests/test_generation_pipeline_domain_generation.py` or
+    `tests/test_generation_pipeline_e2e.py`
+- Subtask `14.1 / 18`:
+  - run generation twice into separate temporary directories
+- Subtask `14.2 / 18`:
+  - compare generated relative file paths
+- Subtask `14.3 / 18`:
+  - compare generated file bytes
+- Subtask `14.4 / 18`:
+  - assert generated output remains ASCII-only when current generator policy keeps
+    that guarantee
+- User manual modifications needed:
+  - test file should be edited by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - add end-to-end pipeline test
+
+### Task `15 / 18` - Add End-To-End Pipeline Test
+
+- Task summary:
+  - test the real pipeline from canonical source package through generated domain
+    imports
+- Expected test location:
+  - `tests/test_generation_pipeline_e2e.py`
+- Subtask `15.1 / 18`:
+  - start from canonical XML and XSD paths
+- Subtask `15.2 / 18`:
+  - build auxiliary bundle and enriched normalization result
+- Subtask `15.3 / 18`:
+  - build semantic policies and domain generation result
+- Subtask `15.4 / 18`:
+  - render and write generated domain files to a temporary directory
+- Subtask `15.5 / 18`:
+  - import generated package and representative modules
+- Subtask `15.6 / 18`:
+  - assert stable high-level counts such as normalized entry count and generated
+    file count when still valid
+- User manual modifications needed:
+  - test file should be created by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - adjust existing tests to avoid duplication or fragility
+
+### Task `16 / 18` - Adjust Existing Tests
+
+- Task summary:
+  - keep unit tests focused and move repeated setup into shared fixtures where
+    useful
+- Expected files:
+  - `tests/conftest.py`
+  - existing `tests/test_*` files only when needed
+- Subtask `16.1 / 18`:
+  - identify duplicated canonical path and helper setup
+- Subtask `16.2 / 18`:
+  - move shared setup to fixtures without changing test meaning
+- Subtask `16.3 / 18`:
+  - keep semantic-policy unit tests separate from generator tests
+- Subtask `16.4 / 18`:
+  - keep integration tests focused on real canonical pipeline behavior
+- User manual modifications needed:
+  - test files should be edited by the user unless explicit code-edit approval is
+    given
+- Next step:
+  - run final verification
+
+### Task `17 / 18` - Run Final Verification
+
+- Task summary:
+  - prove issue `#16` coverage passes locally and under the CI command from issue
+    `#25`
+- Commands:
+  - `uv run pytest -n auto tests/test_generation_pipeline_structural.py tests/test_generation_pipeline_parse_smoke.py tests/test_generation_pipeline_normalization_integration.py tests/test_generation_pipeline_reference_regressions.py tests/test_generation_pipeline_semantic_integration.py tests/test_generation_pipeline_wrapper_handoff.py tests/test_generation_pipeline_domain_generation.py tests/test_generation_pipeline_e2e.py -v`
+  - `uv run pytest -n auto tests`
+  - `uv run python -m cvn_codegen.domain_model_generator` if canonical generated
+    output must be refreshed or verified
+- Subtask `17.1 / 18`:
+  - run targeted issue `#16` tests
+- Subtask `17.2 / 18`:
+  - run full repository test suite
+- Subtask `17.3 / 18`:
+  - run canonical domain generator verification when needed
+- Subtask `17.4 / 18`:
+  - record exact command output and failures
+- User manual modifications needed:
+  - none unless verification exposes required code or test fixes
+- Next step:
+  - update closure documentation
+
+### Task `18 / 18` - Update Closure Documentation
+
+- Task summary:
+  - close issue `#16` with implementation details, verification results,
+    limitations, and issue `#17` handoff
+- Files involved:
+  - `docs/roadmap/issues/issue-16-generation-pipeline-tests.md`
+  - `docs/context/current_status.md`
+  - `docs/roadmap/cvn_generation_roadmap.md`
+  - `docs/pipeline/known_limitations.md` only if a new limitation is found
+  - `PROJECT_GUIDE.md` only if human-facing orientation changes
+- Subtask `18.1 / 18`:
+  - record implementation performed
+- Subtask `18.2 / 18`:
+  - record verification commands and exact results
+- Subtask `18.3 / 18`:
+  - record findings and limitations
+- Subtask `18.4 / 18`:
+  - update issue status when implementation is verified
+- Subtask `18.5 / 18`:
+  - update roadmap and current status if issue state changes
+- Subtask `18.6 / 18`:
+  - leave explicit handoff checklist for issue `#17`
+- User manual modifications needed:
+  - none expected for documentation updates when explicitly requested
+- Next step:
+  - start issue `#17` only after issue `#16` is implemented and verified
+
+## Representative Regression Cases Required
+
+The test suite must include explicit coverage for these documented cases:
+
+- `000.010.000.020` / `Nombre` as plain text and enum-ineligible
+- `CVN_SEX_A` as compact direct table and strict-enum eligible from dynamic
+  evidence
+- `CVN_ENTITY_TYPE` as compact direct table and strict-enum ineligible due to
+  delegate/open evidence
+- `CVN_KNOW_A` as subtype-backed reference family
+- `ENTITY@Entity.xsd` as side-package registry reference
+- `THESAURUS@thesaurus.xsd` as side-package thesaurus or vocabulary reference
+- `UNESCO_CODES` as hierarchical thematic reference
+- `CVN_AGENCY_C` as unresolved manual-only reference
+- `CVN_INTERVENTION_A` and `CVN_PRUEBA` as under-traced tables
+- `FlexibleDatesType`, `OfficialIdType`, `EntityTypeType`, and `EntityNameType`
+  as wrapper handoff cases
+
 ## Minimum Coverage Goals
 
 1. structural parsing smoke tests for generated bindings
 2. normalization tests using real XML inputs
 3. regression tests for `choice` and recursion-related cases where relevant
-4. tests for semantic-class-driven mapping decisions, including enum-vs-open
-   treatment where relevant
-5. end-to-end generation tests for importable domain outputs
+4. semantic-class-driven mapping tests, including enum-vs-open behavior
+5. generator tests proving distinct domain shapes per semantic class
+6. end-to-end generation tests for importable domain outputs
+7. determinism tests for generated domain files
 
 ## Known Inputs From Earlier Issues
 
 - issue `#12` already added runner smoke tests
-- known XML/XSD mismatches must be asserted as documented behavior rather than
-  treated as surprising failures
-<<<<<<< Updated upstream
-=======
 - issue `#13` already preserves the validated normalization baseline:
   - total normalized codes: `1457`
   - manual-only codes: `27`
@@ -106,79 +555,141 @@ generator failures can be separated from semantic-policy failures.
   - ambiguous auxiliary resolution
   - missing subtype support
   - under-traced reference table
-
-## Representative Regression Cases Required
-
-The corrected test suite should include explicit coverage for documented cases
-such as:
-
-- `CVN_SEX_A` as compact direct table
-- `CVN_KNOW_A` as subtype-backed reference family
-- `ENTITY@Entity.xsd` as side-package registry reference
-- `THESAURUS@thesaurus.xsd` as side-package thesaurus reference
-- `UNESCO_CODES` as hierarchical thematic reference
-- `CVN_AGENCY_C` as unresolved manual-only reference
-- `CVN_INTERVENTION_A` and `CVN_PRUEBA` as under-traced tables
-
-Additional policy-level expectations from issue `#14` are:
-
-- `000.010.000.020` / `Nombre` remains plain text and enum-ineligible
-- `CVN_SEX_A` remains strict-enum eligible when table evidence is closed and
-  stable
-- `CVN_ENTITY_TYPE` remains strict-enum ineligible because delegate/open behavior
-  prevents closed strict-enum generation
-- side-package, hierarchical, subtype-backed, unresolved, and under-traced cases
-  remain strict-enum ineligible by default
+- issue `#14` provides semantic policy and validation inventory
+- issue `#15` provides domain generator and generated domain output
+- known XML/XSD mismatches must be asserted as documented behavior rather than
+  treated as surprising failures
 
 ## CI Impact
 
 - issue `#25` already provides pull-request execution of all tests under
   `tests/`
-- new auxiliary-generation, normalization-resolution, semantic-policy, and
-  generator tests should therefore remain under `tests/` so CI picks them up
-  automatically without workflow changes
->>>>>>> Stashed changes
+- new structural, normalization, semantic-policy, generator, wrapper, and
+  end-to-end tests must remain under `tests/` so CI picks them up automatically
+  without workflow changes
 
 ## Adjustments Made During Implementation
 
-- No implementation has been performed yet.
-- Pre-implementation planning is now aligned with the semantic-policy contract
-  agreed in issue `#14`.
-- The future test scope now separates semantic-policy verification from domain
-  generator verification.
+- Pre-implementation planning is aligned with the semantic-policy contract from
+  issue `#14`, the domain generator contract from issue `#15`, and the wrapper
+  handoff from hotfix `#8`.
+- The test scope separates semantic-policy verification from domain-generator
+  verification so failures can be attributed to the correct layer.
+- The accepted execution protocol and detailed 18-task implementation plan have
+  been recorded before test implementation begins.
+- Existing runner smoke tests and new structural generation tests both regenerate
+  `src/generated/*`; full-suite multicore execution exposed a race between those
+  tests. A test-only file lock now serializes xsdata generation tests while
+  preserving `pytest -n auto` for the rest of the suite.
+- `CVN_SEX_A` remains a compact enum-like table with eligible enum evidence, but
+  its current serialization pattern is `UNKNOWN_PRESENT_BUT_RESOLVED` rather than
+  `FILTER_VALUE`; tests assert the implemented normalized contract.
+- Domain generation result entries may repeat when one normalized code appears in
+  multiple generation units, so generator tests assert unique normalized codes
+  separately from per-unit entry occurrences.
 
 ## Implementation Performed
 
-- None yet. Issue `#16` remains pending until issue `#14` and issue `#15`
-  provide implementation artifacts to test.
+- Shared canonical pipeline fixtures were added in `tests/conftest.py` for:
+  - repository root and canonical source package paths
+  - XML and XSD path lookup
+  - auxiliary source bundle construction
+  - XSD-enriched canonical normalization result construction
+  - temporary domain-generation output directories
+- A test-only xsdata generation lock was added in
+  `tests/xsdata_generation_lock.py` and used by both:
+  - `tests/test_xsdata_runner_smoke.py`
+  - `tests/test_generation_pipeline_structural.py`
+- New issue `#16` pipeline tests were added under `tests/`:
+  - `tests/test_generation_pipeline_structural.py`
+  - `tests/test_generation_pipeline_parse_smoke.py`
+  - `tests/test_generation_pipeline_normalization_integration.py`
+  - `tests/test_generation_pipeline_reference_regressions.py`
+  - `tests/test_generation_pipeline_semantic_integration.py`
+  - `tests/test_generation_pipeline_wrapper_handoff.py`
+  - `tests/test_generation_pipeline_domain_generation.py`
+  - `tests/test_generation_pipeline_e2e.py`
+  - `tests/test_generation_pipeline_source_coverage.py`
+- The implemented coverage validates:
+  - manual, tree, auxiliary catalog, semantic policy, and domain-generation
+    source coverage from canonical inputs to code-level artifacts
+  - core and auxiliary structural generation targets
+  - real XML parse smoke behavior, including documented `CVNTreeModel.xml`
+    mismatch behavior
+  - canonical normalization baseline and enriched auxiliary-reference resolution
+  - representative auxiliary reference classifications
+  - semantic policy decisions before generator behavior
+  - override precedence, naming, trace preservation, and wrapper handoff behavior
+  - generator domain-shape mapping, importability, rendered output determinism,
+    and ASCII output
+  - end-to-end generation from canonical XML/XSD inputs to importable temporary
+    domain output
 
 ## Verification
 
-- No code verification has been run for issue `#16`.
-- Future verification must include semantic-policy tests, generator tests, and
-  end-to-end tests under `tests/` so CI from issue `#25` runs them.
+- Targeted issue `#16` verification passed with:
+  - `uv run pytest -n auto tests/test_generation_pipeline_structural.py tests/test_generation_pipeline_parse_smoke.py tests/test_generation_pipeline_normalization_integration.py tests/test_generation_pipeline_reference_regressions.py tests/test_generation_pipeline_semantic_integration.py tests/test_generation_pipeline_wrapper_handoff.py tests/test_generation_pipeline_domain_generation.py tests/test_generation_pipeline_e2e.py -v`
+  - result: `61 passed in 146.76s (0:02:26)`
+- Full repository verification initially exposed an xdist race between xsdata
+  generation tests. After adding the test-only generation lock, the affected
+  smoke and structural tests passed with:
+  - `uv run pytest -n auto tests/test_xsdata_runner_smoke.py tests/test_generation_pipeline_structural.py -v`
+  - result: `17 passed in 141.50s (0:02:21)`
+- Final full repository verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `289 passed in 280.75s (0:04:40)`
+- After adding the explicit source-coverage audit test, focused verification
+  passed with:
+  - `uv run pytest -n auto tests/test_generation_pipeline_source_coverage.py -v`
+  - result: `5 passed in 90.15s (0:01:30)`
+- Final full repository verification after the source-coverage audit passed with:
+  - `uv run pytest -n auto tests`
+  - result: `294 passed in 277.77s (0:04:37)`
 
 ## Findings
 
-- Semantic-policy behavior needs dedicated unit coverage before generated-model
-  assertions, otherwise failures may be misattributed to the generator.
-- Representative cases from issue `#14` provide the minimum regression inventory
-  for controlled-reference behavior.
+- Existing unit tests cover many semantic-policy and generator internals, but
+  issue `#16` must add real-pipeline integration and end-to-end regression
+  coverage.
+- Semantic-policy behavior must remain tested before generator-output behavior so
+  failures are not misattributed.
+- Generated-domain importability and determinism are first-class pipeline
+  requirements after issue `#15`.
+- Tests that execute structural regeneration must be serialized across xdist
+  workers because they clean and rewrite shared `src/generated/*` directories.
+- The generator result distinguishes semantic-policy uniqueness from per-output
+  generation-unit occurrences; tests should assert both concepts separately.
+- End-to-end pipeline testing can safely render generated domain output to a
+  temporary package for importability checks without modifying the committed
+  canonical generated domain output.
+- Explicit source-coverage auditing confirms all `SpecificationManual.xml` items,
+  all unique `CVNTreeModel.xml` codes, all normalized codes, loaded reference
+  tables, subtype items, entity registry items, thesaurus items, and generated
+  core `AuxTable.xsd` enums are represented in code-level artifacts.
 
 ## Known Limitations
 
-- The final semantic-policy test commands and fixtures cannot be finalized until
-  issue `#14` implementation creates concrete modules and public functions.
-- Generator-output tests cannot be finalized until issue `#15` defines concrete
-  Python artifact shapes.
+- `CVNTreeModel.xml` still has a documented XML/XSD mismatch.
+- `Subtype_Spa.xml` still lacks a strict per-table bridge such as `CVN_KNOW_A`
+  to subtype records.
+- `CVN_AGENCY_C` remains unresolved from the source package alone.
+- `CVN_INTERVENTION_A` and `CVN_PRUEBA` remain technically present but
+  under-traced.
+- Wrapper-aware field attachment requires normalization runs that provide
+  `CVN.xsd` and `Common.xsd`; canonical generation provides those inputs.
 
 ## Impact On Future Issues
 
 - Issue `#17` must document how to run semantic-policy tests separately from
-  structural, normalization, generator, and end-to-end tests.
+  structural, normalization, generator, wrapper, and end-to-end tests.
+- Issue `#17` must document `SemanticPolicyBundle` as the semantic source of
+  truth for domain generation.
 - CI workflow from issue `#25` does not need changes if new tests remain under
   `tests/`.
+- Issue `#17` should document the canonical full-suite command as the main
+  workflow verification entry point and mention that xsdata-regeneration tests
+  are serialized internally under xdist.
 
 ## Status
 
-- Status: pending
+- Status: completed

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,0 +1,5 @@
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-16-generation-pipeline-tests.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 16. Primero unicamente debes de crear el plan de ejecución
+
+
+
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-16-generation-pipeline-tests.md

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import pytest
+
+from cvn_codegen.auxiliary_sources.bundle import build_auxiliary_source_bundle
+from cvn_codegen.normalization import build_normalization_result
+
+
+@pytest.fixture(scope="session")
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="session")
+def canonical_package_dir(repo_root: Path) -> Path:
+    return repo_root / "docs" / "CvnXML_v1.4.3_2.1_17012025"
+
+
+@pytest.fixture(scope="session")
+def canonical_xml_dir(canonical_package_dir: Path) -> Path:
+    return canonical_package_dir / "XML"
+
+
+@pytest.fixture(scope="session")
+def canonical_xsd_dir(canonical_package_dir: Path) -> Path:
+    return canonical_package_dir / "XSD"
+
+
+@pytest.fixture(scope="session")
+def canonical_paths(canonical_xml_dir: Path, canonical_xsd_dir: Path) -> dict[str, Path]:
+    return {
+        "specification_manual": canonical_xml_dir / "SpecificationManual.xml",
+        "tree_model": canonical_xml_dir / "CVNTreeModel.xml",
+        "reference_tables": canonical_xml_dir / "ReferenceTables.xml",
+        "subtypes": canonical_xml_dir / "Subtype_Spa.xml",
+        "entity": canonical_xml_dir / "Entity.xml",
+        "thesaurus": canonical_xml_dir / "Thesaurus.xml",
+        "cvn_xsd": canonical_xsd_dir / "CVN.xsd",
+        "common_xsd": canonical_xsd_dir / "Common.xsd",
+    }
+
+
+@pytest.fixture(scope="session")
+def canonical_auxiliary_bundle(canonical_paths: dict[str, Path]):
+    return build_auxiliary_source_bundle(
+        reference_tables_path=canonical_paths["reference_tables"],
+        subtypes_path=canonical_paths["subtypes"],
+        entity_path=canonical_paths["entity"],
+        thesaurus_path=canonical_paths["thesaurus"],
+    )
+
+
+@pytest.fixture(scope="session")
+def canonical_normalization_result(canonical_paths: dict[str, Path]):
+    return build_normalization_result(
+        specification_manual_path=canonical_paths["specification_manual"],
+        tree_model_path=canonical_paths["tree_model"],
+        reference_tables_path=canonical_paths["reference_tables"],
+        subtypes_path=canonical_paths["subtypes"],
+        entity_path=canonical_paths["entity"],
+        thesaurus_path=canonical_paths["thesaurus"],
+        cvn_xsd_path=canonical_paths["cvn_xsd"],
+        common_xsd_path=canonical_paths["common_xsd"],
+    )
+
+
+@pytest.fixture
+def domain_generation_output_dir(tmp_path: Path) -> Path:
+    return tmp_path / "generated_domain"

--- a/tests/test_generation_pipeline_domain_generation.py
+++ b/tests/test_generation_pipeline_domain_generation.py
@@ -1,0 +1,230 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+from cvn_codegen.domain_model_generator import (
+    build_domain_generation_result,
+    build_semantic_policy_index,
+    get_python_type_for_controlled_reference,
+    group_entries_by_cvn_item_code,
+    render_domain_generation_result,
+)
+from cvn_codegen.normalization_types import NormalizationResult
+from cvn_codegen.semantic_policy import (
+    DomainShapeKind,
+    EnumEligibility,
+    build_default_semantic_policy_bundle,
+)
+def build_canonical_generation_result(normalization_result: NormalizationResult):
+    bundle = build_default_semantic_policy_bundle()
+    policy_index = build_semantic_policy_index(normalization_result, bundle)
+    grouped_entries = group_entries_by_cvn_item_code(normalization_result.by_code)
+    return build_domain_generation_result(
+        policy_index=policy_index,
+        grouped_entries=grouped_entries,
+    )
+
+def clear_models_generated_imports() -> dict[str, ModuleType]:
+    saved_modules = {
+        module_name: module
+        for module_name, module in sys.modules.items()
+        if module_name == "models.cvn.generated"
+        or module_name.startswith("models.cvn.generated.")
+    }
+    for module_name in tuple(saved_modules):
+        sys.modules.pop(module_name, None)
+    importlib.invalidate_caches()
+    return saved_modules
+def restore_models_generated_imports(saved_modules: dict[str, ModuleType]) -> None:
+    for module_name in tuple(sys.modules):
+        if module_name == "models.cvn.generated" or module_name.startswith(
+            "models.cvn.generated."
+        ):
+            sys.modules.pop(module_name, None)
+    sys.modules.update(saved_modules)
+    importlib.invalidate_caches()
+
+def write_rendered_files_to_temp_package(
+    rendered_files: dict[str, str],
+    output_dir: Path,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for relative_path, content in rendered_files.items():
+        (output_dir / relative_path).write_text(content, encoding="utf-8")
+
+def collect_file_bytes(output_dir: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(output_dir).as_posix(): path.read_bytes()
+        for path in sorted(output_dir.glob("*.py"))
+    }
+
+def test_generator_pipeline_builds_policy_index_for_all_normalized_entries(
+    canonical_normalization_result: NormalizationResult,
+):
+    bundle = build_default_semantic_policy_bundle()
+    policy_index = build_semantic_policy_index(canonical_normalization_result, bundle)
+    assert tuple(policy_index) == tuple(sorted(canonical_normalization_result.by_code))
+    assert len(policy_index) == 1457
+def test_generator_pipeline_builds_domain_generation_units(
+    canonical_normalization_result: NormalizationResult,
+):
+    result = build_canonical_generation_result(canonical_normalization_result)
+    assert result.units
+    assert result.normalized_entries
+    assert result.semantic_policies
+    assert len({entry.code for entry in result.normalized_entries}) == 1457
+    assert len(result.semantic_policies) == 1457
+    assert any(unit.module_name == "manual_only" for unit in result.units)
+    assert any(unit.module_name.startswith("cvn_item_") for unit in result.units)
+    assert set(policy.code for policy in result.semantic_policies) == set(
+    canonical_normalization_result.by_code
+    )
+
+def test_generator_pipeline_emits_enum_spec_only_for_eligible_strict_enum(
+    canonical_normalization_result: NormalizationResult,
+):
+    result = build_canonical_generation_result(canonical_normalization_result)
+    enum_sources = {enum.source_reference for enum in result.enums}
+    assert "CVN_SEX_A" in enum_sources
+    assert "CVN_ENTITY_TYPE" not in enum_sources
+    assert "CVN_KNOW_A" not in enum_sources
+    assert "UNESCO_CODES" not in enum_sources
+def test_generator_pipeline_maps_non_enum_controlled_reference_components(
+    canonical_normalization_result: NormalizationResult,
+):
+    bundle = build_default_semantic_policy_bundle()
+    policy_index = build_semantic_policy_index(canonical_normalization_result, bundle)
+    expected_types_by_reference = {
+        "CVN_KNOW_A": "SubtypeBackedValue",
+        "ENTITY@Entity.xsd": "RegistryReference",
+        "THESAURUS@thesaurus.xsd": "VocabularyReference",
+        "UNESCO_CODES": "HierarchicalCodeReference",
+        "CVN_AGENCY_C": "UnresolvedReference",
+    }
+    for raw_reference, expected_type in expected_types_by_reference.items():
+        matching_policies = []
+        for code, policy in policy_index.items():
+            entry = canonical_normalization_result.by_code[code]
+            if entry.manual is None:
+                continue
+            if entry.manual.manual_reference_table != raw_reference:
+                continue
+            matching_policies.append(policy)
+        assert matching_policies
+        assert get_python_type_for_controlled_reference(matching_policies[0]) == expected_type
+def test_generator_pipeline_preserves_cvn_trace_in_field_specs(
+    canonical_normalization_result: NormalizationResult,
+):
+    result = build_canonical_generation_result(canonical_normalization_result)
+    field_specs = [
+        field
+        for unit in result.units
+        for field in unit.fields
+    ]
+    assert field_specs
+    assert all(field.trace["code"] == field.code for field in field_specs)
+    assert all("domain_shape_kind" in field.trace for field in field_specs)
+    assert all("enum_eligibility" in field.trace for field in field_specs)
+def test_generator_pipeline_domain_shapes_match_semantic_policy(
+    canonical_normalization_result: NormalizationResult,
+):
+    bundle = build_default_semantic_policy_bundle()
+    policy_index = build_semantic_policy_index(canonical_normalization_result, bundle)
+    sex_policy = policy_index["000.010.000.030"]
+    assert sex_policy.domain_shape_kind == DomainShapeKind.STRICT_ENUM_CANDIDATE
+    assert sex_policy.enum_eligibility == EnumEligibility.ELIGIBLE
+
+
+def test_generator_pipeline_writes_importable_generated_package(
+    canonical_normalization_result: NormalizationResult,
+    domain_generation_output_dir: Path,
+):
+    result = build_canonical_generation_result(canonical_normalization_result)
+    rendered_files = render_domain_generation_result(result)
+    write_rendered_files_to_temp_package(rendered_files, domain_generation_output_dir)
+    generated_root = domain_generation_output_dir.parent
+    saved_modules = clear_models_generated_imports()
+    sys.path.insert(0, str(generated_root))
+    try:
+        generated_package = importlib.import_module("generated_domain")
+        enums_module = importlib.import_module("generated_domain.enums")
+        manual_only_module = importlib.import_module("generated_domain.manual_only")
+        assert generated_package is not None
+        assert enums_module is not None
+        assert manual_only_module is not None
+    finally:
+        sys.path.remove(str(generated_root))
+        restore_models_generated_imports(saved_modules)
+def test_generator_pipeline_imports_representative_cvn_item_module(
+    canonical_normalization_result: NormalizationResult,
+    domain_generation_output_dir: Path,
+):
+    result = build_canonical_generation_result(canonical_normalization_result)
+    rendered_files = render_domain_generation_result(result)
+    write_rendered_files_to_temp_package(rendered_files, domain_generation_output_dir)
+    generated_root = domain_generation_output_dir.parent
+    representative_module = next(
+        path.stem
+        for path in sorted(domain_generation_output_dir.glob("cvn_item_*.py"))
+    )
+    saved_modules = clear_models_generated_imports()
+    sys.path.insert(0, str(generated_root))
+    try:
+        imported_module = importlib.import_module(
+            f"generated_domain.{representative_module}"
+        )
+        assert imported_module is not None
+    finally:
+        sys.path.remove(str(generated_root))
+        restore_models_generated_imports(saved_modules)
+def test_generator_pipeline_field_trace_metadata_contains_required_keys(
+    canonical_normalization_result: NormalizationResult,
+):
+    result = build_canonical_generation_result(canonical_normalization_result)
+    field = next(
+        field
+        for unit in result.units
+        for field in unit.fields
+        if field.code == "000.010.000.030"
+    )
+    assert field.trace["code"] == "000.010.000.030"
+    assert "xml_paths" in field.trace
+    assert "domain_shape_kind" in field.trace
+    assert "enum_eligibility" in field.trace
+
+def test_generator_pipeline_rendered_output_is_deterministic(
+    canonical_normalization_result: NormalizationResult,
+):
+    result_a = build_canonical_generation_result(canonical_normalization_result)
+    result_b = build_canonical_generation_result(canonical_normalization_result)
+    rendered_a = render_domain_generation_result(result_a)
+    rendered_b = render_domain_generation_result(result_b)
+    assert rendered_a.keys() == rendered_b.keys()
+    assert rendered_a == rendered_b
+
+def test_generator_pipeline_written_output_is_deterministic(
+    canonical_normalization_result: NormalizationResult,
+    tmp_path: Path,
+):
+    result = build_canonical_generation_result(canonical_normalization_result)
+    rendered_files = render_domain_generation_result(result)
+    output_a = tmp_path / "generated_a"
+    output_b = tmp_path / "generated_b"
+    write_rendered_files_to_temp_package(rendered_files, output_a)
+    write_rendered_files_to_temp_package(rendered_files, output_b)
+    assert collect_file_bytes(output_a) == collect_file_bytes(output_b)
+
+
+def test_generator_pipeline_rendered_output_is_ascii_only(
+    canonical_normalization_result: NormalizationResult,
+):
+    result = build_canonical_generation_result(canonical_normalization_result)
+    rendered_files = render_domain_generation_result(result)
+    non_ascii_files = [
+        relative_path
+        for relative_path, content in rendered_files.items()
+        if not content.isascii()
+    ]
+    assert non_ascii_files == []

--- a/tests/test_generation_pipeline_e2e.py
+++ b/tests/test_generation_pipeline_e2e.py
@@ -1,0 +1,82 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from cvn_codegen.domain_model_generator import (
+    build_domain_generation_result,
+    build_semantic_policy_index,
+    group_entries_by_cvn_item_code,
+    render_domain_generation_result,
+)
+from cvn_codegen.normalization import build_normalization_result
+from cvn_codegen.semantic_policy import build_default_semantic_policy_bundle
+def clear_generated_domain_imports(package_name: str) -> dict[str, ModuleType]:
+    saved_modules = {
+        module_name: module
+        for module_name, module in sys.modules.items()
+        if module_name == package_name or module_name.startswith(f"{package_name}.")
+    }
+    for module_name in tuple(saved_modules):
+        sys.modules.pop(module_name, None)
+    importlib.invalidate_caches()
+    return saved_modules
+def restore_generated_domain_imports(
+    package_name: str,
+    saved_modules: dict[str, ModuleType],
+) -> None:
+    for module_name in tuple(sys.modules):
+        if module_name == package_name or module_name.startswith(f"{package_name}."):
+            sys.modules.pop(module_name, None)
+    sys.modules.update(saved_modules)
+    importlib.invalidate_caches()
+def write_temp_generated_package(rendered_files: dict[str, str], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for relative_path, content in rendered_files.items():
+        (output_dir / relative_path).write_text(content, encoding="utf-8")
+def test_generation_pipeline_e2e_from_canonical_sources_to_importable_domain_package(
+    canonical_paths: dict[str, Path],
+    tmp_path: Path,
+):
+    normalization_result = build_normalization_result(
+        specification_manual_path=canonical_paths["specification_manual"],
+        tree_model_path=canonical_paths["tree_model"],
+        reference_tables_path=canonical_paths["reference_tables"],
+        subtypes_path=canonical_paths["subtypes"],
+        entity_path=canonical_paths["entity"],
+        thesaurus_path=canonical_paths["thesaurus"],
+        cvn_xsd_path=canonical_paths["cvn_xsd"],
+        common_xsd_path=canonical_paths["common_xsd"],
+    )
+    bundle = build_default_semantic_policy_bundle()
+    policy_index = build_semantic_policy_index(normalization_result, bundle)
+    grouped_entries = group_entries_by_cvn_item_code(normalization_result.by_code)
+    generation_result = build_domain_generation_result(
+        policy_index=policy_index,
+        grouped_entries=grouped_entries,
+    )
+    rendered_files = render_domain_generation_result(generation_result)
+    output_dir = tmp_path / "generated_domain"
+    write_temp_generated_package(rendered_files, output_dir)
+    saved_modules = clear_generated_domain_imports("generated_domain")
+    sys.path.insert(0, str(tmp_path))
+    try:
+        generated_package = importlib.import_module("generated_domain")
+        enums_module = importlib.import_module("generated_domain.enums")
+        manual_only_module = importlib.import_module("generated_domain.manual_only")
+        representative_module_name = next(
+            path.stem for path in sorted(output_dir.glob("cvn_item_*.py"))
+        )
+        representative_module = importlib.import_module(
+            f"generated_domain.{representative_module_name}"
+        )
+        assert generated_package is not None
+        assert enums_module is not None
+        assert manual_only_module is not None
+        assert representative_module is not None
+        assert len(normalization_result.by_code) == 1457
+        assert len(policy_index) == 1457
+        assert len(generation_result.semantic_policies) == 1457
+        assert len(rendered_files) == 105
+    finally:
+        sys.path.remove(str(tmp_path))
+        restore_generated_domain_imports("generated_domain", saved_modules)

--- a/tests/test_generation_pipeline_normalization_integration.py
+++ b/tests/test_generation_pipeline_normalization_integration.py
@@ -1,0 +1,86 @@
+from cvn_codegen.normalization_types import (
+    NormalizationMismatchKind,
+    NormalizationResult,
+    ReferenceResolutionStatus,
+    ReferenceSourceFamily,
+)
+def test_pipeline_normalization_preserves_documented_baseline_counts(
+    canonical_normalization_result: NormalizationResult,
+):
+    result = canonical_normalization_result
+    overlap_count = (
+        len(result.by_code)
+        - len(result.manual_only_codes)
+        - len(result.tree_only_codes)
+    )
+    assert len(result.by_code) == 1457
+    assert len(result.manual_only_codes) == 27
+    assert len(result.tree_only_codes) == 1
+    assert overlap_count == 1429
+def test_pipeline_normalization_reports_documented_mismatch_categories(
+    canonical_normalization_result: NormalizationResult,
+):
+    mismatches = canonical_normalization_result.mismatches
+    mismatch_kinds = {mismatch.kind for mismatch in mismatches}
+    mismatch_codes = {mismatch.code for mismatch in mismatches}
+    assert NormalizationMismatchKind.MANUAL_ONLY_CODE in mismatch_kinds
+    assert NormalizationMismatchKind.TREE_ONLY_CODE in mismatch_kinds
+    assert NormalizationMismatchKind.UNEXPECTED_TREE_ELEMENT in mismatch_kinds
+    assert NormalizationMismatchKind.UNRESOLVED_MANUAL_REFERENCE in mismatch_kinds
+    assert NormalizationMismatchKind.UNDER_TRACED_REFERENCE_TABLE in mismatch_kinds
+    assert "030.010.000.250" in canonical_normalization_result.tree_only_codes
+    assert "060.030.070.220" in mismatch_codes
+    assert "060.030.070.230" in mismatch_codes
+    assert "CVN_INTERVENTION_A" in mismatch_codes
+    assert "CVN_PRUEBA" in mismatch_codes
+def test_pipeline_normalization_attaches_auxiliary_reference_resolution(
+    canonical_normalization_result: NormalizationResult,
+):
+    sex_entry = canonical_normalization_result.by_code["000.010.000.030"]
+    assert sex_entry.reference_resolution is not None
+    assert sex_entry.reference_resolution.status == ReferenceResolutionStatus.RESOLVED
+    assert sex_entry.reference_resolution.resolved_name == "CVN_SEX_A"
+    assert sex_entry.reference_resolution.source_family == ReferenceSourceFamily.REFERENCE_TABLE
+    assert sex_entry.reference_resolution.reference_table_enum_evidence is not None
+def test_pipeline_normalization_attaches_side_package_reference_resolution(
+    canonical_normalization_result: NormalizationResult,
+):
+    entity_entries = [
+        entry
+        for entry in canonical_normalization_result.by_code.values()
+        if entry.manual is not None
+        and entry.manual.manual_reference_table == "ENTITY@Entity.xsd"
+    ]
+    thesaurus_entries = [
+        entry
+        for entry in canonical_normalization_result.by_code.values()
+        if entry.manual is not None
+        and entry.manual.manual_reference_table == "THESAURUS@thesaurus.xsd"
+    ]
+    assert entity_entries
+    assert thesaurus_entries
+    entity_resolution = entity_entries[0].reference_resolution
+    thesaurus_resolution = thesaurus_entries[0].reference_resolution
+    assert entity_resolution is not None
+    assert thesaurus_resolution is not None
+    assert entity_resolution.source_family == ReferenceSourceFamily.SIDE_PACKAGE_REGISTRY
+    assert thesaurus_resolution.source_family == ReferenceSourceFamily.SIDE_PACKAGE_THESAURUS
+def test_pipeline_normalization_attaches_structural_type_evidence(
+    canonical_normalization_result: NormalizationResult,
+):
+    entries_with_structural_evidence = [
+        entry
+        for entry in canonical_normalization_result.by_code.values()
+        if entry.structural_type_evidence
+    ]
+    terminal_wrapper_names = {
+        evidence.terminal_wrapper_type_name
+        for entry in entries_with_structural_evidence
+        for evidence in entry.structural_type_evidence
+        if evidence.terminal_wrapper_type_name is not None
+    }
+    assert entries_with_structural_evidence
+    assert "FlexibleDatesType" in terminal_wrapper_names
+    assert "OfficialIdType" in terminal_wrapper_names
+    assert "EntityTypeType" in terminal_wrapper_names
+    assert "EntityNameType" in terminal_wrapper_names

--- a/tests/test_generation_pipeline_parse_smoke.py
+++ b/tests/test_generation_pipeline_parse_smoke.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from typing import Any
+import pytest
+from xsdata_pydantic.bindings import XmlParser
+from generated.entity import Entity
+from generated.reference_tables import ReferenceTables
+from generated.specification_manual import SpecificationManual
+from generated.subtypes import Cvnsubtype
+from generated.thesaurus import Thesaurus
+from generated.tree_model import CvntreeModel
+def parse_xml(path: Path, model_type: type[Any]) -> Any:
+    parser = XmlParser()
+    return parser.from_path(path, model_type)
+def test_parse_specification_manual_canonical_xml(canonical_paths: dict[str, Path]):
+    result = parse_xml(
+        canonical_paths["specification_manual"],
+        SpecificationManual,
+    )
+    assert isinstance(result, SpecificationManual)
+@pytest.mark.parametrize(
+    ("path_key", "model_type"),
+    [
+        ("reference_tables", ReferenceTables),
+        ("subtypes", Cvnsubtype),
+        ("entity", Entity),
+        ("thesaurus", Thesaurus),
+    ],
+)
+def test_parse_auxiliary_canonical_xml(
+    canonical_paths: dict[str, Path],
+    path_key: str,
+    model_type: type[Any],
+):
+    result = parse_xml(canonical_paths[path_key], model_type)
+    assert isinstance(result, model_type)
+def test_parse_tree_model_canonical_xml_reports_documented_xsd_mismatch(
+    canonical_paths: dict[str, Path],
+):
+    with pytest.raises(Exception) as exc_info:
+        parse_xml(canonical_paths["tree_model"], CvntreeModel)
+    message = str(exc_info.value)
+    assert "Type" in message

--- a/tests/test_generation_pipeline_reference_regressions.py
+++ b/tests/test_generation_pipeline_reference_regressions.py
@@ -1,0 +1,115 @@
+import pytest
+from cvn_codegen.auxiliary_sources.bundle import AuxiliarySourceBundle
+from cvn_codegen.auxiliary_sources.reference_resolution import resolve_manual_reference
+from cvn_codegen.normalization_types import (
+    ReferenceResolutionStatus,
+    ReferenceSourceFamily,
+    SemanticReferenceKind,
+    SerializationPattern,
+)
+def test_reference_regression_cvn_sex_a_is_direct_enum_like_table(
+    canonical_auxiliary_bundle: AuxiliarySourceBundle,
+):
+    resolution = resolve_manual_reference("CVN_SEX_A", canonical_auxiliary_bundle)
+    assert resolution.status == ReferenceResolutionStatus.RESOLVED
+    assert resolution.source_family == ReferenceSourceFamily.REFERENCE_TABLE
+    assert resolution.source_artifact == "ReferenceTables.xml"
+    assert resolution.resolved_name == "CVN_SEX_A"
+    assert resolution.serialization_pattern == SerializationPattern.UNKNOWN_PRESENT_BUT_RESOLVED
+    assert resolution.semantic_kind == SemanticReferenceKind.COMPACT_ENUM_LIKE_TABLE
+    assert resolution.reference_table_enum_evidence is not None
+    assert resolution.reference_table_enum_evidence.table_name == "CVN_SEX_A"
+    assert resolution.reference_table_enum_evidence.item_count == 2
+    assert resolution.reference_table_enum_evidence.has_delegate is False
+    assert resolution.reference_table_enum_evidence.has_hierarchy is False
+def test_reference_regression_cvn_entity_type_has_delegate_open_world_signal(
+    canonical_auxiliary_bundle: AuxiliarySourceBundle,
+):
+    resolution = resolve_manual_reference("CVN_ENTITY_TYPE", canonical_auxiliary_bundle)
+    assert resolution.status == ReferenceResolutionStatus.RESOLVED
+    assert resolution.source_family == ReferenceSourceFamily.REFERENCE_TABLE
+    assert resolution.source_artifact == "ReferenceTables.xml"
+    assert resolution.resolved_name == "CVN_ENTITY_TYPE"
+    assert resolution.semantic_kind == SemanticReferenceKind.COMPACT_ENUM_LIKE_TABLE
+    assert resolution.reference_table_enum_evidence is not None
+    assert resolution.reference_table_enum_evidence.table_name == "CVN_ENTITY_TYPE"
+    assert resolution.reference_table_enum_evidence.has_delegate is True
+    assert "delegate_present" in resolution.reference_table_enum_evidence.open_world_signals
+def test_reference_regression_cvn_know_a_is_subtype_backed(
+    canonical_auxiliary_bundle: AuxiliarySourceBundle,
+):
+    resolution = resolve_manual_reference("CVN_KNOW_A", canonical_auxiliary_bundle)
+    assert resolution.status == ReferenceResolutionStatus.RESOLVED
+    assert resolution.source_family == ReferenceSourceFamily.SUBTYPE_BACKED_TABLE
+    assert resolution.source_artifact == "ReferenceTables.xml"
+    assert resolution.resolved_name == "CVN_KNOW_A"
+    assert resolution.serialization_pattern == SerializationPattern.SUBTYPE
+    assert resolution.semantic_kind == SemanticReferenceKind.SUBTYPE_BACKED_CONTROLLED_FAMILY
+    assert resolution.is_subtype_backed is True
+    assert resolution.subtype_metadata_present is True
+    assert resolution.reference_table_enum_evidence is not None
+    assert resolution.reference_table_enum_evidence.table_name == "CVN_KNOW_A"
+def test_reference_regression_entity_reference_is_side_package_registry(
+    canonical_auxiliary_bundle: AuxiliarySourceBundle,
+):
+    resolution = resolve_manual_reference("ENTITY@Entity.xsd", canonical_auxiliary_bundle)
+    assert resolution.status == ReferenceResolutionStatus.RESOLVED
+    assert resolution.source_family == ReferenceSourceFamily.SIDE_PACKAGE_REGISTRY
+    assert resolution.source_artifact == "Entity.xml"
+    assert resolution.resolved_name == "ENTITY@Entity.xsd"
+    assert resolution.serialization_pattern == SerializationPattern.SIDE_PACKAGE_REGISTRY
+    assert resolution.semantic_kind == SemanticReferenceKind.SIDE_PACKAGE_REGISTRY
+    assert resolution.reference_table_enum_evidence is None
+def test_reference_regression_thesaurus_reference_is_side_package_vocabulary(
+    canonical_auxiliary_bundle: AuxiliarySourceBundle,
+):
+    resolution = resolve_manual_reference(
+        "THESAURUS@thesaurus.xsd",
+        canonical_auxiliary_bundle,
+    )
+    assert resolution.status == ReferenceResolutionStatus.RESOLVED
+    assert resolution.source_family == ReferenceSourceFamily.SIDE_PACKAGE_THESAURUS
+    assert resolution.source_artifact == "Thesaurus.xml"
+    assert resolution.resolved_name == "THESAURUS@thesaurus.xsd"
+    assert resolution.serialization_pattern == SerializationPattern.SIDE_PACKAGE_THESAURUS
+    assert resolution.semantic_kind == SemanticReferenceKind.SIDE_PACKAGE_THESAURUS_OR_VOCABULARY
+    assert resolution.reference_table_enum_evidence is None
+def test_reference_regression_unesco_codes_is_hierarchical_thematic_reference(
+    canonical_auxiliary_bundle: AuxiliarySourceBundle,
+):
+    resolution = resolve_manual_reference("UNESCO_CODES", canonical_auxiliary_bundle)
+    assert resolution.status == ReferenceResolutionStatus.RESOLVED
+    assert resolution.source_family == ReferenceSourceFamily.REFERENCE_TABLE
+    assert resolution.source_artifact == "ReferenceTables.xml"
+    assert resolution.resolved_name == "UNESCO_CODES"
+    assert resolution.serialization_pattern == SerializationPattern.SUBJECT_DESCRIPTION
+    assert resolution.semantic_kind == SemanticReferenceKind.HIERARCHICAL_THEMATIC_CLASSIFICATION
+    assert resolution.reference_table_enum_evidence is not None
+    assert resolution.reference_table_enum_evidence.table_name == "UNESCO_CODES"
+    assert resolution.reference_table_enum_evidence.has_hierarchy is True
+def test_reference_regression_cvn_agency_c_is_unresolved_manual_only(
+    canonical_auxiliary_bundle: AuxiliarySourceBundle,
+):
+    resolution = resolve_manual_reference("CVN_AGENCY_C", canonical_auxiliary_bundle)
+    assert resolution.status == ReferenceResolutionStatus.UNRESOLVED
+    assert resolution.source_family == ReferenceSourceFamily.UNRESOLVED_MANUAL_ONLY
+    assert resolution.source_artifact is None
+    assert resolution.resolved_name == "CVN_AGENCY_C"
+    assert resolution.serialization_pattern == SerializationPattern.UNRESOLVED
+    assert resolution.semantic_kind == SemanticReferenceKind.UNRESOLVED_MANUAL_ONLY_REFERENCE
+    assert resolution.diagnostic_message is not None
+    assert resolution.reference_table_enum_evidence is None
+@pytest.mark.parametrize("raw_reference", ["CVN_INTERVENTION_A", "CVN_PRUEBA"])
+def test_reference_regression_under_traced_tables_are_explicit(
+    canonical_auxiliary_bundle: AuxiliarySourceBundle,
+    raw_reference: str,
+):
+    resolution = resolve_manual_reference(raw_reference, canonical_auxiliary_bundle)
+    assert resolution.status == ReferenceResolutionStatus.RESOLVED
+    assert resolution.source_family == ReferenceSourceFamily.REFERENCE_TABLE
+    assert resolution.source_artifact == "ReferenceTables.xml"
+    assert resolution.resolved_name == raw_reference
+    assert resolution.semantic_kind == SemanticReferenceKind.UNDER_TRACED_REFERENCE_TABLE
+    assert resolution.diagnostic_message is not None
+    assert resolution.reference_table_enum_evidence is not None
+    assert resolution.reference_table_enum_evidence.table_name == raw_reference

--- a/tests/test_generation_pipeline_semantic_integration.py
+++ b/tests/test_generation_pipeline_semantic_integration.py
@@ -1,0 +1,337 @@
+from cvn_codegen.normalization_types import (
+    NormalizationResult,
+    ReferenceResolutionStatus,
+    ManualCodeEntry, 
+    NormalizedCodeEntry,
+)
+from cvn_codegen.semantic_policy import (
+    DomainShapeKind,
+    EnumEligibility,
+    PolicyConfidence,
+    SemanticBaseKind,
+    SemanticFieldPolicy,
+    CardinalityKind,
+    DomainShapeKind,
+    EnumEligibility,
+    OverrideRule,
+    PolicyConfidence,
+    PresenceKind,
+    SemanticPolicyBundle,
+    build_default_semantic_policy_bundle,
+    build_semantic_field_policy,
+    build_default_semantic_policy_bundle,
+    select_applicable_override,
+    build_naming_policy,
+
+)
+
+from cvn_codegen.domain_model_generator import (
+    resolve_field_name_collisions,
+)
+
+def build_policy_for_code(
+    normalization_result: NormalizationResult,
+    code: str,
+) -> SemanticFieldPolicy:
+    bundle = build_default_semantic_policy_bundle()
+    return build_semantic_field_policy(
+        entry=normalization_result.by_code[code],
+        bundle=bundle,
+    )
+def find_policy_by_reference(
+    normalization_result: NormalizationResult,
+    raw_reference: str,
+) -> SemanticFieldPolicy:
+    bundle = build_default_semantic_policy_bundle()
+    for entry in normalization_result.by_code.values():
+        if entry.manual is None:
+            continue
+        if entry.manual.manual_reference_table != raw_reference:
+            continue
+        return build_semantic_field_policy(entry=entry, bundle=bundle)
+    raise AssertionError(f"Reference {raw_reference!r} not found in normalization result.")
+def test_semantic_pipeline_builds_deterministic_policy_for_real_entry(
+    canonical_normalization_result: NormalizationResult,
+):
+    policy_a = build_policy_for_code(canonical_normalization_result, "000.010.000.030")
+    policy_b = build_policy_for_code(canonical_normalization_result, "000.010.000.030")
+    assert policy_a == policy_b
+    assert policy_a.code == "000.010.000.030"
+    assert policy_a.decision_trace.code == "000.010.000.030"
+def test_semantic_pipeline_maps_plain_name_to_text_and_enum_ineligible(
+    canonical_normalization_result: NormalizationResult,
+):
+    policy = build_policy_for_code(canonical_normalization_result, "000.010.000.020")
+    assert policy.base_kind == SemanticBaseKind.TEXT
+    assert policy.domain_shape_kind == DomainShapeKind.PLAIN_VALUE
+    assert policy.enum_eligibility == EnumEligibility.INELIGIBLE
+    assert policy.naming_policy.normalized_field_name == "nombre"
+def test_semantic_pipeline_maps_cvn_sex_a_to_eligible_strict_enum_candidate(
+    canonical_normalization_result: NormalizationResult,
+):
+    policy = build_policy_for_code(canonical_normalization_result, "000.010.000.030")
+    assert policy.base_kind == SemanticBaseKind.CONTROLLED_REFERENCE
+    assert policy.domain_shape_kind == DomainShapeKind.STRICT_ENUM_CANDIDATE
+    assert policy.fallback_shape_kind == DomainShapeKind.OPEN_CODED_VALUE
+    assert policy.enum_eligibility == EnumEligibility.ELIGIBLE
+    assert policy.policy_confidence == PolicyConfidence.HIGH
+    assert "enum_evidence:strict_enum_eligible" in policy.decision_trace.applied_rules
+def test_semantic_pipeline_maps_cvn_entity_type_to_ineligible_strict_enum_candidate(
+    canonical_normalization_result: NormalizationResult,
+):
+    policy = find_policy_by_reference(
+        canonical_normalization_result,
+        "CVN_ENTITY_TYPE",
+    )
+    assert policy.base_kind == SemanticBaseKind.CONTROLLED_REFERENCE
+    assert policy.domain_shape_kind == DomainShapeKind.STRICT_ENUM_CANDIDATE
+    assert policy.fallback_shape_kind == DomainShapeKind.OPEN_CODED_VALUE
+    assert policy.enum_eligibility == EnumEligibility.INELIGIBLE
+    assert policy.policy_confidence == PolicyConfidence.HIGH
+    assert "enum_evidence:delegate_present" in policy.decision_trace.applied_rules
+def test_semantic_pipeline_maps_representative_reference_families(
+    canonical_normalization_result: NormalizationResult,
+):
+    expected_shapes = {
+        "CVN_KNOW_A": DomainShapeKind.SUBTYPE_BACKED_VALUE,
+        "ENTITY@Entity.xsd": DomainShapeKind.REGISTRY_REFERENCE,
+        "THESAURUS@thesaurus.xsd": DomainShapeKind.VOCABULARY_REFERENCE,
+        "UNESCO_CODES": DomainShapeKind.HIERARCHICAL_CODE_REFERENCE,
+        "CVN_AGENCY_C": DomainShapeKind.UNRESOLVED_REFERENCE,
+    }
+    for raw_reference, expected_shape in expected_shapes.items():
+        policy = find_policy_by_reference(canonical_normalization_result, raw_reference)
+        assert policy.base_kind == SemanticBaseKind.CONTROLLED_REFERENCE
+        assert policy.domain_shape_kind == expected_shape
+        assert policy.enum_eligibility == EnumEligibility.INELIGIBLE
+def test_semantic_pipeline_preserves_reference_trace_for_real_entry(
+    canonical_normalization_result: NormalizationResult,
+):
+    entry = canonical_normalization_result.by_code["000.010.000.030"]
+    policy = build_policy_for_code(canonical_normalization_result, "000.010.000.030")
+    assert entry.reference_resolution is not None
+    assert entry.reference_resolution.status == ReferenceResolutionStatus.RESOLVED
+    assert policy.xml_paths
+    assert policy.decision_trace.xml_paths == policy.xml_paths
+    assert policy.decision_trace.manual_reference_table == "CVN_SEX_A"
+    assert policy.decision_trace.reference_source_artifact == "ReferenceTables.xml"
+    assert (
+        policy.decision_trace.semantic_reference_kind
+        == entry.reference_resolution.semantic_kind
+    )
+    assert (
+        policy.decision_trace.serialization_pattern
+        == entry.reference_resolution.serialization_pattern
+    )
+
+def test_semantic_pipeline_override_prefers_code_and_xml_path(
+    canonical_normalization_result: NormalizationResult,
+):
+    entry = canonical_normalization_result.by_code["000.010.000.030"]
+    xml_path = entry.tree_paths[0].xml_path
+    selection = select_applicable_override(
+        entry,
+        (
+            OverrideRule(
+                rule_id="code_only",
+                target_code=entry.code,
+                enum_eligibility=EnumEligibility.INELIGIBLE,
+            ),
+            OverrideRule(
+                rule_id="code_and_xml_path",
+                target_code=entry.code,
+                target_xml_path=xml_path,
+                enum_eligibility=EnumEligibility.REVIEW_REQUIRED,
+            ),
+        ),
+    )
+    assert selection.selected_override is not None
+    assert selection.selected_override.rule_id == "code_and_xml_path"
+    assert selection.conflict_detected is False
+def test_semantic_pipeline_override_prefers_code_over_xml_path(
+    canonical_normalization_result: NormalizationResult,
+):
+    entry = canonical_normalization_result.by_code["000.010.000.030"]
+    xml_path = entry.tree_paths[0].xml_path
+    selection = select_applicable_override(
+        entry,
+        (
+            OverrideRule(
+                rule_id="xml_path_only",
+                target_xml_path=xml_path,
+                enum_eligibility=EnumEligibility.REVIEW_REQUIRED,
+            ),
+            OverrideRule(
+                rule_id="code_only",
+                target_code=entry.code,
+                enum_eligibility=EnumEligibility.INELIGIBLE,
+            ),
+        ),
+    )
+    assert selection.selected_override is not None
+    assert selection.selected_override.rule_id == "code_only"
+    assert selection.conflict_detected is False
+def test_semantic_pipeline_override_matches_semantic_kind_and_serialization_pattern(
+    canonical_normalization_result: NormalizationResult,
+):
+    entry = canonical_normalization_result.by_code["000.010.000.030"]
+    assert entry.reference_resolution is not None
+    selection = select_applicable_override(
+        entry,
+        (
+            OverrideRule(
+                rule_id="semantic_kind_match",
+                target_semantic_reference_kind=entry.reference_resolution.semantic_kind,
+                enum_eligibility=EnumEligibility.INELIGIBLE,
+            ),
+            OverrideRule(
+                rule_id="serialization_pattern_match",
+                target_serialization_pattern=entry.reference_resolution.serialization_pattern,
+                enum_eligibility=EnumEligibility.REVIEW_REQUIRED,
+            ),
+        ),
+    )
+    assert selection.conflict_detected is True
+    assert selection.matched_rule_ids == (
+        "semantic_kind_match",
+        "serialization_pattern_match",
+    )
+def test_semantic_pipeline_override_application_changes_only_policy_outputs(
+    canonical_normalization_result: NormalizationResult,
+):
+    default_bundle = build_default_semantic_policy_bundle()
+    bundle = SemanticPolicyBundle(
+        metadata=default_bundle.metadata,
+        base_type_policies_by_manual_type=default_bundle.base_type_policies_by_manual_type,
+        reference_kind_policies=default_bundle.reference_kind_policies,
+        serialization_pattern_refinements=default_bundle.serialization_pattern_refinements,
+        wrapper_policies_by_name=default_bundle.wrapper_policies_by_name,
+        overrides=(
+            OverrideRule(
+                rule_id="force_open_value",
+                target_code="000.010.000.030",
+                domain_shape_kind=DomainShapeKind.OPEN_CODED_VALUE,
+                enum_eligibility=EnumEligibility.REVIEW_REQUIRED,
+                presence_kind=PresenceKind.REQUIRED,
+                cardinality_kind=CardinalityKind.REPEATED,
+                normalized_name="sexo_forzado",
+            ),
+        ),
+        validation_cases=default_bundle.validation_cases,
+    )
+    entry = canonical_normalization_result.by_code["000.010.000.030"]
+    policy = build_semantic_field_policy(entry=entry, bundle=bundle)
+    assert policy.code == entry.code
+    assert policy.decision_trace.manual_reference_table == "CVN_SEX_A"
+    assert policy.domain_shape_kind == DomainShapeKind.OPEN_CODED_VALUE
+    assert policy.enum_eligibility == EnumEligibility.REVIEW_REQUIRED
+    assert policy.presence_kind == PresenceKind.REQUIRED
+    assert policy.cardinality_kind == CardinalityKind.REPEATED
+    assert policy.naming_policy.normalized_field_name == "sexo_forzado"
+    assert "Applied override rule 'force_open_value'." in policy.notes
+def test_semantic_pipeline_same_rank_override_conflict_requires_review(
+    canonical_normalization_result: NormalizationResult,
+):
+    default_bundle = build_default_semantic_policy_bundle()
+    bundle = SemanticPolicyBundle(
+        metadata=default_bundle.metadata,
+        base_type_policies_by_manual_type=default_bundle.base_type_policies_by_manual_type,
+        reference_kind_policies=default_bundle.reference_kind_policies,
+        serialization_pattern_refinements=default_bundle.serialization_pattern_refinements,
+        wrapper_policies_by_name=default_bundle.wrapper_policies_by_name,
+        overrides=(
+            OverrideRule(
+                rule_id="code_conflict_a",
+                target_code="000.010.000.030",
+                enum_eligibility=EnumEligibility.INELIGIBLE,
+            ),
+            OverrideRule(
+                rule_id="code_conflict_b",
+                target_code="000.010.000.030",
+                enum_eligibility=EnumEligibility.REVIEW_REQUIRED,
+            ),
+        ),
+        validation_cases=default_bundle.validation_cases,
+    )
+    entry = canonical_normalization_result.by_code["000.010.000.030"]
+    policy = build_semantic_field_policy(entry=entry, bundle=bundle)
+    assert policy.policy_confidence == PolicyConfidence.REQUIRES_REVIEW
+    assert any("Override conflict detected" in note for note in policy.notes)
+
+def test_semantic_pipeline_naming_normalizes_ascii_and_snake_case(
+    canonical_normalization_result: NormalizationResult,
+):
+    entry = canonical_normalization_result.by_code["000.010.000.020"]
+    policy = build_policy_for_code(canonical_normalization_result, entry.code)
+    assert policy.naming_policy.source_label == "Nombre"
+    assert policy.naming_policy.normalized_field_name == "nombre"
+    assert policy.naming_policy.normalized_class_name == "Nombre"
+def test_semantic_pipeline_naming_preserves_source_code_in_trace(
+    canonical_normalization_result: NormalizationResult,
+):
+    policy = build_policy_for_code(canonical_normalization_result, "000.010.000.020")
+    assert policy.code == "000.010.000.020"
+    assert policy.decision_trace.code == "000.010.000.020"
+
+def test_semantic_pipeline_naming_preserves_unesco_acronym():
+    entry = NormalizedCodeEntry(
+        code="999.999.999.999",
+        manual=ManualCodeEntry(
+            code="999.999.999.999",
+            manual_name="Código UNESCO",
+            manual_short_name=None,
+            manual_type="Alphanumeric",
+            manual_obligatory=False,
+            manual_multiplicity=False,
+            manual_reference_table=None,
+        ),
+        tree_paths=(),
+        source_files=("SpecificationManual.xml",),
+    )
+    policy = build_semantic_field_policy(
+        entry=entry,
+        bundle=build_default_semantic_policy_bundle(),
+    )
+    assert policy.naming_policy.normalized_class_name == "CodigoUNESCO"
+    assert policy.naming_policy.normalized_field_name == "codigo_unesco"
+
+def test_semantic_pipeline_naming_collision_fallback_is_deterministic():
+    entry_a = NormalizedCodeEntry(
+        code="001.001",
+        manual=ManualCodeEntry(
+            code="001.001",
+            manual_name="Título",
+            manual_short_name=None,
+            manual_type="Alphanumeric",
+            manual_obligatory=False,
+            manual_multiplicity=False,
+            manual_reference_table=None,
+        ),
+        tree_paths=(),
+        source_files=("SpecificationManual.xml",),
+    )
+    entry_b = NormalizedCodeEntry(
+        code="002.002",
+        manual=ManualCodeEntry(
+            code="002.002",
+            manual_name="Título",
+            manual_short_name=None,
+            manual_type="Alphanumeric",
+            manual_obligatory=False,
+            manual_multiplicity=False,
+            manual_reference_table=None,
+        ),
+        tree_paths=(),
+        source_files=("SpecificationManual.xml",),
+    )
+    bundle = build_default_semantic_policy_bundle()
+    policies = (
+        build_semantic_field_policy(entry=entry_b, bundle=bundle),
+        build_semantic_field_policy(entry=entry_a, bundle=bundle),
+    )
+    resolved = resolve_field_name_collisions(policies)
+    assert resolved == {
+        "001.001": "titulo_001_001",
+        "002.002": "titulo_002_002",
+    }
+    assert resolved == resolve_field_name_collisions(policies)

--- a/tests/test_generation_pipeline_source_coverage.py
+++ b/tests/test_generation_pipeline_source_coverage.py
@@ -1,0 +1,127 @@
+from enum import Enum
+from pathlib import Path
+
+from cvn_codegen.auxiliary_sources.entity_metadata import load_entity_xml
+from cvn_codegen.auxiliary_sources.reference_tables_metadata import (
+    load_reference_tables_xml,
+)
+from cvn_codegen.auxiliary_sources.subtypes_metadata import load_subtypes_xml
+from cvn_codegen.auxiliary_sources.thesaurus_metadata import load_thesaurus_xml
+from cvn_codegen.domain_model_generator import (
+    build_domain_generation_result,
+    build_semantic_policy_index,
+    group_entries_by_cvn_item_code,
+)
+from cvn_codegen.manual_metadata import extract_manual_entries, load_specification_manual
+from cvn_codegen.normalization_types import NormalizationResult
+from cvn_codegen.semantic_policy import build_default_semantic_policy_bundle
+from cvn_codegen.tree_metadata import load_and_extract_tree_entries
+from generated.cvn import aux_table
+
+
+def test_all_manual_items_are_represented_in_normalization_policy_and_domain(
+    canonical_paths: dict[str, Path],
+    canonical_normalization_result: NormalizationResult,
+):
+    specification_manual = load_specification_manual(
+        canonical_paths["specification_manual"]
+    )
+    manual_entries = extract_manual_entries(specification_manual)
+    bundle = build_default_semantic_policy_bundle()
+    policy_index = build_semantic_policy_index(canonical_normalization_result, bundle)
+    generation_result = build_domain_generation_result(
+        policy_index=policy_index,
+        grouped_entries=group_entries_by_cvn_item_code(
+            canonical_normalization_result.by_code
+        ),
+    )
+    generated_codes = {entry.code for entry in generation_result.normalized_entries}
+
+    assert len(specification_manual.manual.item) == 1456
+    assert len(manual_entries) == 1456
+    assert set(manual_entries) <= set(canonical_normalization_result.by_code)
+    assert set(manual_entries) <= set(policy_index)
+    assert set(manual_entries) <= generated_codes
+
+    for code, manual_entry in manual_entries.items():
+        normalized_entry = canonical_normalization_result.by_code[code]
+        assert normalized_entry.manual == manual_entry
+
+
+def test_all_tree_codes_are_represented_in_normalization_and_domain(
+    canonical_paths: dict[str, Path],
+    canonical_normalization_result: NormalizationResult,
+):
+    tree_entries = load_and_extract_tree_entries(canonical_paths["tree_model"])
+    tree_codes = {entry.code for entry in tree_entries}
+    bundle = build_default_semantic_policy_bundle()
+    policy_index = build_semantic_policy_index(canonical_normalization_result, bundle)
+    generation_result = build_domain_generation_result(
+        policy_index=policy_index,
+        grouped_entries=group_entries_by_cvn_item_code(
+            canonical_normalization_result.by_code
+        ),
+    )
+    generated_codes = {entry.code for entry in generation_result.normalized_entries}
+
+    assert len(tree_entries) == 5051
+    assert len(tree_codes) == 1430
+    assert tree_codes <= set(canonical_normalization_result.by_code)
+    assert tree_codes <= generated_codes
+
+
+def test_auxiliary_xml_sources_are_loaded_without_losing_catalog_items(
+    canonical_paths: dict[str, Path],
+    canonical_auxiliary_bundle,
+):
+    reference_tables = load_reference_tables_xml(canonical_paths["reference_tables"])
+    subtypes = load_subtypes_xml(canonical_paths["subtypes"])
+    entity = load_entity_xml(canonical_paths["entity"])
+    thesaurus = load_thesaurus_xml(canonical_paths["thesaurus"])
+
+    assert len(canonical_auxiliary_bundle.reference_tables_by_name) == len(
+        reference_tables.table
+    )
+    assert sum(
+        metadata.item_count
+        for metadata in canonical_auxiliary_bundle.reference_tables_by_name.values()
+    ) == sum(len(table.item) for table in reference_tables.table)
+    assert len(canonical_auxiliary_bundle.subtypes_by_source_code) == len(
+        subtypes.subtype.item
+    )
+    assert canonical_auxiliary_bundle.entity_catalog is not None
+    assert canonical_auxiliary_bundle.entity_catalog.item_count == len(entity.item)
+    assert canonical_auxiliary_bundle.thesaurus_catalog is not None
+    assert canonical_auxiliary_bundle.thesaurus_catalog.item_count == len(
+        thesaurus.item
+    )
+
+
+def test_normalized_codes_have_semantic_policy_and_domain_generation_coverage(
+    canonical_normalization_result: NormalizationResult,
+):
+    bundle = build_default_semantic_policy_bundle()
+    policy_index = build_semantic_policy_index(canonical_normalization_result, bundle)
+    generation_result = build_domain_generation_result(
+        policy_index=policy_index,
+        grouped_entries=group_entries_by_cvn_item_code(
+            canonical_normalization_result.by_code
+        ),
+    )
+    generated_codes = {entry.code for entry in generation_result.normalized_entries}
+
+    assert len(canonical_normalization_result.by_code) == 1457
+    assert set(canonical_normalization_result.by_code) == set(policy_index)
+    assert set(canonical_normalization_result.by_code) == generated_codes
+
+
+def test_core_aux_table_structural_enums_are_generated_and_importable():
+    enum_classes = tuple(
+        value
+        for value in vars(aux_table).values()
+        if isinstance(value, type) and issubclass(value, Enum) and value is not Enum
+    )
+
+    assert len(enum_classes) >= 30
+    assert aux_table.CvnGenderType.VALUE_000.value == "000"
+    assert aux_table.CvnGenderType.VALUE_010.value == "010"

--- a/tests/test_generation_pipeline_structural.py
+++ b/tests/test_generation_pipeline_structural.py
@@ -1,0 +1,56 @@
+import importlib
+
+import pytest
+
+from cvn_codegen.xsdata_runner import (
+    TARGET_TABLE,
+    XSDTargetSpec,
+)
+from xsdata_generation_lock import run_xsdata_generation_per_target_locked
+
+
+CORE_TARGETS = (
+    ("cvn", "generated.cvn"),
+    ("specification_manual", "generated.specification_manual"),
+    ("tree_model", "generated.tree_model"),
+)
+AUXILIARY_TARGETS = (
+    ("reference_tables", "generated.reference_tables"),
+    ("subtypes", "generated.subtypes"),
+    ("entity", "generated.entity"),
+    ("thesaurus", "generated.thesaurus"),
+)
+
+
+def assert_generated_target_is_importable(target: XSDTargetSpec, package_name: str) -> None:
+    run_xsdata_generation_per_target_locked(target)
+    assert target.output_dir.exists()
+    assert any(target.output_dir.glob("**/*.py"))
+    imported_module = importlib.import_module(package_name)
+    assert imported_module is not None
+
+
+@pytest.mark.parametrize(("target_name", "package_name"), CORE_TARGETS)
+def test_structural_generation_core_targets_are_importable(
+    target_name: str,
+    package_name: str,
+):
+    target = TARGET_TABLE[target_name]
+    assert_generated_target_is_importable(target, package_name)
+
+
+@pytest.mark.parametrize(("target_name", "package_name"), AUXILIARY_TARGETS)
+def test_structural_generation_auxiliary_targets_are_importable(
+    target_name: str,
+    package_name: str,
+):
+    target = TARGET_TABLE[target_name]
+    assert_generated_target_is_importable(target, package_name)
+
+
+def test_structural_generation_all_targets_are_covered_by_pipeline_tests():
+    tested_targets = {
+        target_name
+        for target_name, _package_name in CORE_TARGETS + AUXILIARY_TARGETS
+    }
+    assert tested_targets == set(TARGET_TABLE)

--- a/tests/test_generation_pipeline_wrapper_handoff.py
+++ b/tests/test_generation_pipeline_wrapper_handoff.py
@@ -1,0 +1,117 @@
+from cvn_codegen.domain_model_generator import resolve_python_type_for_policy
+from cvn_codegen.normalization_types import NormalizationResult
+from cvn_codegen.semantic_policy import (
+    StructuralLimitationFlag,
+    WrapperPolicyKind,
+    build_default_semantic_policy_bundle,
+    build_semantic_field_policy,
+)
+def find_policy_with_terminal_wrapper(
+    normalization_result: NormalizationResult,
+    wrapper_name: str,
+):
+    bundle = build_default_semantic_policy_bundle()
+    for entry in normalization_result.by_code.values():
+        terminal_wrapper_names = {
+            evidence.terminal_wrapper_type_name
+            for evidence in entry.structural_type_evidence
+            if evidence.terminal_wrapper_type_name is not None
+        }
+        if wrapper_name not in terminal_wrapper_names:
+            continue
+        return build_semantic_field_policy(entry=entry, bundle=bundle)
+    raise AssertionError(f"Terminal wrapper {wrapper_name!r} not found.")
+def find_entry_with_ancestor_wrapper(
+    normalization_result: NormalizationResult,
+    wrapper_name: str,
+):
+    for entry in normalization_result.by_code.values():
+        ancestor_wrapper_names = {
+            ancestor_name
+            for evidence in entry.structural_type_evidence
+            for ancestor_name in evidence.ancestor_wrapper_type_names
+        }
+        if wrapper_name in ancestor_wrapper_names:
+            return entry
+    raise AssertionError(f"Ancestor wrapper {wrapper_name!r} not found.")
+
+def find_entry_with_ancestor_only_wrapper(
+    normalization_result: NormalizationResult,
+    wrapper_name: str,
+):
+    for entry in normalization_result.by_code.values():
+        terminal_wrapper_names = {
+            evidence.terminal_wrapper_type_name
+            for evidence in entry.structural_type_evidence
+            if evidence.terminal_wrapper_type_name is not None
+        }
+        ancestor_wrapper_names = {
+            ancestor_name
+            for evidence in entry.structural_type_evidence
+            for ancestor_name in evidence.ancestor_wrapper_type_names
+        }
+        if wrapper_name in ancestor_wrapper_names and wrapper_name not in terminal_wrapper_names:
+            return entry
+    raise AssertionError(f"Ancestor-only wrapper {wrapper_name!r} not found.")
+
+
+def test_wrapper_handoff_flexible_dates_maps_to_value_component(
+    canonical_normalization_result: NormalizationResult,
+):
+    policy = find_policy_with_terminal_wrapper(
+        canonical_normalization_result,
+        "FlexibleDatesType",
+    )
+    assert policy.wrapper_type_names == ("FlexibleDatesType",)
+    assert policy.wrapper_policy_kinds == (WrapperPolicyKind.CHOICE_OBJECT_CANDIDATE,)
+    assert StructuralLimitationFlag.CHOICE_NOT_ENFORCED in policy.structural_limitation_flags
+    assert resolve_python_type_for_policy(policy) == "FlexibleDateValue"
+def test_wrapper_handoff_official_id_maps_to_value_component(
+    canonical_normalization_result: NormalizationResult,
+):
+    policy = find_policy_with_terminal_wrapper(
+        canonical_normalization_result,
+        "OfficialIdType",
+    )
+    assert policy.wrapper_type_names == ("OfficialIdType",)
+    assert policy.wrapper_policy_kinds == (WrapperPolicyKind.CHOICE_OBJECT_CANDIDATE,)
+    assert StructuralLimitationFlag.CHOICE_NOT_ENFORCED in policy.structural_limitation_flags
+    assert resolve_python_type_for_policy(policy) == "OfficialIdValue"
+def test_wrapper_handoff_entity_type_maps_to_value_component(
+    canonical_normalization_result: NormalizationResult,
+):
+    policy = find_policy_with_terminal_wrapper(
+        canonical_normalization_result,
+        "EntityTypeType",
+    )
+    assert policy.wrapper_type_names == ("EntityTypeType",)
+    assert policy.wrapper_policy_kinds == (WrapperPolicyKind.CHOICE_OBJECT_CANDIDATE,)
+    assert StructuralLimitationFlag.CHOICE_NOT_ENFORCED in policy.structural_limitation_flags
+    assert resolve_python_type_for_policy(policy) == "EntityTypeValue"
+def test_wrapper_handoff_entity_name_maps_to_value_component(
+    canonical_normalization_result: NormalizationResult,
+):
+    policy = find_policy_with_terminal_wrapper(
+        canonical_normalization_result,
+        "EntityNameType",
+    )
+    assert policy.wrapper_type_names == ("EntityNameType",)
+    assert policy.wrapper_policy_kinds == (WrapperPolicyKind.CHOICE_OBJECT_CANDIDATE,)
+    assert StructuralLimitationFlag.CHOICE_NOT_ENFORCED in policy.structural_limitation_flags
+    assert resolve_python_type_for_policy(policy) == "EntityNameValue"
+def test_wrapper_handoff_ancestor_wrapper_does_not_attach_terminal_policy(
+    canonical_normalization_result: NormalizationResult,
+):
+    entry = find_entry_with_ancestor_only_wrapper(
+    canonical_normalization_result,
+    "OfficialIdType",
+)
+    policy = build_semantic_field_policy(
+        entry=entry,
+        bundle=build_default_semantic_policy_bundle(),
+    )
+    assert policy.wrapper_type_names == ()
+    assert policy.wrapper_policy_kinds == ()
+    assert policy.decision_trace.terminal_wrapper_type_names == ()
+    assert "OfficialIdType" in policy.decision_trace.ancestor_wrapper_type_names
+    assert resolve_python_type_for_policy(policy) != "OfficialIdValue"

--- a/tests/test_xsdata_runner_smoke.py
+++ b/tests/test_xsdata_runner_smoke.py
@@ -3,10 +3,10 @@ import importlib
 from cvn_codegen.xsdata_runner import (
     TARGET_TABLE as target_table,
     XSDTargetSpec,
-    run_xsdata_generation_per_target,
 )
 import pytest as pt
 
+from xsdata_generation_lock import run_xsdata_generation_per_target_locked
 
 
 def test_smoke_generate_specification_manual_creates_python_files():
@@ -14,7 +14,7 @@ def test_smoke_generate_specification_manual_creates_python_files():
     target : XSDTargetSpec = target_table["specification_manual"]
 
     # Act
-    run_xsdata_generation_per_target(target)
+    run_xsdata_generation_per_target_locked(target)
     
     # Assert
     assert target.output_dir.exists(), f"Expected output directory '{target.output_dir}' to exist after generation."
@@ -28,7 +28,7 @@ def test_smoke_generate_specification_manual_creates_python_files():
 
 def test_smoke_generate_auxiliary_target_creates_python_files(target_name: str):
     target: XSDTargetSpec = target_table[target_name]
-    run_xsdata_generation_per_target(target)
+    run_xsdata_generation_per_target_locked(target)
     assert target.output_dir.exists(), (
         f"Expected output directory '{target.output_dir}' to exist after generation."
     )
@@ -49,6 +49,6 @@ def test_smoke_import_generated_auxiliary_package_after_generation(
     target_name: str, package_name: str
 ):
     target: XSDTargetSpec = target_table[target_name]
-    run_xsdata_generation_per_target(target)
+    run_xsdata_generation_per_target_locked(target)
     imported_module = importlib.import_module(package_name)
     assert imported_module is not None

--- a/tests/xsdata_generation_lock.py
+++ b/tests/xsdata_generation_lock.py
@@ -1,0 +1,26 @@
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+import fcntl
+
+from cvn_codegen.xsdata_runner import XSDTargetSpec, run_xsdata_generation_per_target
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LOCK_PATH = REPO_ROOT / ".pytest_cache" / "xsdata_generation.lock"
+
+
+@contextmanager
+def locked_xsdata_generation() -> Iterator[None]:
+    LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with LOCK_PATH.open("w", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def run_xsdata_generation_per_target_locked(target: XSDTargetSpec) -> None:
+    with locked_xsdata_generation():
+        run_xsdata_generation_per_target(target)


### PR DESCRIPTION
## Summary
- Add issue #16 pipeline test coverage for structural generation, XML parse smoke, normalization, auxiliary reference resolution, semantic policy, wrapper handoff, domain generation, source coverage, and E2E importability.
- Add shared canonical test fixtures and an xsdata generation file lock to prevent xdist races while regenerating `src/generated/*`.
- Update issue #16, current status, and roadmap docs; mark issue #16 completed and issue #17 next.
## Verification
- `uv run pytest -n auto tests/test_generation_pipeline_source_coverage.py -v`
- `uv run pytest -n auto tests`
- Final result: `294 passed in 277.77s (0:04:37)`

closes #16 