### PR TITLE
Define canonical Open CVN JSON format

### DIFF
--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -80,7 +80,12 @@ files in order:
   issue `#44` agnostic conceptual diagrams
 - `docs/pipeline/json_schema_generation.md`: issue `#45` JSON Schema generation
   approach and regeneration notes
+- `docs/pipeline/open_cvn_json_format.md`: issue `#46` canonical Open CVN JSON
+  document format
+- `docs/pipeline/open_cvn_json_mapping.md`: issue `#46` mapping notes from the
+  conceptual inventory and schema annotations to runtime JSON
 - `schemas/open_cvn.schema.json`: generated issue `#45` JSON Schema artifact
+- `examples/open_cvn/`: representative issue `#46` Open CVN JSON examples
 - `docs/pipeline/known_limitations.md`: structural limitations, source-package
   inconsistencies, and follow-up implications
 - `docs/adr/`: architecture decision records
@@ -109,6 +114,8 @@ files in order:
   authoritative record of issue `#25`
 - `docs/roadmap/issues/issue-43-agnostic-conceptual-model-extraction-layer.md`:
   authoritative record of issue `#43`
+- `docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md`:
+  authoritative record of issue `#46`
 - `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`: maintenance
   record for the runner logging convention update
 - `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`: maintenance

--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -2,7 +2,7 @@
 
 ## Status Date
 
-- Last updated: 2026-07-04
+- Last updated: 2026-07-05
 
 ## Completed Or Stabilized Work
 
@@ -505,6 +505,53 @@
   `uv run pytest -n auto tests`
 - Full-suite verification result:
   `326 passed in 780.28s (0:13:00)`
+- Additional manual schema checks passed for:
+  - canonical regeneration without artifact drift
+  - JSON parsing
+  - root metadata
+  - `$defs` presence and internal `$ref` resolution
+  - `core.curriculum` and `identity.person` definitions
+  - `CVN_SEX_A` closed enum behavior
+  - `CVN_ENTITY_TYPE` open reference behavior
+  - temporary CLI output byte-for-byte equality
+  - historical issue `#45` provisional root example shape
+- issue `#46` later replaced the issue `#45` provisional root with the canonical
+  Open CVN JSON root: `schema_version`, `metadata`, `curriculum`, and
+  `extensions`
+- External `jsonschema` meta-schema validation was not executed because the
+  `jsonschema` package is not installed in the project environment
+
+### Issue `#46`
+
+- the canonical Open CVN JSON format is documented in:
+  - `docs/pipeline/open_cvn_json_format.md`
+- mapping notes from conceptual inventory and schema annotations to runtime JSON
+  are documented in:
+  - `docs/pipeline/open_cvn_json_mapping.md`
+- representative JSON examples now exist under:
+  - `examples/open_cvn/`
+- the canonical JSON root shape is now:
+  - `schema_version`
+  - `metadata`
+  - `curriculum`
+  - `extensions`
+- semantic policy metadata now lives under `metadata.policy` instead of root-level
+  `policy_name` and `policy_version`
+- curriculum content is grouped by conceptual domain area, with `identity` as a
+  single object and repeated sections represented as arrays of entries
+- controlled references use a common runtime shape while keeping enum-ineligible,
+  unresolved, registry, thesaurus, hierarchical, and subtype-backed references
+  open
+- the JSON Schema generator now emits the issue `#46` canonical root shape while
+  preserving conceptual `$defs`
+- targeted issue `#46` verification passed with:
+  `uv run pytest -n auto tests/test_json_schema_generator_unit.py tests/test_generation_pipeline_json_schema.py tests/test_open_cvn_json_format_examples.py -v`
+- targeted verification result:
+  `21 passed in 159.97s (0:02:39)`
+- full-suite verification passed with:
+  `uv run pytest -n auto tests`
+- full-suite verification result:
+  `334 passed in 890.21s (0:14:50)`
 
 ## Current Technical Baseline
 
@@ -517,11 +564,10 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#45` closure: issue `#46`, define canonical Open CVN
-  JSON shape
-- Issue `#46` should use the issue `#45` generated schema as a traceable
-  prototype, not as a final constraint that prevents refining the canonical JSON
-  document layout
+- Next work item after issue `#46` closure: issue `#47`, define the unified parser
+  and validator contract
+- Issue `#47` should consume the issue `#46` canonical Open CVN JSON format and
+  distinguish parser contracts from concrete XML/PDF/JSON import implementations
 
 ## Blocking Or Relevant Limitations
 

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -55,6 +55,11 @@ Agents should also read `AGENTS.md` before this file.
 - `docs/pipeline/json_schema_generation.md`: issue `#45` JSON Schema generation
   approach and regeneration notes
 - `schemas/open_cvn.schema.json`: generated issue `#45` JSON Schema artifact
+- `docs/pipeline/open_cvn_json_format.md`: issue `#46` canonical Open CVN JSON
+  document format
+- `docs/pipeline/open_cvn_json_mapping.md`: issue `#46` mapping notes from the
+  conceptual inventory and schema annotations to runtime JSON
+- `examples/open_cvn/`: representative issue `#46` Open CVN JSON examples
 - `docs/pipeline/known_limitations.md`: structural limitations, detected
   discrepancies, and follow-up implications
 - `docs/adr/`: architecture decision records
@@ -84,6 +89,8 @@ Agents should also read `AGENTS.md` before this file.
   implementation record for issue `#43`
 - `docs/roadmap/issues/issue-45-generate-json-schema-from-domain-models.md`:
   implementation record for issue `#45`
+- `docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md`:
+  implementation record for issue `#46`
 - `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`: maintenance
   record for the runner logging convention update
 - `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`: maintenance

--- a/docs/pipeline/json_schema_generation.md
+++ b/docs/pipeline/json_schema_generation.md
@@ -57,13 +57,15 @@ The schema metadata includes:
 - policy name and policy version from the semantic policy bundle
 - issue and inventory trace through `x-open-cvn-*` extensions
 
-The root object is provisional until issue `#46` defines the canonical Open CVN
-JSON shape. The current root includes:
+The root object follows the canonical Open CVN JSON shape defined by issue `#46`.
+The current root includes:
 
 - `schema_version`
-- `policy_name`
-- `policy_version`
+- `metadata`
 - `curriculum`
+- `extensions`
+
+Semantic policy metadata is represented under `metadata.policy`.
 
 Definitions are emitted under `$defs` for conceptual entities, vocabularies, and
 shared wrapper value shapes.
@@ -112,16 +114,36 @@ Targeted verification for issue `#45` is:
 uv run pytest -n auto tests/test_json_schema_generator_unit.py tests/test_generation_pipeline_json_schema.py -v
 ```
 
+Targeted verification for the issue `#46` canonical JSON root and examples is:
+
+```bash
+uv run pytest -n auto tests/test_json_schema_generator_unit.py tests/test_generation_pipeline_json_schema.py tests/test_open_cvn_json_format_examples.py -v
+```
+
 Default repository verification remains:
 
 ```bash
 uv run pytest -n auto tests
 ```
 
+Additional manual checks used during issue `#45` completion:
+
+- regenerate `schemas/open_cvn.schema.json` and confirm no artifact drift
+- parse the generated artifact with Python `json`
+- verify `$schema`, `$id`, `title`, and policy metadata
+- verify `$defs` is present and representative definitions exist
+- verify every local `$ref` resolves to a `$defs` entry
+- verify `CVN_SEX_A` is closed as an enum-backed vocabulary
+- verify `CVN_ENTITY_TYPE` remains open because it is enum-ineligible
+- generate to a temporary path and compare bytes with the canonical artifact
+- verify the canonical issue `#46` root object shape
+
+External meta-schema validation can be added later with the `jsonschema` package,
+but that package is not part of the current project dependencies.
+
 ## Limitations
 
-- The issue `#45` root shape is provisional and intentionally defers final Open
-  CVN JSON layout decisions to issue `#46`.
+- The issue `#46` root shape is now canonical for Open CVN JSON validation.
 - JSON Schema cannot express every CVN semantic invariant, external registry
   requirement, or curated conceptual relationship.
 - Conceptual relationships remain conservative because issue `#43` does not infer

--- a/docs/pipeline/known_limitations.md
+++ b/docs/pipeline/known_limitations.md
@@ -88,21 +88,23 @@ do not need to rediscover them.
 
 ## JSON Schema Generation Limitations
 
-### Issue `#45` JSON Schema Root Is Provisional
+### Issue `#45` Provisional Root Was Replaced By Issue `#46`
 
 - Confirmed behavior:
   - issue `#45` generates `schemas/open_cvn.schema.json` from the issue `#43`
     conceptual inventory
-  - the artifact declares JSON Schema Draft 2020-12 and preserves trace through
-    `x-open-cvn-*` extensions
+  - issue `#46` defines the canonical Open CVN JSON root shape and aligns the
+    generated schema root to `schema_version`, `metadata`, `curriculum`, and
+    `extensions`
   - direct Pydantic JSON Schema output is not used as the canonical root because
     it exposes generated Python class shapes
 - Impact:
-  - the schema is useful for validation research and traceable review
-  - the final Open CVN JSON document layout remains intentionally deferred
+  - the schema is now aligned with the canonical issue `#46` JSON document layout
+  - future parser work can consume the schema without inheriting the older
+    root-level `policy_name` and `policy_version` prototype
 - Expected follow-up:
-  - issue `#46` should define the canonical JSON shape and decide whether to keep,
-    refine, or replace the provisional root layout from issue `#45`
+  - issue `#47` should define parser contracts over the canonical issue `#46`
+    JSON shape
 
 ### JSON Schema Cannot Express Every CVN Semantic Rule
 

--- a/docs/pipeline/open_cvn_json_format.md
+++ b/docs/pipeline/open_cvn_json_format.md
@@ -1,0 +1,274 @@
+# Open CVN JSON Format
+
+## Purpose
+
+This document defines the canonical Open CVN JSON document shape for issue `#46`.
+It is the runtime JSON format that later parser and validation work should accept
+for Open CVN files.
+
+The format is designed for text files, local persistence, and NoSQL-like storage.
+It must be easier to consume than CVN XML while preserving traceability to the
+official CVN source package.
+
+## Source Of Truth
+
+The canonical JSON shape is based on the issue `#43` conceptual inventory and the
+issue `#45` JSON Schema prototype.
+
+The conceptual inventory remains the semantic source of truth for:
+
+- curriculum domain areas
+- conceptual entities
+- conceptual attributes
+- controlled vocabularies
+- CVN code and XML path trace
+- semantic-policy evidence
+
+The generated JSON Schema remains the validation artifact. It must reflect this
+format before issue `#49` relies on it for Open CVN JSON import.
+
+## Root Object
+
+Every Open CVN JSON document is an object with these canonical root fields:
+
+```json
+{
+  "schema_version": "0.1.0",
+  "metadata": {},
+  "curriculum": {},
+  "extensions": {}
+}
+```
+
+Required root fields:
+
+- `schema_version`
+- `metadata`
+- `curriculum`
+
+Optional root fields:
+
+- `extensions`
+
+`schema_version` is the Open CVN format version. It is not the JSON Schema draft
+version.
+
+## Metadata
+
+`metadata` describes the Open CVN document, not the curriculum content itself.
+
+Canonical metadata fields:
+
+- `language`: BCP 47 language tag for the primary human-language content, such as
+  `es`
+- `source`: optional object describing the input family used to create the file
+- `created_at`: optional ISO 8601 timestamp for document creation
+- `updated_at`: optional ISO 8601 timestamp for document update
+- `generator`: optional object describing the tool that produced the file
+- `policy`: object describing semantic policy evidence used to produce or validate
+  the file
+
+Canonical `metadata.policy` fields:
+
+- `name`
+- `version`
+
+Generated timestamps are optional. Generators must not create nondeterministic
+timestamps in reproducible artifacts unless the timestamp is part of user data or
+explicit runtime output.
+
+## Curriculum
+
+`curriculum` groups content by conceptual domain area rather than by CVN XML
+structure or generated Python modules.
+
+Canonical section names are:
+
+- `identity`
+- `education`
+- `research`
+- `professional_experience`
+- `achievements`
+- `other`
+
+`identity` is a single object because it describes the curriculum owner.
+
+Other sections are arrays of entries because they commonly contain repeated
+curriculum records.
+
+Minimal empty curriculum shape:
+
+```json
+{
+  "identity": {},
+  "education": [],
+  "research": [],
+  "professional_experience": [],
+  "achievements": [],
+  "other": []
+}
+```
+
+Sections may be omitted when empty, except when a validation profile requires
+explicit empty sections.
+
+## Entries
+
+Repeated sections contain entry objects.
+
+Canonical entry fields:
+
+- `id`: optional stable local identifier for the entry
+- `type`: stable conceptual entry type
+- `data`: object containing the entry fields
+- `trace`: optional CVN trace metadata
+- `extensions`: optional extension object
+
+Example:
+
+```json
+{
+  "id": "education-001",
+  "type": "education.degree",
+  "data": {
+    "degree_name": "Doctorado"
+  },
+  "trace": {
+    "cvn_codes": ["020.010.010.000"]
+  }
+}
+```
+
+Array order preserves source document order unless a producer explicitly documents
+a different ordering policy. Consumers must not treat array position as identity.
+
+## Fields
+
+Field names must be stable semantic names in `snake_case`.
+
+Field names must not be generated Python module names, generated class names, raw
+CVN XML element names, or one-off `cvn_item_*` identifiers.
+
+Primitive values use JSON primitives:
+
+- text values use strings
+- date-like values use strings unless represented by `FlexibleDateValue`
+- duration-like values use strings
+- decimal values use numbers
+- boolean values use booleans
+
+Wrapper values use objects that match the shared wrapper definitions from the
+domain layer:
+
+- `FlexibleDateValue`
+- `OfficialIdValue`
+- `EntityTypeValue`
+- `EntityNameValue`
+
+Omitted fields mean no value is present. Explicit `null` means the value slot is
+known but empty, unavailable, or intentionally blank. Producers should prefer
+omission for unknown data unless a source distinction must be preserved.
+
+## Controlled References
+
+Controlled references use a common object shape.
+
+Canonical fields:
+
+- `code`: source code when known
+- `label`: human-readable label when known
+- `source`: source vocabulary, table, registry, or thesaurus reference
+- `raw_value`: original value when normalization could not fully resolve it
+- `uri`: optional external identifier
+- `reference_status`: optional status for unresolved or under-traced cases
+
+Closed enum behavior is allowed only when semantic policy marks the vocabulary as
+enum-eligible. For example, `CVN_SEX_A` may be validated as a closed enum.
+
+Open references must remain open even when the source package contains many known
+values. This applies to enum-ineligible reference tables, registries, thesauri,
+hierarchical code lists, subtype-backed tables without a strict bridge, unresolved
+references, and under-traced references.
+
+`CVN_ENTITY_TYPE` remains open because canonical evidence marks it enum-ineligible.
+`CVN_AGENCY_C` remains unresolved unless stronger source evidence is introduced.
+
+## Trace Metadata
+
+`trace` preserves source CVN evidence for auditing, import diagnostics, and future
+round-trip work.
+
+Canonical trace fields:
+
+- `cvn_codes`
+- `xml_paths`
+- `source_files`
+- `source_artifacts`
+- `manual_reference_table`
+- `semantic_reference_kind`
+- `serialization_pattern`
+- `domain_shape_kind`
+- `confidence`
+
+Trace may appear at entry level, field level, or both.
+
+Entry-level trace describes the conceptual record or CVN group. Field-level trace
+describes a specific attribute when more precise evidence is useful.
+
+Trace is metadata. It must not change the semantic value of the curriculum data.
+
+## Extensions
+
+`extensions` is the canonical location for tool-specific or project-specific
+metadata.
+
+Extension keys should use either:
+
+- reverse-DNS names, such as `org.example.importer`
+- `x-*` names for local experiments
+
+Consumers should ignore unknown extensions unless configured for strict mode.
+
+Extensions must not override canonical fields. If a value belongs to the canonical
+format, it should be promoted to a documented canonical field in a future minor or
+major version instead of being hidden in `extensions`.
+
+## Versioning
+
+The initial canonical format version is `0.1.0`.
+
+Compatibility rules:
+
+- patch version changes clarify documentation, examples, or non-breaking schema
+  details
+- minor version changes may add optional fields or new optional sections
+- major version changes may remove fields, rename fields, or change validation
+  semantics incompatibly
+
+Parser expectations:
+
+- parsers should accept compatible versions with the same major version
+- parsers may warn for newer minor versions
+- parsers should reject unknown major versions unless explicitly configured to try
+  best-effort parsing
+
+## Relationship To JSON Schema
+
+The JSON Schema artifact at `schemas/open_cvn.schema.json` validates the canonical
+shape. It also preserves source evidence through non-validating `x-open-cvn-*`
+schema annotations.
+
+Runtime Open CVN JSON uses ordinary data fields such as `metadata`, `trace`, and
+`extensions`. Schema annotations such as `x-open-cvn-code` are not required to
+appear in every JSON data file, but they inform validators and generators.
+
+## Limitations
+
+- JSON Schema cannot enforce every semantic rule, registry lookup, or source
+  package consistency check.
+- Conceptual relationships remain conservative until curated domain rules are
+  added.
+- Some CVN references remain unresolved or under-traced from the current source
+  package alone.
+- The format preserves trace to CVN sources but does not require XML-centric
+  document structure.

--- a/docs/pipeline/open_cvn_json_mapping.md
+++ b/docs/pipeline/open_cvn_json_mapping.md
@@ -1,0 +1,127 @@
+# Open CVN JSON Mapping Notes
+
+## Purpose
+
+This document records how issue `#43` conceptual evidence and issue `#45` JSON
+Schema evidence map into the issue `#46` canonical Open CVN JSON format.
+
+## Conceptual Inventory To JSON
+
+`ConceptualModelInventory` maps to one Open CVN JSON document.
+
+- `inventory.policy_name` maps to `metadata.policy.name`
+- `inventory.policy_version` maps to `metadata.policy.version`
+- `ConceptualDomainArea.area_id` maps to a `curriculum` section
+- `ConceptualEntity` maps to either `curriculum.identity` or a repeated section
+  entry
+- `ConceptualAttribute` maps to a field under `data` or, for identity, under
+  `curriculum.identity`
+- `ConceptualVocabulary` maps to controlled-reference validation and source
+  metadata
+- `ConceptualTrace` maps to runtime `trace` metadata where source evidence is
+  useful for auditing
+
+## Entity Mapping
+
+`core.curriculum` represents the conceptual root and maps to the runtime
+`curriculum` object.
+
+`identity.person` maps to `curriculum.identity` because the person identity is a
+single owner record rather than a repeated entry.
+
+Other conceptual entities map to entries in their domain-area array:
+
+```text
+education.* -> curriculum.education[]
+research.* -> curriculum.research[]
+professional_experience.* -> curriculum.professional_experience[]
+achievements.* -> curriculum.achievements[]
+other.* -> curriculum.other[]
+```
+
+The entry `type` should be a stable semantic identifier. It may be derived from
+the conceptual entity identifier, but it must not expose generated module names.
+
+## Attribute Mapping
+
+`ConceptualAttribute.name` maps to a JSON field name. It should be stable,
+semantic, and `snake_case`.
+
+`ConceptualValueKind` maps as follows:
+
+| Conceptual value kind | JSON shape |
+| --- | --- |
+| `text` | string |
+| `date_like` | string or `FlexibleDateValue` when wrapper evidence exists |
+| `duration_like` | string |
+| `boolean` | boolean |
+| `decimal_number` | number |
+| `controlled_reference` | controlled-reference object |
+| `value_object` | shared wrapper object |
+| `unknown` | permissive value plus limitation trace |
+
+`ConceptualCardinalityKind.REPEATED` maps to arrays.
+
+`ConceptualPresenceKind.REQUIRED` should be enforced by schema and parser
+profiles when the requirement is reliable. Optional and unknown presence allow the
+field to be omitted.
+
+## Controlled Reference Mapping
+
+`ConceptualVocabularyKind.ENUMERATION` with eligible enum evidence may validate
+`code` as a closed enum.
+
+Other vocabulary kinds remain open:
+
+- `code_list`
+- `registry`
+- `thesaurus`
+- `hierarchical_code_list`
+- `subtype_backed_code_list`
+- `unresolved_reference`
+- `under_traced_reference`
+
+Canonical controlled-reference fields are:
+
+- `code`
+- `label`
+- `source`
+- `raw_value`
+- `uri`
+- `reference_status`
+
+Representative mappings:
+
+- `CVN_SEX_A` maps to an enum-backed controlled reference
+- `CVN_ENTITY_TYPE` maps to an open controlled reference
+- `UNESCO_CODES` maps to a hierarchical code-list controlled reference
+- `THESAURUS@thesaurus.xsd` maps to a thesaurus controlled reference
+- `ENTITY@Entity.xsd` maps to a registry controlled reference
+- `CVN_AGENCY_C` maps to an unresolved controlled reference
+
+## Trace Mapping
+
+Issue `#45` schema extensions map to runtime trace fields as follows:
+
+| JSON Schema annotation | Runtime trace field |
+| --- | --- |
+| `x-open-cvn-code` | `cvn_codes[]` |
+| `x-open-cvn-xml-paths` | `xml_paths[]` |
+| `x-open-cvn-source-reference` | `manual_reference_table` or `source_artifacts[]` |
+| `x-open-cvn-domain-shape-kind` | `domain_shape_kind` |
+| `x-open-cvn-confidence` | `confidence` |
+| `x-open-cvn-vocabulary-kind` | controlled-reference `source` and trace evidence |
+
+Trace can be omitted from hand-authored documents, but importers should preserve
+it when source evidence exists.
+
+## Exclusions
+
+The canonical JSON format must not expose these as document structure:
+
+- generated Python module names such as `cvn_item_050_020_010_000`
+- generated Pydantic class names as required runtime type names
+- raw XML wrapper mechanics unless represented as shared value objects
+- one JSON object per CVN code when a stable conceptual entry exists
+
+CVN codes remain trace metadata, not the primary JSON shape.

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -40,6 +40,7 @@ Goal:
 | `#43` | Define agnostic conceptual model extraction layer | Completed | Conceptual IR, extractor, targeted/full-suite tests, and extraction documentation implemented |
 | `#44` | Generate UML or UML-like diagrams | Completed | PlantUML now emits readable and reference views under `docs/diagrams/`; Mermaid remains optional future output |
 | `#45` | Generate JSON Schema from domain models | Completed | JSON Schema Draft 2020-12 artifact now generated from conceptual inventory under `schemas/open_cvn.schema.json` |
+| `#46` | Define canonical Open CVN JSON format | Completed | Canonical root, metadata, curriculum sections, entries, trace, extensions, examples, and schema alignment implemented |
 
 Corrective planning after hotfixes `#4`, `#5`, and `#6`:
 
@@ -463,6 +464,26 @@ Authoritative record:
 Authoritative record:
 
 - `docs/roadmap/issues/issue-45-generate-json-schema-from-domain-models.md`
+
+### Issue `#46`
+
+- Goal:
+  define the canonical Open CVN JSON document format that later parser and
+  validation work will consume
+- Implemented outcome:
+  - the canonical JSON format is documented in
+    `docs/pipeline/open_cvn_json_format.md`
+  - mapping notes are documented in `docs/pipeline/open_cvn_json_mapping.md`
+  - representative JSON examples exist under `examples/open_cvn/`
+  - the generated JSON Schema root now follows the canonical issue `#46` shape:
+    `schema_version`, `metadata`, `curriculum`, and `extensions`
+  - policy metadata now lives under `metadata.policy`
+  - runtime trace and extension conventions are documented for future parser work
+  - targeted JSON Schema and example tests passed
+
+Authoritative record:
+
+- `docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md`
 
 ## Required Companion Documents
 

--- a/docs/roadmap/issues/issue-45-generate-json-schema-from-domain-models.md
+++ b/docs/roadmap/issues/issue-45-generate-json-schema-from-domain-models.md
@@ -401,6 +401,33 @@ reason and the strongest executed substitute verification in this issue document
 - Full-suite verification result:
   `326 passed in 780.28s (0:13:00)`
 
+Additional manual schema checks were executed after implementation:
+
+- canonical regeneration with:
+  `uv run python -m cvn_codegen.json_schema_generator`
+- JSON parsing of `schemas/open_cvn.schema.json`
+- metadata verification for `$schema`, `$id`, and `title`
+- `$defs` presence verification; current generated schema contains `182`
+  definitions
+- internal `$ref` resolution check; no broken local `$defs` references found
+- presence verification for `core.curriculum` and `identity.person`
+- `CVN_SEX_A` vocabulary verification; emitted as a closed enum with `2` values
+- `CVN_ENTITY_TYPE` vocabulary verification; remains open and has
+  `x-open-cvn-enum-eligibility: ineligible`
+- temporary CLI output verification with:
+  `uv run python -m cvn_codegen.json_schema_generator --output-path /tmp/opencode/open_cvn.schema.json`
+- byte-for-byte comparison between temporary output and
+  `schemas/open_cvn.schema.json`
+- historical issue `#45` provisional root example shape verification with:
+  `schema_version`, `policy_name`, `policy_version`, and empty `curriculum`
+
+Issue `#46` later replaced this provisional root with the canonical Open CVN JSON
+root shape: `schema_version`, `metadata`, `curriculum`, and `extensions`.
+
+External JSON Schema meta-schema validation with the `jsonschema` Python package
+was not executed because `jsonschema` is not installed in the project
+environment.
+
 ## Verification
 
 - schema is valid JSON

--- a/docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md
+++ b/docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md
@@ -44,6 +44,557 @@ traceability to official CVN sources.
 8. document examples for representative personal, academic, and research data
 9. update JSON Schema generation plan if needed
 
+## Accepted Execution Protocol
+
+The user accepted the execution plan before issue `#46` implementation starts.
+
+At every execution step, the implementer must report:
+
+1. current task number and task name
+2. current subtask number and subtask name, when a subtask is being executed
+3. short initial summary of what the task or subtask will do
+4. short final result for the task or subtask
+5. whether the user must modify any file manually
+6. next step to follow
+
+File-modification rule:
+
+- documentation changes may be performed when explicitly requested
+- code changes should be left for the user unless the user explicitly authorizes
+  the agent to edit code
+- generated code under `src/generated/` must not be edited manually
+- generated domain code under `src/models/cvn/generated/` must not be edited
+  manually
+
+## Accepted Execution Plan
+
+### Task `1 / 18` - Confirm Issue Scope
+
+- Task summary:
+  - confirm the boundaries of issue `#46` before implementation work starts
+- Files involved:
+  - `docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md`
+  - `docs/roadmap/issues/issue-43-agnostic-conceptual-model-extraction-layer.md`
+  - `docs/roadmap/issues/issue-45-generate-json-schema-from-domain-models.md`
+  - `docs/pipeline/json_schema_generation.md`
+  - `schemas/open_cvn.schema.json`
+- Subtask `1.1 / 18`:
+  - confirm that issue `#46` defines the canonical Open CVN JSON document format
+- Subtask `1.2 / 18`:
+  - confirm that parser implementation, XML/PDF import, storage, UI, and export
+    workflows remain out of scope
+- Subtask `1.3 / 18`:
+  - decide whether issue `#46` only documents the canonical format or also updates
+    the generated JSON Schema artifact from issue `#45`
+- User manual modifications needed:
+  - none expected for scope confirmation
+- Next step:
+  - inventory the real evidence sources from issues `#43` and `#45`
+
+### Task `2 / 18` - Inventory Real Evidence Sources
+
+- Task summary:
+  - identify the existing artifacts that can support canonical JSON decisions
+- Files involved:
+  - `src/cvn_codegen/conceptual_model_types.py`
+  - `src/cvn_codegen/conceptual_model_extractor.py`
+  - `src/cvn_codegen/json_schema_generator.py`
+  - `schemas/open_cvn.schema.json`
+  - `docs/pipeline/conceptual_model_extraction.md`
+  - `docs/pipeline/json_schema_generation.md`
+  - `docs/pipeline/known_limitations.md`
+- Subtask `2.1 / 18`:
+  - review `ConceptualModelInventory` as the conceptual source of truth
+- Subtask `2.2 / 18`:
+  - review the issue `#45` provisional root fields: `schema_version`,
+    `policy_name`, `policy_version`, and `curriculum`
+- Subtask `2.3 / 18`:
+  - review representative definitions for `core.curriculum`, `identity.person`,
+    vocabularies, and shared wrapper values
+- Subtask `2.4 / 18`:
+  - record active limitations that affect the canonical JSON format, especially
+    conservative relationships and non-validating schema trace extensions
+- User manual modifications needed:
+  - none expected; this task is read-only
+- Next step:
+  - decide the root object and metadata shape
+
+### Task `3 / 18` - Decide Root Object And Metadata Shape
+
+- Task summary:
+  - define the top-level Open CVN JSON object and stable metadata fields
+- Files involved if documentation is authorized:
+  - `docs/open_cvn_json_format.md` or
+    `docs/pipeline/open_cvn_json_format.md`
+  - `docs/pipeline/json_schema_generation.md`
+- Candidate root fields:
+  - `schema_version`
+  - `metadata`
+  - `curriculum`
+  - `extensions`
+- Candidate metadata fields:
+  - `language`
+  - `source`
+  - `created_at`
+  - `updated_at`
+  - `generator`
+  - `policy`
+- Subtask `3.1 / 18`:
+  - decide whether to keep `schema_version` as the root format version field or
+    introduce a different name such as `open_cvn_version`
+- Subtask `3.2 / 18`:
+  - decide whether `policy_name` and `policy_version` remain root fields or move
+    under `metadata.policy`
+- Subtask `3.3 / 18`:
+  - define creation and update timestamp policy, including when generated
+    timestamps are allowed or omitted
+- Subtask `3.4 / 18`:
+  - define language metadata for Spanish-first CVN content without making the
+    whole format language-specific
+- User manual modifications needed:
+  - documentation changes are required only if explicitly authorized; code/schema
+    changes remain user-owned unless implementation is authorized
+- Next step:
+  - define format versioning and compatibility rules
+
+### Task `4 / 18` - Define Versioning And Compatibility Rules
+
+- Task summary:
+  - define how Open CVN JSON versions evolve without breaking old data
+- Files involved if documentation is authorized:
+  - `docs/open_cvn_json_format.md` or
+    `docs/pipeline/open_cvn_json_format.md`
+- Subtask `4.1 / 18`:
+  - define the initial canonical version, expected to start at `0.1.0`
+- Subtask `4.2 / 18`:
+  - define patch, minor, and major compatibility meaning for the JSON format
+- Subtask `4.3 / 18`:
+  - define parser expectations for same-major versions, future minor versions, and
+    unknown major versions
+- Subtask `4.4 / 18`:
+  - distinguish Open CVN format versioning from JSON Schema Draft 2020-12
+    metadata
+- User manual modifications needed:
+  - documentation changes are required only if explicitly authorized
+- Next step:
+  - define curriculum sections and entry layout
+
+### Task `5 / 18` - Define Curriculum Section And Entry Layout
+
+- Task summary:
+  - define how curriculum content is grouped into JSON sections and entries
+- Files involved if documentation is authorized:
+  - `docs/open_cvn_json_format.md` or
+    `docs/pipeline/open_cvn_json_format.md`
+  - `docs/pipeline/conceptual_model_extraction.md` for source rules only if a
+    cross-reference update is needed
+- Initial section candidates:
+  - `identity`
+  - `education`
+  - `research`
+  - `professional_experience`
+  - `achievements`
+  - `other`
+- Candidate entry fields:
+  - `id`
+  - `type`
+  - `data`
+  - `trace`
+  - `extensions`
+- Subtask `5.1 / 18`:
+  - decide whether `curriculum` is grouped by conceptual domain areas from issue
+    `#43`
+- Subtask `5.2 / 18`:
+  - decide whether repeated sections are arrays of entries or keyed objects
+- Subtask `5.3 / 18`:
+  - define stable entry identifiers and avoid generated Python names such as
+    `cvn_item_*`
+- Subtask `5.4 / 18`:
+  - define how fallback or weakly classified areas are represented without losing
+    traceability
+- User manual modifications needed:
+  - documentation changes are required only if explicitly authorized
+- Next step:
+  - define repeated-entry ordering and identity rules
+
+### Task `6 / 18` - Define Repeated Entry Rules
+
+- Task summary:
+  - define how repeated academic, research, professional, and other curriculum
+    entries are represented
+- Files involved if documentation is authorized:
+  - `docs/open_cvn_json_format.md` or
+    `docs/pipeline/open_cvn_json_format.md`
+- Subtask `6.1 / 18`:
+  - define arrays as the canonical shape for repeated entries
+- Subtask `6.2 / 18`:
+  - define whether array order preserves source order, chronological order, or only
+    document order
+- Subtask `6.3 / 18`:
+  - define optional `id` or `entry_id` behavior for imported records without a
+    stable external identifier
+- Subtask `6.4 / 18`:
+  - define representative repeated-entry examples for education and research
+- User manual modifications needed:
+  - documentation changes are required only if explicitly authorized
+- Next step:
+  - define field representation rules
+
+### Task `7 / 18` - Define Field Representation Rules
+
+- Task summary:
+  - define how conceptual attributes become JSON fields
+- Files involved if documentation is authorized:
+  - `docs/open_cvn_json_format.md` or
+    `docs/pipeline/open_cvn_json_format.md`
+  - `docs/pipeline/open_cvn_json_mapping.md` if mapping notes are split out
+- Subtask `7.1 / 18`:
+  - define field naming from stable semantic names rather than CVN XML names or
+    generated Python identifiers
+- Subtask `7.2 / 18`:
+  - define primitive value shapes for text, date-like values, duration-like values,
+    numbers, booleans, and unknown values
+- Subtask `7.3 / 18`:
+  - define wrapper value object usage for `FlexibleDateValue`, `OfficialIdValue`,
+    `EntityTypeValue`, and `EntityNameValue`
+- Subtask `7.4 / 18`:
+  - define the difference between omitted fields and explicit `null`
+- Subtask `7.5 / 18`:
+  - define how permissive or unknown fields are represented without hiding
+    limitations
+- User manual modifications needed:
+  - documentation changes are required only if explicitly authorized
+- Next step:
+  - define controlled-reference JSON shapes
+
+### Task `8 / 18` - Define Controlled-Reference JSON Shapes
+
+- Task summary:
+  - define how CVN controlled references, code lists, registries, thesauri, and
+    unresolved references appear in JSON
+- Files involved if documentation is authorized:
+  - `docs/open_cvn_json_format.md` or
+    `docs/pipeline/open_cvn_json_format.md`
+  - `docs/pipeline/open_cvn_json_mapping.md` if mapping notes are split out
+- Candidate controlled-reference fields:
+  - `code`
+  - `label`
+  - `source`
+  - `raw_value`
+  - `uri`
+  - `reference_status`
+- Representative cases:
+  - `CVN_SEX_A`
+  - `CVN_ENTITY_TYPE`
+  - `CVN_KNOW_A`
+  - `ENTITY@Entity.xsd`
+  - `THESAURUS@thesaurus.xsd`
+  - `UNESCO_CODES`
+  - `CVN_AGENCY_C`
+- Subtask `8.1 / 18`:
+  - define closed enum behavior only when semantic policy marks the source as
+    enum-eligible
+- Subtask `8.2 / 18`:
+  - define open code-list behavior for enum-ineligible or review-required
+    reference tables
+- Subtask `8.3 / 18`:
+  - define registry, thesaurus, hierarchical, subtype-backed, unresolved, and
+    under-traced reference shapes
+- Subtask `8.4 / 18`:
+  - define how labels and raw input values are preserved when codes are missing or
+    unresolved
+- User manual modifications needed:
+  - documentation changes are required only if explicitly authorized
+- Next step:
+  - define CVN trace metadata placement and shape
+
+### Task `9 / 18` - Define CVN Trace Metadata Rules
+
+- Task summary:
+  - define how source CVN identifiers survive in the canonical JSON format
+- Files involved if documentation is authorized:
+  - `docs/open_cvn_json_format.md` or
+    `docs/pipeline/open_cvn_json_format.md`
+  - `docs/pipeline/open_cvn_json_mapping.md` if mapping notes are split out
+- Candidate trace fields:
+  - `cvn_codes`
+  - `xml_paths`
+  - `source_artifacts`
+  - `manual_reference_table`
+  - `semantic_kind`
+  - `domain_shape_kind`
+  - `confidence`
+- Subtask `9.1 / 18`:
+  - decide when trace lives at entry level, field level, or both
+- Subtask `9.2 / 18`:
+  - define minimal trace required for round-trip auditability
+- Subtask `9.3 / 18`:
+  - map issue `#45` non-validating `x-open-cvn-*` schema extensions into runtime
+    JSON `trace` objects where useful
+- Subtask `9.4 / 18`:
+  - define trace as audit metadata rather than business data that changes value
+    semantics
+- User manual modifications needed:
+  - documentation changes are required only if explicitly authorized
+- Next step:
+  - define extension rules
+
+### Task `10 / 18` - Define Extension Rules
+
+- Task summary:
+  - define safe future extension behavior for the Open CVN JSON format
+- Files involved if documentation is authorized:
+  - `docs/open_cvn_json_format.md` or
+    `docs/pipeline/open_cvn_json_format.md`
+- Subtask `10.1 / 18`:
+  - define the `extensions` object as the canonical location for project- or
+    tool-specific metadata
+- Subtask `10.2 / 18`:
+  - define extension key naming, such as reverse-DNS names or `x-*` keys
+- Subtask `10.3 / 18`:
+  - define that consumers must ignore unknown extensions unless configured to be
+    strict
+- Subtask `10.4 / 18`:
+  - define that extensions must not override canonical fields
+- User manual modifications needed:
+  - documentation changes are required only if explicitly authorized
+- Next step:
+  - write the canonical format specification
+
+### Task `11 / 18` - Write Canonical Format Specification
+
+- Task summary:
+  - create or update the authoritative documentation for the canonical Open CVN
+    JSON format
+- Files involved if documentation is authorized:
+  - `docs/open_cvn_json_format.md` or
+    `docs/pipeline/open_cvn_json_format.md`
+- Required sections:
+  - purpose
+  - source of truth
+  - root object
+  - metadata
+  - curriculum sections
+  - entries
+  - fields
+  - controlled references
+  - trace metadata
+  - extensions
+  - versioning
+  - compatibility
+  - examples
+  - relationship to issues `#43`, `#45`, and `#49`
+  - limitations
+- Subtask `11.1 / 18`:
+  - define document location and title
+- Subtask `11.2 / 18`:
+  - write the normative root and section format rules
+- Subtask `11.3 / 18`:
+  - write field, controlled-reference, trace, and extension rules
+- Subtask `11.4 / 18`:
+  - write versioning and compatibility rules
+- User manual modifications needed:
+  - documentation changes are required unless the user authorizes the agent to edit
+    them
+- Next step:
+  - write mapping notes from conceptual/domain evidence to JSON
+
+### Task `12 / 18` - Write Mapping Notes
+
+- Task summary:
+  - document how existing conceptual inventory and schema evidence map into the
+    canonical JSON format
+- Files involved if documentation is authorized:
+  - `docs/pipeline/open_cvn_json_mapping.md` or a mapping section inside the
+    canonical format specification
+- Required mappings:
+  - conceptual entity to JSON section or entry
+  - conceptual attribute to JSON field
+  - conceptual vocabulary to controlled reference
+  - schema `x-open-cvn-*` extension to runtime trace metadata
+  - wrapper value object to JSON object
+  - unresolved or under-traced reference to explicit status
+  - XML/Python exclusion rule to stable JSON naming
+- Subtask `12.1 / 18`:
+  - map `ConceptualModelInventory` records into JSON document concepts
+- Subtask `12.2 / 18`:
+  - map issue `#45` JSON Schema definitions into canonical runtime examples
+- Subtask `12.3 / 18`:
+  - document known non-mappings, especially generated Python module names and raw
+    XML mechanics
+- User manual modifications needed:
+  - documentation changes are required unless the user authorizes the agent to edit
+    them
+- Next step:
+  - create representative JSON examples
+
+### Task `13 / 18` - Create Representative JSON Examples
+
+- Task summary:
+  - provide concrete JSON examples for implementers and future parser tests
+- Files involved if documentation/examples are authorized:
+  - `examples/open_cvn/minimal.json`
+  - `examples/open_cvn/identity.json`
+  - `examples/open_cvn/education_entry.json`
+  - `examples/open_cvn/research_entry.json`
+  - `examples/open_cvn/controlled_references.json`
+  - `examples/open_cvn/trace_and_extensions.json`
+- Subtask `13.1 / 18`:
+  - create a minimal valid Open CVN JSON document
+- Subtask `13.2 / 18`:
+  - create a representative identity example using official-id and person fields
+- Subtask `13.3 / 18`:
+  - create an education or academic-history repeated-entry example
+- Subtask `13.4 / 18`:
+  - create a research-entry example with repeated content and trace metadata
+- Subtask `13.5 / 18`:
+  - create controlled-reference examples for closed, open, hierarchical, thesaurus,
+    registry, and unresolved cases
+- User manual modifications needed:
+  - example file changes are required unless the user authorizes the agent to edit
+    them
+- Next step:
+  - align the generated JSON Schema with the canonical format if needed
+
+### Task `14 / 18` - Align JSON Schema Generation With Canonical Format
+
+- Task summary:
+  - decide and implement or document the relationship between the issue `#45`
+    generated schema and the issue `#46` canonical JSON format
+- Files involved if code/schema work is authorized:
+  - `src/cvn_codegen/json_schema_generator.py`
+  - `schemas/open_cvn.schema.json`
+  - `docs/pipeline/json_schema_generation.md`
+  - `tests/test_json_schema_generator_unit.py`
+  - `tests/test_generation_pipeline_json_schema.py`
+- Subtask `14.1 / 18`:
+  - compare the canonical root format against the issue `#45` provisional root
+- Subtask `14.2 / 18`:
+  - if authorized, update the generator root layout while preserving conceptual
+    `$defs`
+- Subtask `14.3 / 18`:
+  - regenerate `schemas/open_cvn.schema.json` if generator changes are authorized
+- Subtask `14.4 / 18`:
+  - if code changes are not authorized, document the exact delta as a follow-up
+    before issue `#49`
+- User manual modifications needed:
+  - code and generated schema changes should be done by the user unless the user
+    explicitly authorizes the agent to edit code/schema artifacts
+- Next step:
+  - add validation tests for examples and schema behavior if implementation is
+    authorized
+
+### Task `15 / 18` - Add Tests For Format Examples And Schema Behavior
+
+- Task summary:
+  - verify that the canonical examples and schema behavior match the issue `#46`
+    decisions
+- Files involved if tests are authorized:
+  - `tests/test_open_cvn_json_format_examples.py`
+  - `tests/test_json_schema_generator_unit.py`
+  - `tests/test_generation_pipeline_json_schema.py`
+- Subtask `15.1 / 18`:
+  - test that all example files are valid JSON
+- Subtask `15.2 / 18`:
+  - test that examples validate against `schemas/open_cvn.schema.json` when the
+    schema has been aligned to the canonical format
+- Subtask `15.3 / 18`:
+  - test canonical root fields and metadata policy
+- Subtask `15.4 / 18`:
+  - test controlled-reference examples for closed enum, open code list, and
+    unresolved reference behavior
+- Subtask `15.5 / 18`:
+  - test that trace metadata remains optional but valid where present
+- User manual modifications needed:
+  - test changes should be done by the user unless the user explicitly authorizes
+    the agent to edit tests
+- Next step:
+  - run regeneration and verification commands if implementation is authorized
+
+### Task `16 / 18` - Regenerate And Verify Artifacts
+
+- Task summary:
+  - run the strongest available verification after documentation, example, schema,
+    or test changes
+- Commands if schema/test work is authorized:
+  - `uv run python -m cvn_codegen.json_schema_generator`
+  - `uv run pytest -n auto tests/test_json_schema_generator_unit.py tests/test_generation_pipeline_json_schema.py tests/test_open_cvn_json_format_examples.py -v`
+  - `uv run pytest -n auto tests`
+- Subtask `16.1 / 18`:
+  - regenerate the canonical JSON Schema if generator changes were made
+- Subtask `16.2 / 18`:
+  - run targeted tests for schema generation and examples
+- Subtask `16.3 / 18`:
+  - run the full repository test suite when practical
+- Subtask `16.4 / 18`:
+  - record any skipped verification with the exact reason and strongest executed
+    substitute
+- User manual modifications needed:
+  - none expected for command execution if the agent is authorized to run commands
+- Next step:
+  - update persistent documentation and roadmap state
+
+### Task `17 / 18` - Update Persistent Documentation
+
+- Task summary:
+  - record issue `#46` implementation outcome and keep repository context aligned
+- Files involved:
+  - `docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md`
+  - `docs/context/current_status.md`
+  - `docs/roadmap/cvn_generation_roadmap.md`
+  - `docs/pipeline/json_schema_generation.md`
+  - `docs/pipeline/known_limitations.md` only if a new limitation is found
+  - `PROJECT_GUIDE.md` only if human-facing document maps or repository
+    orientation change
+- Subtask `17.1 / 18`:
+  - add implementation summary, artifacts, decisions, deviations, and verification
+    to issue `#46`
+- Subtask `17.2 / 18`:
+  - update current status with issue `#46` outcome and next planned issue `#47`
+- Subtask `17.3 / 18`:
+  - update roadmap status if issue `#46` is completed
+- Subtask `17.4 / 18`:
+  - update JSON Schema generation documentation if the provisional root changes or
+    remains a known delta
+- Subtask `17.5 / 18`:
+  - update known limitations only if a durable new limitation is discovered
+- Subtask `17.6 / 18`:
+  - update `PROJECT_GUIDE.md` only if new document or example paths become
+    contributor entry-point knowledge
+- User manual modifications needed:
+  - documentation changes are required unless the user authorizes the agent to edit
+    them
+- Next step:
+  - verify issue closure criteria
+
+### Task `18 / 18` - Verify Issue Closure
+
+- Task summary:
+  - confirm issue `#46` is ready for parser and validation work in later issues
+- Closure checks:
+  - root object and metadata shape are defined
+  - curriculum sections and repeated entries are defined
+  - field naming and wrapper value rules are defined
+  - controlled-reference and unresolved-reference shapes are defined
+  - CVN trace metadata is preserved
+  - extension and compatibility rules are defined
+  - representative examples exist if implementation is authorized
+  - schema alignment or schema delta is recorded before issue `#49`
+  - format is not XML-centric
+  - no generated structural or generated domain code was manually edited
+- Subtask `18.1 / 18`:
+  - review the issue `#46` design questions and confirm each has an explicit answer
+- Subtask `18.2 / 18`:
+  - review representative examples and schema alignment status
+- Subtask `18.3 / 18`:
+  - confirm issue `#47` and issue `#49` can consume the canonical format without
+    redesigning the root shape
+- User manual modifications needed:
+  - none expected after closure verification; any required manual changes should
+    have been recorded earlier
+- Next step:
+  - proceed to issue `#47` only after the user accepts issue `#46` closure
+
 ## Expected Output
 
 - canonical Open CVN JSON format specification under `docs/`
@@ -51,9 +602,80 @@ traceability to official CVN sources.
 - mapping notes from CVN/domain Pydantic fields to JSON
 - decisions for future versioning
 
+## Implementation Summary
+
+- The canonical Open CVN JSON format is documented in:
+  `docs/pipeline/open_cvn_json_format.md`
+- Mapping notes from the issue `#43` conceptual inventory and issue `#45` schema
+  annotations to runtime JSON are documented in:
+  `docs/pipeline/open_cvn_json_mapping.md`
+- Representative JSON examples are provided under:
+  `examples/open_cvn/`
+- The issue `#45` JSON Schema generator now emits the issue `#46` canonical root
+  shape with:
+  - `schema_version`
+  - `metadata`
+  - `curriculum`
+  - `extensions`
+- Semantic policy metadata now lives under `metadata.policy` instead of root-level
+  `policy_name` and `policy_version` fields.
+- The generated JSON Schema artifact remains:
+  `schemas/open_cvn.schema.json`
+- The schema artifact now identifies issue `#46` as the source issue for the
+  canonical root shape.
+
+## Implementation Decisions
+
+- `schema_version` remains the root Open CVN format-version field.
+- `metadata` is required and includes `language` and `policy` as required fields.
+- `curriculum` is grouped by conceptual domain areas rather than CVN XML
+  structures or generated Python modules.
+- `identity` is represented as a single object, while education, research,
+  professional experience, achievements, and fallback content are represented as
+  arrays of entries.
+- Repeated-section entries use `type` and `data` as required fields, with optional
+  `id`, `trace`, and `extensions`.
+- Controlled references use a common shape with `code`, `label`, `source`,
+  `raw_value`, `uri`, and `reference_status`.
+- Closed enum validation remains limited to enum-eligible vocabularies such as
+  `CVN_SEX_A`; enum-ineligible and unresolved references remain open.
+- Runtime trace metadata is represented through `trace` objects rather than
+  requiring schema-only `x-open-cvn-*` annotations to appear in data files.
+
+## Artifacts Created Or Updated
+
+- `docs/pipeline/open_cvn_json_format.md`
+- `docs/pipeline/open_cvn_json_mapping.md`
+- `examples/open_cvn/minimal.json`
+- `examples/open_cvn/identity.json`
+- `examples/open_cvn/education_entry.json`
+- `examples/open_cvn/research_entry.json`
+- `examples/open_cvn/controlled_references.json`
+- `examples/open_cvn/trace_and_extensions.json`
+- `src/cvn_codegen/json_schema_generator.py`
+- `schemas/open_cvn.schema.json`
+- `tests/test_json_schema_generator_unit.py`
+- `tests/test_generation_pipeline_json_schema.py`
+- `tests/test_open_cvn_json_format_examples.py`
+
+## Verification Performed
+
+- Canonical JSON Schema regeneration passed with:
+  `uv run python -m cvn_codegen.json_schema_generator`
+- Targeted issue `#46` verification passed with:
+  `uv run pytest -n auto tests/test_json_schema_generator_unit.py tests/test_generation_pipeline_json_schema.py tests/test_open_cvn_json_format_examples.py -v`
+- Targeted verification result:
+  `21 passed in 159.97s (0:02:39)`
+- Full-suite verification passed with:
+  `uv run pytest -n auto tests`
+- Full-suite verification result:
+  `334 passed in 890.21s (0:14:50)`
+
 ## Verification
 
-- examples validate against generated schema once issue `#45` is implemented
+- examples are valid JSON and follow the canonical root, section, entry,
+  controlled-reference, trace, and extension conventions
+- the generated schema validates the canonical root shape defined by issue `#46`
 - format is not XML-centric
 - traceability to CVN source identifiers remains preserved
 
@@ -64,4 +686,4 @@ traceability to official CVN sources.
 
 ## Status
 
-- Status: planned
+- Status: completed

--- a/examples/open_cvn/controlled_references.json
+++ b/examples/open_cvn/controlled_references.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {
+    "language": "es",
+    "policy": {
+      "name": "default_cvn_semantic_policy",
+      "version": "0.1.0"
+    }
+  },
+  "curriculum": {
+    "identity": {
+      "sex": {
+        "code": "000",
+        "label": "Mujer",
+        "source": "CVN_SEX_A"
+      },
+      "entity_type": {
+        "code": "OTHERS",
+        "label": "Otra entidad",
+        "source": "CVN_ENTITY_TYPE",
+        "raw_value": "Fundacion privada"
+      }
+    },
+    "education": [],
+    "research": [
+      {
+        "id": "research-001",
+        "type": "research.topic",
+        "data": {
+          "unesco_code": {
+            "code": "1203.17",
+            "label": "Informatica",
+            "source": "UNESCO_CODES"
+          },
+          "keyword": {
+            "code": "example-term",
+            "label": "Curriculum interoperable",
+            "source": "THESAURUS@thesaurus.xsd"
+          },
+          "agency": {
+            "label": "Agencia no resuelta",
+            "source": "CVN_AGENCY_C",
+            "raw_value": "AGENCIA EJEMPLO",
+            "reference_status": "unresolved"
+          }
+        }
+      }
+    ],
+    "professional_experience": [],
+    "achievements": [],
+    "other": []
+  }
+}

--- a/examples/open_cvn/education_entry.json
+++ b/examples/open_cvn/education_entry.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {
+    "language": "es",
+    "policy": {
+      "name": "default_cvn_semantic_policy",
+      "version": "0.1.0"
+    }
+  },
+  "curriculum": {
+    "identity": {},
+    "education": [
+      {
+        "id": "education-001",
+        "type": "education.degree",
+        "data": {
+          "degree_name": "Doctorado en Informatica",
+          "entity_name": {
+            "name": "Universidad de Ejemplo",
+            "others": null
+          },
+          "start_date": {
+            "day": null,
+            "month": "09",
+            "raw_value": "2020-09",
+            "year": "2020"
+          },
+          "end_date": {
+            "day": null,
+            "month": "06",
+            "raw_value": "2024-06",
+            "year": "2024"
+          }
+        },
+        "trace": {
+          "cvn_codes": [
+            "020.010.010.000"
+          ],
+          "confidence": "medium"
+        }
+      }
+    ],
+    "research": [],
+    "professional_experience": [],
+    "achievements": [],
+    "other": []
+  }
+}

--- a/examples/open_cvn/identity.json
+++ b/examples/open_cvn/identity.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {
+    "language": "es",
+    "policy": {
+      "name": "default_cvn_semantic_policy",
+      "version": "0.1.0"
+    },
+    "source": {
+      "format": "open_cvn_json"
+    }
+  },
+  "curriculum": {
+    "identity": {
+      "given_name": "Ana",
+      "family_name": "Garcia Lopez",
+      "official_id": {
+        "dni": "00000000T",
+        "nie": null,
+        "others": null,
+        "passport": null
+      },
+      "sex": {
+        "code": "000",
+        "label": "Mujer",
+        "source": "CVN_SEX_A"
+      },
+      "trace": {
+        "cvn_codes": [
+          "000.010.000.000"
+        ],
+        "confidence": "high"
+      }
+    },
+    "education": [],
+    "research": [],
+    "professional_experience": [],
+    "achievements": [],
+    "other": []
+  }
+}

--- a/examples/open_cvn/minimal.json
+++ b/examples/open_cvn/minimal.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {
+    "language": "es",
+    "policy": {
+      "name": "default_cvn_semantic_policy",
+      "version": "0.1.0"
+    }
+  },
+  "curriculum": {
+    "identity": {},
+    "education": [],
+    "research": [],
+    "professional_experience": [],
+    "achievements": [],
+    "other": []
+  }
+}

--- a/examples/open_cvn/research_entry.json
+++ b/examples/open_cvn/research_entry.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {
+    "language": "es",
+    "policy": {
+      "name": "default_cvn_semantic_policy",
+      "version": "0.1.0"
+    }
+  },
+  "curriculum": {
+    "identity": {},
+    "education": [],
+    "research": [
+      {
+        "id": "research-001",
+        "type": "research.publication",
+        "data": {
+          "title": "Open CVN data representation",
+          "publication_year": "2026",
+          "subject": {
+            "code": "1203.17",
+            "label": "Informatica",
+            "source": "UNESCO_CODES"
+          },
+          "authors": [
+            "Ana Garcia Lopez",
+            "Carlos Perez"
+          ]
+        },
+        "trace": {
+          "cvn_codes": [
+            "060.010.010.000"
+          ],
+          "manual_reference_table": "UNESCO_CODES",
+          "semantic_reference_kind": "hierarchical_code_list"
+        }
+      }
+    ],
+    "professional_experience": [],
+    "achievements": [],
+    "other": []
+  }
+}

--- a/examples/open_cvn/trace_and_extensions.json
+++ b/examples/open_cvn/trace_and_extensions.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {
+    "language": "es",
+    "generator": {
+      "name": "open-cvn-example-writer",
+      "version": "0.1.0"
+    },
+    "policy": {
+      "name": "default_cvn_semantic_policy",
+      "version": "0.1.0"
+    }
+  },
+  "curriculum": {
+    "identity": {},
+    "education": [],
+    "research": [
+      {
+        "id": "research-001",
+        "type": "research.project",
+        "data": {
+          "project_title": "Open CVN validation pipeline"
+        },
+        "trace": {
+          "cvn_codes": [
+            "050.020.010.000"
+          ],
+          "xml_paths": [
+            "/Node/CVNItem[@code='050.020.010.000']"
+          ],
+          "source_files": [
+            "SpecificationManual.xml",
+            "CVNTreeModel.xml"
+          ],
+          "domain_shape_kind": "plain_value",
+          "confidence": "high"
+        },
+        "extensions": {
+          "x-local-review-note": {
+            "reviewed": false
+          }
+        }
+      }
+    ],
+    "professional_experience": [],
+    "achievements": [],
+    "other": []
+  },
+  "extensions": {
+    "org.open-cvn.example": {
+      "purpose": "trace and extension demonstration"
+    }
+  }
+}

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-45-generate-json-schema-from-domain-models.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 44. Primero unicamente debes de crear el plan de ejecución
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 46. Primero unicamente debes de crear el plan de ejecución
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-45-generate-json-schema-from-domain-models.md.
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md.
 
 
 

--- a/schemas/open_cvn.schema.json
+++ b/schemas/open_cvn.schema.json
@@ -271,6 +271,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -366,6 +390,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -392,6 +440,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -580,6 +652,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -607,6 +703,30 @@
               "$ref": "#/$defs/vocabularies.cvn_language_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -674,6 +794,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -701,6 +845,30 @@
               "$ref": "#/$defs/vocabularies.cvn_language_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -736,6 +904,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object",
@@ -763,6 +955,30 @@
               "$ref": "#/$defs/vocabularies.cvn_language_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -831,6 +1047,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -960,6 +1200,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -1065,6 +1329,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -1104,6 +1392,30 @@
               "$ref": "#/$defs/vocabularies.cvn_thematic_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -1173,6 +1485,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -1215,6 +1551,30 @@
               "$ref": "#/$defs/vocabularies.cvn_participation_e"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -1311,6 +1671,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -1494,6 +1878,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object",
@@ -1548,6 +1956,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -1827,6 +2259,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -1996,6 +2452,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -2022,6 +2502,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -2156,6 +2660,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -2251,6 +2779,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -2413,6 +2965,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -2451,6 +3027,30 @@
               "$ref": "#/$defs/vocabularies.cvn_title_c"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -2624,6 +3224,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -2719,6 +3343,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -2753,6 +3401,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -2783,6 +3455,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -2808,6 +3504,30 @@
               "$ref": "#/$defs/vocabularies.cvn_prize_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -2895,6 +3615,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -2938,6 +3682,30 @@
               "$ref": "#/$defs/vocabularies.cvn_title_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -3077,6 +3845,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -3103,6 +3895,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -3244,6 +4060,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -3315,6 +4155,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -3340,6 +4204,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -3383,6 +4271,30 @@
               "$ref": "#/$defs/vocabularies.cvn_publication_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -3457,6 +4369,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -3499,6 +4435,30 @@
               "$ref": "#/$defs/vocabularies.cvn_participation_e"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -3661,6 +4621,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -3691,6 +4675,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -3717,6 +4725,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -3949,6 +4981,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -4013,6 +5069,30 @@
               "$ref": "#/$defs/vocabularies.cvn_summons_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -4148,6 +5228,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -4211,6 +5315,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -4236,6 +5364,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -4269,6 +5421,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -4294,6 +5470,30 @@
               "$ref": "#/$defs/vocabularies.cvn_subject_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -4345,6 +5545,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -4371,6 +5595,30 @@
               "$ref": "#/$defs/vocabularies.cvn_teaching_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -4494,6 +5742,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -4541,6 +5813,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -4565,6 +5861,30 @@
               "$ref": "#/$defs/vocabularies.cvn_programme_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -4612,6 +5932,30 @@
               "$ref": "#/$defs/vocabularies.cvn_title_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -4727,6 +6071,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -4897,6 +6265,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -4958,6 +6350,30 @@
               "$ref": "#/$defs/vocabularies.cvn_activity_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -5053,6 +6469,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -5140,6 +6580,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -5368,6 +6832,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -5393,6 +6881,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -5626,6 +7138,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -5652,6 +7188,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -5703,6 +7263,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -5904,6 +7488,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -5929,6 +7537,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -6175,6 +7807,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -6201,6 +7857,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -6382,6 +8062,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -6407,6 +8111,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -6626,6 +8354,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -6652,6 +8404,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -6846,6 +8622,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -6871,6 +8671,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -7016,6 +8840,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -7060,6 +8908,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -7296,6 +9168,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -7484,6 +9380,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object",
@@ -7638,6 +9558,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -7701,6 +9645,30 @@
               "$ref": "#/$defs/vocabularies.cvn_support_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -7810,6 +9778,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -7948,6 +9940,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -8013,6 +10029,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -8039,6 +10079,30 @@
               "$ref": "#/$defs/vocabularies.cvn_title_d"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -8151,6 +10215,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -8282,6 +10370,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -8308,6 +10420,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -8522,6 +10658,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object",
@@ -8587,6 +10747,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -8799,6 +10983,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -8860,6 +11068,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -8884,6 +11116,30 @@
               "$ref": "#/$defs/vocabularies.cvn_summons_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -8931,6 +11187,30 @@
               "$ref": "#/$defs/vocabularies.cvn_duration_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -9059,6 +11339,30 @@
               "$ref": "#/$defs/vocabularies.cvn_participation_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -9207,6 +11511,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -9386,6 +11714,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -9411,6 +11763,30 @@
               "$ref": "#/$defs/vocabularies.cvn_publication_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -9480,6 +11856,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_source_b"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -9650,6 +12050,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -9825,6 +12249,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -10097,6 +12545,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -10191,6 +12663,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -10315,6 +12811,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -10390,6 +12910,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -10553,6 +13097,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -10579,6 +13147,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -10756,6 +13348,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -10782,6 +13398,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -10853,6 +13493,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -10877,6 +13541,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -10923,6 +13611,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -10963,6 +13675,30 @@
               "$ref": "#/$defs/vocabularies.cvn_sex_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -11021,6 +13757,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_source_c"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -11218,6 +13978,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -11244,6 +14028,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -11386,6 +14194,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -11411,6 +14243,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -11441,6 +14297,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -11683,6 +14563,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -11709,6 +14613,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -11851,6 +14779,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -11876,6 +14828,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -11906,6 +14882,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -12148,6 +15148,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -12174,6 +15198,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -12316,6 +15364,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -12341,6 +15413,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -12371,6 +15467,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -12599,6 +15719,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -12733,6 +15877,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -12759,6 +15927,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -12946,6 +16138,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -13080,6 +16296,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -13106,6 +16346,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -13293,6 +16557,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -13447,6 +16735,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -13473,6 +16785,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -13675,6 +17011,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -13701,6 +17061,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -13843,6 +17227,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -13868,6 +17276,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -13898,6 +17330,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -14080,6 +17536,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -14152,6 +17632,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -14178,6 +17682,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -14291,6 +17819,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -14335,6 +17887,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -14360,6 +17936,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -14463,6 +18063,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -14506,6 +18130,30 @@
               "$ref": "#/$defs/vocabularies.cvn_event_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -14603,6 +18251,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -14629,6 +18301,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -14803,6 +18499,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -14865,6 +18585,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -14890,6 +18634,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -14933,6 +18701,30 @@
               "$ref": "#/$defs/vocabularies.cvn_publication_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -15039,6 +18831,30 @@
               "$ref": "#/$defs/vocabularies.cvn_participation_e"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -15279,6 +19095,30 @@
               "$ref": "#/$defs/vocabularies.cvn_situation_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -15546,6 +19386,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -15687,6 +19551,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -15712,6 +19600,30 @@
               "$ref": "#/$defs/vocabularies.cvn_publication_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -15781,6 +19693,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_source_b"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -15909,6 +19845,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -15935,6 +19895,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -16113,6 +20097,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -16138,6 +20146,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -16168,6 +20200,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -16493,6 +20549,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -16588,6 +20668,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -16614,6 +20718,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -16811,6 +20939,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -16836,6 +20988,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -16915,6 +21091,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -16939,6 +21139,30 @@
               "$ref": "#/$defs/vocabularies.cvn_summons_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -17062,6 +21286,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -17105,6 +21353,30 @@
               "$ref": "#/$defs/vocabularies.cvn_project_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -17224,6 +21496,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -17250,6 +21546,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -17444,6 +21764,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -17469,6 +21813,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -17548,6 +21916,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -17572,6 +21964,30 @@
               "$ref": "#/$defs/vocabularies.cvn_summons_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -17691,6 +22107,30 @@
               "$ref": "#/$defs/vocabularies.cvn_participation_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -17894,6 +22334,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -18069,6 +22533,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -18131,6 +22619,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_source_b"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -18266,6 +22778,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -18440,6 +22976,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -18502,6 +23062,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_source_b"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -18629,6 +23213,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -18655,6 +23263,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -18801,6 +23433,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -18826,6 +23482,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -18927,6 +23607,30 @@
               "$ref": "#/$defs/vocabularies.cvn_programme_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -19042,6 +23746,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object",
@@ -19148,6 +23876,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -19206,6 +23958,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -19248,6 +24024,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -19285,6 +24085,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -19514,6 +24338,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -19561,6 +24409,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -19587,6 +24459,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -19644,6 +24540,30 @@
               "$ref": "#/$defs/vocabularies.cvn_dedication_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -19779,6 +24699,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object",
@@ -19853,6 +24797,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -19911,6 +24879,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -19953,6 +24945,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -19990,6 +25006,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -20189,6 +25229,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object",
@@ -20233,6 +25297,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -20259,6 +25347,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -20316,6 +25428,30 @@
               "$ref": "#/$defs/vocabularies.cvn_dedication_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -20572,6 +25708,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -20702,6 +25862,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -20891,6 +26075,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -20917,6 +26125,30 @@
               "$ref": "#/$defs/vocabularies.cvn_supervision_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -20988,6 +26220,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -21049,6 +26305,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -21093,6 +26373,30 @@
               "$ref": "#/$defs/vocabularies.cvn_event_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -21189,6 +26493,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -21257,6 +26585,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -21357,6 +26709,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -21449,6 +26825,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -21517,6 +26917,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -21617,6 +27041,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -21709,6 +27157,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -21763,6 +27235,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -21859,6 +27355,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -21993,6 +27513,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -22147,6 +27691,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -22229,6 +27797,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -22255,6 +27847,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -22386,6 +28002,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -22459,6 +28099,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -22517,6 +28181,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -22555,6 +28243,30 @@
                 "$ref": "#/$defs/vocabularies.unesco_codes"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -22632,6 +28344,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -22658,6 +28394,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -22760,6 +28520,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -22785,6 +28569,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -22918,6 +28726,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -23006,6 +28838,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -23032,6 +28888,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -23179,6 +29059,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -23204,6 +29108,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -23335,6 +29263,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -23419,6 +29371,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -23686,6 +29662,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object",
@@ -23708,6 +29708,30 @@
               "$ref": "#/$defs/vocabularies.cvn_project_c"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -23861,6 +29885,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -23887,6 +29935,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -23945,6 +30017,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -24096,6 +30192,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -24203,6 +30323,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -24281,6 +30425,30 @@
                 "$ref": "#/$defs/vocabularies.iso_3166"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -24434,6 +30602,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -24512,6 +30704,30 @@
                 "$ref": "#/$defs/vocabularies.iso_3166"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -24665,6 +30881,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -24736,6 +30976,30 @@
                 "$ref": "#/$defs/vocabularies.iso_3166"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -24889,6 +31153,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -24967,6 +31255,30 @@
                 "$ref": "#/$defs/vocabularies.iso_3166"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -25141,6 +31453,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -25199,6 +31535,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -25241,6 +31601,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -25278,6 +31662,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -25421,6 +31829,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -25491,6 +31923,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object",
@@ -25531,6 +31987,30 @@
               "$ref": "#/$defs/vocabularies.cvn_stay_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -25579,6 +32059,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -25605,6 +32109,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -25753,6 +32281,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object",
@@ -25834,6 +32386,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -25888,6 +32464,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -26054,6 +32654,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -26119,6 +32743,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -26144,6 +32792,30 @@
               "$ref": "#/$defs/vocabularies.cvn_access_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -26278,6 +32950,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -26332,6 +33028,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -26511,6 +33231,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -26571,6 +33315,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_source_b"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -26729,6 +33497,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -26759,6 +33551,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -26785,6 +33601,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -26961,6 +33801,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -26990,6 +33854,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -27015,6 +33903,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -27153,6 +34065,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -27207,6 +34143,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -27451,6 +34411,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -27477,6 +34461,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -27538,6 +34546,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -27587,6 +34619,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -27630,6 +34686,30 @@
               "$ref": "#/$defs/vocabularies.cvn_management_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -27731,6 +34811,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -27775,6 +34879,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -27994,6 +35122,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -28020,6 +35172,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -28268,6 +35444,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -28339,6 +35539,30 @@
                 "$ref": "#/$defs/vocabularies.iso_3166"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -28603,6 +35827,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -28723,6 +35971,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -28820,6 +36092,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object",
@@ -28899,6 +36195,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -28971,6 +36291,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -28997,6 +36341,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -29108,6 +36476,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -29202,6 +36594,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -29227,6 +36643,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -29367,6 +36807,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -29439,6 +36903,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -29548,6 +37036,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -29702,6 +37214,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -29785,6 +37321,30 @@
               "$ref": "#/$defs/vocabularies.cvn_collaboration_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -29918,6 +37478,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -29944,6 +37528,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -30085,6 +37693,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -30213,6 +37845,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -30290,6 +37946,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -30333,6 +38013,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -30414,6 +38118,30 @@
               "$ref": "#/$defs/vocabularies.cvn_activity_d"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -30578,6 +38306,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -30683,6 +38435,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -30840,6 +38616,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -30913,6 +38713,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -31047,6 +38871,30 @@
               "$ref": "#/$defs/vocabularies.cvn_agency_c"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -31244,6 +39092,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -31270,6 +39142,30 @@
               "$ref": "#/$defs/vocabularies.cvn_qualification_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -31328,6 +39224,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_region"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -31446,6 +39366,30 @@
                 "$ref": "#/$defs/vocabularies.iso_3166"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -31734,6 +39678,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -31760,6 +39728,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -31880,6 +39872,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -31990,6 +40006,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -32074,6 +40114,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -32302,6 +40366,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -32329,6 +40417,30 @@
               "$ref": "#/$defs/vocabularies.cvn_project_c"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -32476,6 +40588,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -32502,6 +40638,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -32560,6 +40720,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -32649,6 +40833,30 @@
               "$ref": "#/$defs/vocabularies.cvn_dedication_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -32764,6 +40972,30 @@
               "$ref": "#/$defs/vocabularies.cvn_participation_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -32939,6 +41171,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -33027,6 +41283,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -33090,6 +41370,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -33118,6 +41422,30 @@
               "$ref": "#/$defs/vocabularies.cvn_participation_g"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -33230,6 +41558,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -33388,6 +41740,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -33529,6 +41905,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -33560,6 +41960,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_source_b"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -33631,6 +42055,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object",
@@ -33671,6 +42119,30 @@
                 "$ref": "#/$defs/vocabularies.iso_639"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -33776,6 +42248,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -33828,6 +42324,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_agency_b"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -34174,6 +42694,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -34349,6 +42893,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -34374,6 +42942,30 @@
               "$ref": "#/$defs/vocabularies.cvn_publication_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -34443,6 +43035,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_source_b"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -34579,6 +43195,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -34758,6 +43398,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -34783,6 +43447,30 @@
               "$ref": "#/$defs/vocabularies.cvn_publication_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -34852,6 +43540,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_source_b"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -34980,6 +43692,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -35006,6 +43742,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -35192,6 +43952,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -35217,6 +44001,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -35424,6 +44232,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -35579,6 +44411,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -35637,6 +44493,30 @@
                   "string",
                   "null"
                 ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": [
@@ -35675,6 +44555,30 @@
                 "$ref": "#/$defs/vocabularies.unesco_codes"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -35777,6 +44681,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -35857,6 +44785,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -36094,6 +45046,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -36167,6 +45143,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -36348,6 +45348,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -36374,6 +45398,30 @@
               "$ref": "#/$defs/vocabularies.cvn_region"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -36494,6 +45542,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -36519,6 +45591,30 @@
               "$ref": "#/$defs/vocabularies.iso_3166"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -36549,6 +45645,30 @@
                 "$ref": "#/$defs/vocabularies.thesaurus_thesaurus_xsd"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -36742,6 +45862,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -36855,6 +45999,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -36881,6 +46049,30 @@
               "$ref": "#/$defs/vocabularies.cvn_publication_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -36916,6 +46108,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_source_a"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -36979,6 +46195,30 @@
               "$ref": "#/$defs/vocabularies.cvn_supervision_a"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -37078,6 +46318,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -37153,6 +46417,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -37195,6 +46483,30 @@
               "$ref": "#/$defs/vocabularies.cvn_participation_e"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -37377,6 +46689,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -37404,6 +46740,30 @@
                 "$ref": "#/$defs/vocabularies.cvn_source_a"
               },
               "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "raw_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uri": {
                 "type": [
                   "string",
                   "null"
@@ -37467,6 +46827,30 @@
               "$ref": "#/$defs/vocabularies.cvn_supervision_b"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -37551,6 +46935,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -37612,6 +47020,30 @@
                 "string",
                 "null"
               ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": [
@@ -37642,6 +47074,30 @@
               "$ref": "#/$defs/vocabularies.cvn_event_c"
             },
             "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "raw_value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reference_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uri": {
               "type": [
                 "string",
                 "null"
@@ -38627,18 +48083,544 @@
   "$id": "https://open-cvn.local/schema/open-cvn.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
-  "description": "Generated Open CVN JSON Schema from the conceptual model inventory and domain-oriented Pydantic evidence. Root shape is provisional until issue #46 defines the canonical Open CVN JSON representation.",
+  "description": "Generated Open CVN JSON Schema from the conceptual model inventory and domain-oriented Pydantic evidence. Root shape follows the canonical Open CVN JSON representation defined in issue #46.",
   "properties": {
     "curriculum": {
-      "$ref": "#/$defs/core.curriculum"
+      "additionalProperties": false,
+      "properties": {
+        "achievements": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "extensions": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trace": {
+                "additionalProperties": false,
+                "properties": {
+                  "confidence": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cvn_codes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "domain_shape_kind": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "manual_reference_table": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "semantic_reference_kind": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serialization_pattern": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_artifacts": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "source_files": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "xml_paths": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "data"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "education": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "extensions": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trace": {
+                "additionalProperties": false,
+                "properties": {
+                  "confidence": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cvn_codes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "domain_shape_kind": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "manual_reference_table": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "semantic_reference_kind": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serialization_pattern": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_artifacts": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "source_files": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "xml_paths": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "data"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "identity": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "other": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "extensions": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trace": {
+                "additionalProperties": false,
+                "properties": {
+                  "confidence": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cvn_codes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "domain_shape_kind": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "manual_reference_table": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "semantic_reference_kind": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serialization_pattern": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_artifacts": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "source_files": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "xml_paths": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "data"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "professional_experience": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "extensions": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trace": {
+                "additionalProperties": false,
+                "properties": {
+                  "confidence": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cvn_codes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "domain_shape_kind": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "manual_reference_table": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "semantic_reference_kind": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serialization_pattern": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_artifacts": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "source_files": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "xml_paths": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "data"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "research": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "extensions": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trace": {
+                "additionalProperties": false,
+                "properties": {
+                  "confidence": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cvn_codes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "domain_shape_kind": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "manual_reference_table": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "semantic_reference_kind": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serialization_pattern": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_artifacts": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "source_files": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "xml_paths": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "data"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
     },
-    "policy_name": {
-      "const": "default_cvn_semantic_policy",
-      "type": "string"
+    "extensions": {
+      "additionalProperties": true,
+      "type": "object"
     },
-    "policy_version": {
-      "const": "0.1.0",
-      "type": "string"
+    "metadata": {
+      "additionalProperties": false,
+      "properties": {
+        "created_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "generator": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "version": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "language": {
+          "type": "string"
+        },
+        "policy": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "const": "default_cvn_semantic_policy",
+              "type": "string"
+            },
+            "version": {
+              "const": "0.1.0",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "source": {
+          "additionalProperties": true,
+          "properties": {
+            "format": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "updated_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "language",
+        "policy"
+      ],
+      "type": "object"
     },
     "schema_version": {
       "const": "0.1.0",
@@ -38647,8 +48629,7 @@
   },
   "required": [
     "schema_version",
-    "policy_name",
-    "policy_version",
+    "metadata",
     "curriculum"
   ],
   "title": "Open CVN JSON Schema",
@@ -38657,5 +48638,5 @@
   "x-open-cvn-policy-name": "default_cvn_semantic_policy",
   "x-open-cvn-policy-version": "0.1.0",
   "x-open-cvn-schema-version": "0.1.0",
-  "x-open-cvn-source-issue": "#45"
+  "x-open-cvn-source-issue": "#46"
 }

--- a/src/cvn_codegen/json_schema_generator.py
+++ b/src/cvn_codegen/json_schema_generator.py
@@ -22,6 +22,13 @@ from cvn_codegen.conceptual_model_types import (
 OPEN_CVN_SCHEMA_ID = "https://open-cvn.local/schema/open-cvn.schema.json"
 OPEN_CVN_SCHEMA_VERSION = "0.1.0"
 JSON_SCHEMA_DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
+CURRICULUM_SECTION_NAMES = (
+    "education",
+    "research",
+    "professional_experience",
+    "achievements",
+    "other",
+)
 
 
 WRAPPER_DEFINITIONS: dict[str, dict[str, Any]] = {
@@ -84,8 +91,8 @@ def build_json_schema_metadata(
         "$schema": JSON_SCHEMA_DRAFT_2020_12,
         "description": (
             "Generated Open CVN JSON Schema from the conceptual model inventory "
-            "and domain-oriented Pydantic evidence. Root shape is provisional "
-            "until issue #46 defines the canonical Open CVN JSON representation."
+            "and domain-oriented Pydantic evidence. Root shape follows the "
+            "canonical Open CVN JSON representation defined in issue #46."
         ),
         "title": "Open CVN JSON Schema",
         "type": "object",
@@ -93,7 +100,7 @@ def build_json_schema_metadata(
         "x-open-cvn-policy-name": inventory.policy_name,
         "x-open-cvn-policy-version": inventory.policy_version,
         "x-open-cvn-schema-version": OPEN_CVN_SCHEMA_VERSION,
-        "x-open-cvn-source-issue": "#45",
+        "x-open-cvn-source-issue": "#46",
     }
 
 
@@ -152,7 +159,112 @@ def build_controlled_reference_schema(attribute: ConceptualAttribute) -> dict[st
         "properties": {
             "code": code_schema,
             "label": {"type": ["string", "null"]},
+            "raw_value": {"type": ["string", "null"]},
+            "reference_status": {"type": ["string", "null"]},
+            "source": {"type": ["string", "null"]},
+            "uri": {"type": ["string", "null"]},
         },
+        "type": "object",
+    }
+
+
+def build_metadata_schema(inventory: ConceptualModelInventory) -> dict[str, Any]:
+    return {
+        "additionalProperties": False,
+        "properties": {
+            "created_at": {"type": ["string", "null"]},
+            "generator": {
+                "additionalProperties": False,
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "version": {"type": ["string", "null"]},
+                },
+                "type": "object",
+            },
+            "language": {"type": "string"},
+            "policy": {
+                "additionalProperties": False,
+                "properties": {
+                    "name": {"const": inventory.policy_name, "type": "string"},
+                    "version": {"const": inventory.policy_version, "type": "string"},
+                },
+                "required": ["name", "version"],
+                "type": "object",
+            },
+            "source": {
+                "additionalProperties": True,
+                "properties": {
+                    "format": {"type": ["string", "null"]},
+                },
+                "type": "object",
+            },
+            "updated_at": {"type": ["string", "null"]},
+        },
+        "required": ["language", "policy"],
+        "type": "object",
+    }
+
+
+def build_trace_schema() -> dict[str, Any]:
+    string_array_schema = {"items": {"type": "string"}, "type": "array"}
+    return {
+        "additionalProperties": False,
+        "properties": {
+            "confidence": {"type": ["string", "null"]},
+            "cvn_codes": string_array_schema,
+            "domain_shape_kind": {"type": ["string", "null"]},
+            "manual_reference_table": {"type": ["string", "null"]},
+            "semantic_reference_kind": {"type": ["string", "null"]},
+            "serialization_pattern": {"type": ["string", "null"]},
+            "source_artifacts": string_array_schema,
+            "source_files": string_array_schema,
+            "xml_paths": string_array_schema,
+        },
+        "type": "object",
+    }
+
+
+def build_extensions_schema() -> dict[str, Any]:
+    return {
+        "additionalProperties": True,
+        "type": "object",
+    }
+
+
+def build_entry_schema() -> dict[str, Any]:
+    return {
+        "additionalProperties": False,
+        "properties": {
+            "data": {
+                "additionalProperties": True,
+                "type": "object",
+            },
+            "extensions": build_extensions_schema(),
+            "id": {"type": ["string", "null"]},
+            "trace": build_trace_schema(),
+            "type": {"type": "string"},
+        },
+        "required": ["type", "data"],
+        "type": "object",
+    }
+
+
+def build_curriculum_schema() -> dict[str, Any]:
+    entry_array_schema = {
+        "items": build_entry_schema(),
+        "type": "array",
+    }
+    properties: dict[str, Any] = {
+        "identity": {
+            "additionalProperties": True,
+            "type": "object",
+        }
+    }
+    for section_name in CURRICULUM_SECTION_NAMES:
+        properties[section_name] = entry_array_schema
+    return {
+        "additionalProperties": False,
+        "properties": properties,
         "type": "object",
     }
 
@@ -279,15 +391,14 @@ def build_open_cvn_json_schema(
             "$defs": build_schema_definitions(inventory),
             "additionalProperties": False,
             "properties": {
-                "curriculum": {"$ref": "#/$defs/core.curriculum"},
-                "policy_name": {"const": inventory.policy_name, "type": "string"},
-                "policy_version": {"const": inventory.policy_version, "type": "string"},
+                "curriculum": build_curriculum_schema(),
+                "extensions": build_extensions_schema(),
+                "metadata": build_metadata_schema(inventory),
                 "schema_version": {"const": OPEN_CVN_SCHEMA_VERSION, "type": "string"},
             },
             "required": [
                 "schema_version",
-                "policy_name",
-                "policy_version",
+                "metadata",
                 "curriculum",
             ],
         }

--- a/tests/test_generation_pipeline_json_schema.py
+++ b/tests/test_generation_pipeline_json_schema.py
@@ -56,6 +56,7 @@ def test_json_schema_pipeline_declares_metadata(
     assert schema["title"] == "Open CVN JSON Schema"
     assert schema["x-open-cvn-policy-name"]
     assert schema["x-open-cvn-policy-version"]
+    assert schema["x-open-cvn-source-issue"] == "#46"
 
 
 def test_json_schema_pipeline_contains_core_definitions(
@@ -66,7 +67,19 @@ def test_json_schema_pipeline_contains_core_definitions(
     assert schema["$defs"]
     assert "core.curriculum" in schema["$defs"]
     assert "identity.person" in schema["$defs"]
-    assert schema["properties"]["curriculum"] == {"$ref": "#/$defs/core.curriculum"}
+    assert schema["properties"]["curriculum"]["properties"]["identity"]["type"] == "object"
+    assert schema["properties"]["curriculum"]["properties"]["research"]["type"] == "array"
+
+
+def test_json_schema_pipeline_uses_canonical_root_shape(
+    canonical_normalization_result: NormalizationResult,
+):
+    schema = build_canonical_schema(canonical_normalization_result)
+
+    assert schema["required"] == ["schema_version", "metadata", "curriculum"]
+    assert "policy_name" not in schema["properties"]
+    assert "policy_version" not in schema["properties"]
+    assert schema["properties"]["metadata"]["required"] == ["language", "policy"]
 
 
 def test_json_schema_pipeline_closes_eligible_enum_reference(

--- a/tests/test_json_schema_generator_unit.py
+++ b/tests/test_json_schema_generator_unit.py
@@ -96,6 +96,25 @@ def test_schema_metadata_declares_draft_2020_12():
     assert schema["$id"] == "https://open-cvn.local/schema/open-cvn.schema.json"
     assert schema["title"] == "Open CVN JSON Schema"
     assert schema["x-open-cvn-policy-name"] == "test_policy"
+    assert schema["x-open-cvn-source-issue"] == "#46"
+
+
+def test_schema_root_uses_canonical_open_cvn_format():
+    schema = build_open_cvn_json_schema(build_inventory())
+
+    assert schema["required"] == ["schema_version", "metadata", "curriculum"]
+    assert set(schema["properties"]) == {
+        "schema_version",
+        "metadata",
+        "curriculum",
+        "extensions",
+    }
+    assert schema["properties"]["schema_version"]["const"] == "0.1.0"
+    assert schema["properties"]["metadata"]["properties"]["policy"]["properties"]["name"] == {
+        "const": "test_policy",
+        "type": "string",
+    }
+    assert schema["properties"]["curriculum"]["properties"]["education"]["type"] == "array"
 
 
 def test_optional_string_attribute_allows_null():
@@ -127,6 +146,24 @@ def test_trace_extensions_are_emitted_for_attribute():
     assert schema["x-open-cvn-code"] == "000.010.000.030"
     assert schema["x-open-cvn-xml-paths"] == ["CVN/CvnItem/Value"]
     assert schema["x-open-cvn-source-reference"] == "CVN_SEX_A"
+
+
+def test_controlled_reference_attribute_accepts_canonical_reference_fields():
+    schema = build_schema_for_attribute(
+        build_attribute(
+            value_kind=ConceptualValueKind.CONTROLLED_REFERENCE,
+            presence=ConceptualPresenceKind.REQUIRED,
+        )
+    )
+
+    assert set(schema["properties"]) == {
+        "code",
+        "label",
+        "raw_value",
+        "reference_status",
+        "source",
+        "uri",
+    }
 
 
 def test_schema_generation_is_deterministic_for_same_inventory():

--- a/tests/test_open_cvn_json_format_examples.py
+++ b/tests/test_open_cvn_json_format_examples.py
@@ -1,0 +1,79 @@
+import json
+
+from pathlib import Path
+
+
+EXAMPLES_DIR = Path("examples/open_cvn")
+REQUIRED_CURRICULUM_SECTIONS = {
+    "identity",
+    "education",
+    "research",
+    "professional_experience",
+    "achievements",
+    "other",
+}
+
+
+def load_examples() -> list[tuple[Path, dict]]:
+    examples = []
+    for path in sorted(EXAMPLES_DIR.glob("*.json")):
+        examples.append((path, json.loads(path.read_text(encoding="utf-8"))))
+    return examples
+
+
+def test_open_cvn_examples_exist():
+    assert {path.name for path, _example in load_examples()} == {
+        "controlled_references.json",
+        "education_entry.json",
+        "identity.json",
+        "minimal.json",
+        "research_entry.json",
+        "trace_and_extensions.json",
+    }
+
+
+def test_open_cvn_examples_use_canonical_root_shape():
+    for path, example in load_examples():
+        assert example["schema_version"] == "0.1.0", path
+        assert set(example) <= {"schema_version", "metadata", "curriculum", "extensions"}, path
+        assert "metadata" in example, path
+        assert "curriculum" in example, path
+        assert example["metadata"]["policy"]["name"] == "default_cvn_semantic_policy", path
+        assert example["metadata"]["policy"]["version"] == "0.1.0", path
+
+
+def test_open_cvn_examples_include_expected_curriculum_sections():
+    for path, example in load_examples():
+        curriculum = example["curriculum"]
+        assert REQUIRED_CURRICULUM_SECTIONS <= set(curriculum), path
+        assert isinstance(curriculum["identity"], dict), path
+        for section in REQUIRED_CURRICULUM_SECTIONS - {"identity"}:
+            assert isinstance(curriculum[section], list), (path, section)
+
+
+def test_open_cvn_examples_use_canonical_repeated_entry_shape():
+    for path, example in load_examples():
+        for section_name, entries in example["curriculum"].items():
+            if section_name == "identity":
+                continue
+            for entry in entries:
+                assert "type" in entry, (path, section_name)
+                assert "data" in entry, (path, section_name)
+                assert set(entry) <= {"id", "type", "data", "trace", "extensions"}, (
+                    path,
+                    section_name,
+                )
+
+
+def test_controlled_reference_example_records_open_and_unresolved_references():
+    example = json.loads(
+        (EXAMPLES_DIR / "controlled_references.json").read_text(encoding="utf-8")
+    )
+
+    identity = example["curriculum"]["identity"]
+    agency = example["curriculum"]["research"][0]["data"]["agency"]
+
+    assert identity["sex"]["source"] == "CVN_SEX_A"
+    assert identity["entity_type"]["source"] == "CVN_ENTITY_TYPE"
+    assert agency["source"] == "CVN_AGENCY_C"
+    assert agency["reference_status"] == "unresolved"


### PR DESCRIPTION
## Summary

- define canonical Open CVN JSON root, metadata, curriculum sections, entries, trace, extensions, and versioning
- add mapping notes from conceptual inventory/schema annotations to runtime JSON
- add representative Open CVN JSON examples
- align JSON Schema generator and generated schema with issue #46 root shape
- add tests for canonical schema root and examples
- update roadmap, status, limitations, and guide docs

## Verification

- `uv run python -m cvn_codegen.json_schema_generator`
- `uv run pytest -n auto tests/test_json_schema_generator_unit.py tests/test_generation_pipeline_json_schema.py tests/test_open_cvn_json_format_examples.py -v`
- `uv run pytest -n auto tests`

closes #46 