### PR TITLE
Issue 47 define unified parser and validator contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Every new session should read these files in order before making changes:
 - conceptual extraction: `docs/pipeline/conceptual_model_extraction.md`
 - conceptual diagrams: `docs/diagrams/`
 - JSON Schema generation: `docs/pipeline/json_schema_generation.md`
+- parser/validator contract: `docs/pipeline/parser_validator_contract.md`
 - known limitations: `docs/pipeline/known_limitations.md`
 - architecture decisions: `docs/adr/`
 
@@ -62,6 +63,14 @@ Every new session should read these files in order before making changes:
   `docs/roadmap/issues/issue-43-agnostic-conceptual-model-extraction-layer.md`
 - issue `#45`:
   `docs/roadmap/issues/issue-45-generate-json-schema-from-domain-models.md`
+- issue `#46`:
+  `docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md`
+- issue `#47`:
+  `docs/roadmap/issues/issue-47-unified-parser-validator-contract.md`
+- issue `#48`:
+  `docs/roadmap/issues/issue-48-cvn-pdf-xml-extraction.md`
+- issue `#49`:
+  `docs/roadmap/issues/issue-49-xml-json-import-validation.md`
 - hotfix `#1`: `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`
 - hotfix `#2`: `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`
 - hotfix `#3`:

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -120,6 +120,10 @@ files in order:
   authoritative record of issue `#46`
 - `docs/roadmap/issues/issue-47-unified-parser-validator-contract.md`:
   authoritative record of issue `#47`
+- `docs/roadmap/issues/issue-48-cvn-pdf-xml-extraction.md`: authoritative
+  record of issue `#48`
+- `docs/roadmap/issues/issue-49-xml-json-import-validation.md`: planned scope of
+  issue `#49`
 - `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`: maintenance
   record for the runner logging convention update
 - `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`: maintenance

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -84,6 +84,8 @@ files in order:
   document format
 - `docs/pipeline/open_cvn_json_mapping.md`: issue `#46` mapping notes from the
   conceptual inventory and schema annotations to runtime JSON
+- `docs/pipeline/parser_validator_contract.md`: issue `#47` public parser and
+  validator contract for future PDF, XML, and JSON import work
 - `schemas/open_cvn.schema.json`: generated issue `#45` JSON Schema artifact
 - `examples/open_cvn/`: representative issue `#46` Open CVN JSON examples
 - `docs/pipeline/known_limitations.md`: structural limitations, source-package
@@ -116,6 +118,8 @@ files in order:
   authoritative record of issue `#43`
 - `docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md`:
   authoritative record of issue `#46`
+- `docs/roadmap/issues/issue-47-unified-parser-validator-contract.md`:
+  authoritative record of issue `#47`
 - `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`: maintenance
   record for the runner logging convention update
 - `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`: maintenance

--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -588,6 +588,42 @@
 - full-suite verification result:
   `348 passed in 857.18s (0:14:17)`
 
+### Issue `#48`
+
+- deterministic CVN XML extraction from PDF inputs is implemented behind the
+  public issue `#47` contract
+- the PDF extraction helper exists at:
+  - `src/open_cvn/pdf_xml_extraction.py`
+- `parse_cvn_pdf(...)` in `src/open_cvn/parser_contract.py` now accepts PDF paths
+  and PDF bytes and returns `CvnParseResult`
+- PyMuPDF is now a runtime dependency for PDF embedded-file and XML metadata
+  access
+- implemented extraction sources are:
+  - embedded PDF files
+  - PDF XML metadata when it contains CVN XML evidence
+- extracted candidates must be well-formed XML and plausibly CVN-related before
+  being returned
+- successful PDF extraction returns `validation_status=not_run` because XML
+  import, XML-to-domain mapping, and Open CVN validation remain deferred to issue
+  `#49`
+- PDF failure behavior is structured through the issue `#47` error contract:
+  - unreadable PDF inputs return `unreadable_file`
+  - readable PDFs without extractable CVN XML return
+    `pdf_without_extractable_xml`
+  - unsupported input shapes return `unsupported_input_format`
+- no OCR, page text reconstruction, LLM reconstruction, or domain validation is
+  attempted in the PDF path
+- synthetic PyMuPDF PDF tests cover embedded XML, XML metadata, PDFs without XML,
+  unreadable inputs, unsupported mapping inputs, and no page-text fallback
+- targeted issue `#48` verification passed with:
+  `uv run pytest -n auto tests/test_pdf_xml_extraction_unit.py tests/test_parser_validator_contract_unit.py -v`
+- targeted verification result:
+  `20 passed in 2.64s`
+- full-suite verification passed with:
+  `uv run pytest -n auto tests`
+- full-suite verification result:
+  `354 passed in 850.95s (0:14:10)`
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -599,10 +635,8 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#47` closure: issue `#48`, implement CVN PDF XML
-  extraction behind the unified parser contract
-- Issue `#49` should later implement XML and JSON import validation behind the
-  same issue `#47` contract
+- Next work item after issue `#48` closure: issue `#49`, implement XML and JSON
+  import validation behind the same issue `#47` contract
 
 ## Blocking Or Relevant Limitations
 

--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -553,6 +553,41 @@
 - full-suite verification result:
   `334 passed in 890.21s (0:14:50)`
 
+### Issue `#47`
+
+- the unified parser and validator contract is implemented under:
+  - `src/open_cvn/`
+- the public contract module is:
+  - `src/open_cvn/parser_contract.py`
+- the public package exports:
+  - `CvnSourceFormat`
+  - `CvnValidationStatus`
+  - `CvnIssueSeverity`
+  - `CvnErrorCode`
+  - `CvnParseIssue`
+  - `CvnParseTrace`
+  - `CvnParseResult`
+  - `parse_cvn_pdf(...)`
+  - `parse_cvn_xml(...)`
+  - `parse_open_cvn_json(...)`
+  - `validate_open_cvn_json(...)`
+- public parser and validator functions intentionally raise `NotImplementedError`
+  because real parsing and validation are deferred to issues `#48` and `#49`
+- parser result invariants now require error-bearing results to use `invalid` or
+  `failed`, and `valid_with_warnings` results to include warning issues
+- the contract documentation exists at:
+  - `docs/pipeline/parser_validator_contract.md`
+- contract-only tests exist at:
+  - `tests/test_parser_validator_contract_unit.py`
+- targeted issue `#47` verification passed with:
+  `uv run pytest -n auto tests/test_parser_validator_contract_unit.py -v`
+- targeted verification result:
+  `14 passed in 2.07s`
+- full-suite verification passed with:
+  `uv run pytest -n auto tests`
+- full-suite verification result:
+  `348 passed in 857.18s (0:14:17)`
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -564,10 +599,10 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#46` closure: issue `#47`, define the unified parser
-  and validator contract
-- Issue `#47` should consume the issue `#46` canonical Open CVN JSON format and
-  distinguish parser contracts from concrete XML/PDF/JSON import implementations
+- Next work item after issue `#47` closure: issue `#48`, implement CVN PDF XML
+  extraction behind the unified parser contract
+- Issue `#49` should later implement XML and JSON import validation behind the
+  same issue `#47` contract
 
 ## Blocking Or Relevant Limitations
 
@@ -648,18 +683,19 @@ Then continue with these supporting files as needed:
 5. `docs/roadmap/issues/issue-25-github-actions-ci-pipeline-for-pr-testing-on-main-and-development.md`
 6. `docs/development/regeneration_workflow.md`
 7. `docs/pipeline/known_limitations.md`
-8. `docs/roadmap/hotfixes/`
-9. `docs/cvn_source_package_auxiliary_artifacts.md`
-10. `docs/cvn_source_package_annex_table_coverage.md`
-11. `docs/cvn_annex_priority_table_families.md`
-12. `docs/cvn_annex_table_families_batch3.md`
-13. `docs/cvn_annex_table_families_batch4.md`
-14. `docs/cvn_annex_table_families_batch5.md`
-15. `docs/cvn_annex_table_families_batch6.md`
-16. `docs/cvn_annex_table_families_batch7.md`
-17. `docs/cvn_annex_table_families_batch8.md`
-18. `docs/cvn_serialization_patterns_reference.md`
-19. `docs/cvn_field_reference_traceability.md`
-20. `docs/roadmap/hotfixes/hotfix-4-structural-scope-correction-for-auxiliary-source-package-artifacts.md`
-21. `docs/roadmap/hotfixes/hotfix-5-normalization-resolution-layer-for-auxiliary-reference-sources.md`
-22. `docs/roadmap/hotfixes/hotfix-6-roadmap-realignment-for-auxiliary-catalog-semantic-integration.md`
+8. `docs/pipeline/parser_validator_contract.md`
+9. `docs/roadmap/hotfixes/`
+10. `docs/cvn_source_package_auxiliary_artifacts.md`
+11. `docs/cvn_source_package_annex_table_coverage.md`
+12. `docs/cvn_annex_priority_table_families.md`
+13. `docs/cvn_annex_table_families_batch3.md`
+14. `docs/cvn_annex_table_families_batch4.md`
+15. `docs/cvn_annex_table_families_batch5.md`
+16. `docs/cvn_annex_table_families_batch6.md`
+17. `docs/cvn_annex_table_families_batch7.md`
+18. `docs/cvn_annex_table_families_batch8.md`
+19. `docs/cvn_serialization_patterns_reference.md`
+20. `docs/cvn_field_reference_traceability.md`
+21. `docs/roadmap/hotfixes/hotfix-4-structural-scope-correction-for-auxiliary-source-package-artifacts.md`
+22. `docs/roadmap/hotfixes/hotfix-5-normalization-resolution-layer-for-auxiliary-reference-sources.md`
+23. `docs/roadmap/hotfixes/hotfix-6-roadmap-realignment-for-auxiliary-catalog-semantic-integration.md`

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -32,9 +32,9 @@ Agents should also read `AGENTS.md` before this file.
   semantic policy, domain generation, conceptual schema, Open CVN JSON format,
   and parser/validator contract completed
 - Last documented issues: `#11`, `#12`, `#13`, `#14`, `#15`, `#16`, `#17`,
-  `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, and `#47`
+  `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, `#47`, and `#48`
 - Latest documented hotfix records: `#3`, `#4`, `#5`, `#6`, `#7`, `#8`
-- Next planned issue: `#48`
+- Next planned issue: `#49`
 - Canonical source package: `docs/CvnXML_v1.4.3_2.1_17012025/`
 
 ## Documentation Map

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -29,10 +29,12 @@ Agents should also read `AGENTS.md` before this file.
 
 - Project: open CVN schema and tooling for Spanish academic CV processing
 - Current pipeline stage: structural generation, metadata normalization,
-  semantic policy, and domain generation completed
-- Last documented issues: `#11`, `#12`, `#13`, `#14`, `#15`, and `#25`
+  semantic policy, domain generation, conceptual schema, Open CVN JSON format,
+  and parser/validator contract completed
+- Last documented issues: `#11`, `#12`, `#13`, `#14`, `#15`, `#16`, `#17`,
+  `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, and `#47`
 - Latest documented hotfix records: `#3`, `#4`, `#5`, `#6`, `#7`, `#8`
-- Next planned issue: `#16`
+- Next planned issue: `#48`
 - Canonical source package: `docs/CvnXML_v1.4.3_2.1_17012025/`
 
 ## Documentation Map
@@ -59,6 +61,8 @@ Agents should also read `AGENTS.md` before this file.
   document format
 - `docs/pipeline/open_cvn_json_mapping.md`: issue `#46` mapping notes from the
   conceptual inventory and schema annotations to runtime JSON
+- `docs/pipeline/parser_validator_contract.md`: issue `#47` public parser and
+  validator contract for future PDF, XML, and JSON import work
 - `examples/open_cvn/`: representative issue `#46` Open CVN JSON examples
 - `docs/pipeline/known_limitations.md`: structural limitations, detected
   discrepancies, and follow-up implications
@@ -91,6 +95,12 @@ Agents should also read `AGENTS.md` before this file.
   implementation record for issue `#45`
 - `docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md`:
   implementation record for issue `#46`
+- `docs/roadmap/issues/issue-47-unified-parser-validator-contract.md`:
+  implementation record for issue `#47`
+- `docs/roadmap/issues/issue-48-cvn-pdf-xml-extraction.md`: planned scope of
+  issue `#48`
+- `docs/roadmap/issues/issue-49-xml-json-import-validation.md`: planned scope of
+  issue `#49`
 - `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`: maintenance
   record for the runner logging convention update
 - `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`: maintenance

--- a/docs/pipeline/parser_validator_contract.md
+++ b/docs/pipeline/parser_validator_contract.md
@@ -53,15 +53,15 @@ parse_open_cvn_json(source, *, source_identifier=None) -> CvnParseResult
 validate_open_cvn_json(document, *, source_identifier=None) -> CvnParseResult
 ```
 
-In issue `#47`, these functions intentionally raise `NotImplementedError` with
+In issue `#47`, these functions intentionally raised `NotImplementedError` with
 this message:
 
 ```text
 Parser implementation is deferred to issue #48/#49.
 ```
 
-This makes the public contract importable without pretending that parsing already
-exists.
+Issue `#48` implements `parse_cvn_pdf(...)` for deterministic PDF XML
+extraction. The XML and JSON entry points remain deferred to issue `#49`.
 
 ## Source Formats
 
@@ -146,16 +146,30 @@ identity when available. Open CVN JSON validation should preserve
 
 ### PDF
 
-Issue `#48` should implement PDF handling behind `parse_cvn_pdf(...)`.
+Issue `#48` implements PDF handling behind `parse_cvn_pdf(...)`.
 
 Responsibilities:
 
 - read PDF input
-- extract embedded or recoverable CVN XML when possible
+- extract embedded-file CVN XML when possible
+- extract PDF XML metadata when it contains CVN XML evidence
+- validate only that the extracted candidate is well-formed and plausibly
+  CVN-related
 - return `pdf_without_extractable_xml` when no XML can be extracted
-- delegate XML interpretation to the XML import path
+- leave XML interpretation to the issue `#49` XML import path
 
-PDF parsing must not become the domain validator.
+PDF parsing is not the domain validator. It does not perform OCR, page text
+reconstruction, LLM reconstruction, XML-to-domain mapping, Open CVN JSON
+validation, or JSON Schema validation.
+
+Successful PDF extraction returns `validation_status="not_run"` because issue
+`#48` extracts XML but does not validate the XML against the future import path.
+The result `data` contains:
+
+- `xml_text`: extracted XML text
+- `extraction`: metadata such as source kind, source name, byte size,
+  embedded-file count, candidate count, metadata presence, and metadata xref when
+  available
 
 ### XML
 
@@ -271,6 +285,42 @@ Responsibilities:
     "cvn_codes": [],
     "xml_paths": [],
     "schema_version": "0.1.0",
+    "policy_name": null,
+    "policy_version": null
+  }
+}
+```
+
+### Successful PDF XML Extraction
+
+```json
+{
+  "source_format": "pdf",
+  "source_identifier": "cvn.pdf",
+  "data": {
+    "xml_text": "<CVNRoot />",
+    "extraction": {
+      "source_kind": "embedded_file",
+      "source_name": "cvn.xml",
+      "source_index": 0,
+      "xml_bytes_size": 11,
+      "metadata_xref": null,
+      "embedded_file_count": 1,
+      "candidate_count": 1,
+      "metadata_present": false
+    }
+  },
+  "validation_status": "not_run",
+  "warnings": [],
+  "errors": [],
+  "trace": {
+    "source_format": "pdf",
+    "source_identifier": "cvn.pdf",
+    "source_path": "cvn.pdf",
+    "extracted_from": "embedded_file:cvn.xml",
+    "cvn_codes": [],
+    "xml_paths": [],
+    "schema_version": null,
     "policy_name": null,
     "policy_version": null
   }

--- a/docs/pipeline/parser_validator_contract.md
+++ b/docs/pipeline/parser_validator_contract.md
@@ -1,0 +1,358 @@
+# Parser And Validator Contract
+
+## Purpose
+
+This document records the issue `#47` public parser and validator contract for
+future PDF, XML, and Open CVN JSON imports.
+
+Issue `#47` defines the public API, result structures, error taxonomy, and trace
+rules. It does not implement real PDF extraction, XML parsing, JSON Schema
+validation, or domain mapping. Those responsibilities are deferred to issues
+`#48` and `#49`.
+
+## Public Package
+
+The public runtime package is:
+
+```text
+src/open_cvn/
+```
+
+The contract implementation lives in:
+
+```text
+src/open_cvn/parser_contract.py
+```
+
+The package exports the contract through:
+
+```python
+from open_cvn import (
+    CvnErrorCode,
+    CvnIssueSeverity,
+    CvnParseIssue,
+    CvnParseResult,
+    CvnParseTrace,
+    CvnSourceFormat,
+    CvnValidationStatus,
+    parse_cvn_pdf,
+    parse_cvn_xml,
+    parse_open_cvn_json,
+    validate_open_cvn_json,
+)
+```
+
+## Public Functions
+
+The public parser and validator entry points are:
+
+```python
+parse_cvn_pdf(source, *, source_identifier=None) -> CvnParseResult
+parse_cvn_xml(source, *, source_identifier=None) -> CvnParseResult
+parse_open_cvn_json(source, *, source_identifier=None) -> CvnParseResult
+validate_open_cvn_json(document, *, source_identifier=None) -> CvnParseResult
+```
+
+In issue `#47`, these functions intentionally raise `NotImplementedError` with
+this message:
+
+```text
+Parser implementation is deferred to issue #48/#49.
+```
+
+This makes the public contract importable without pretending that parsing already
+exists.
+
+## Source Formats
+
+`CvnSourceFormat` values are stable JSON-serializable strings:
+
+- `pdf`
+- `cvn_xml`
+- `open_cvn_json`
+
+## Validation Status
+
+`CvnValidationStatus` values are:
+
+- `not_run`: validation was not attempted
+- `valid`: input was accepted without warnings
+- `valid_with_warnings`: input was accepted with warnings
+- `invalid`: processing completed far enough to classify the input as invalid
+- `failed`: processing could not complete
+
+## Error Codes
+
+`CvnErrorCode` values are:
+
+- `unsupported_input_format`
+- `unreadable_file`
+- `pdf_without_extractable_xml`
+- `invalid_xml`
+- `xml_semantically_unmappable`
+- `invalid_json`
+- `json_schema_validation_failure`
+- `pydantic_validation_failure`
+
+Errors and warnings share `CvnParseIssue`, but their severity differs.
+
+## Result Structure
+
+Parser and validator functions return `CvnParseResult` once concrete
+implementation exists.
+
+Canonical fields:
+
+- `source_format`
+- `source_identifier`
+- `data`
+- `validation_status`
+- `warnings`
+- `errors`
+- `trace`
+
+Contract invariants:
+
+- results with errors must use `invalid` or `failed`
+- `valid_with_warnings` results must include at least one warning
+- `warnings` must contain warning-severity issues
+- `errors` must contain error-severity issues
+- `data` remains broad in issue `#47`; concrete validated object shapes are
+  finalized by later implementation work
+
+## Trace Rules
+
+`CvnParseTrace` preserves source and Open CVN evidence.
+
+Canonical fields:
+
+- `source_format`
+- `source_identifier`
+- `source_path`
+- `extracted_from`
+- `cvn_codes`
+- `xml_paths`
+- `schema_version`
+- `policy_name`
+- `policy_version`
+
+Trace is metadata. It must not change curriculum values.
+
+PDF extraction should preserve both the PDF identity and the extracted XML
+identity when available. Open CVN JSON validation should preserve
+`schema_version` and `metadata.policy` values when present.
+
+## Source-Specific Responsibilities
+
+### PDF
+
+Issue `#48` should implement PDF handling behind `parse_cvn_pdf(...)`.
+
+Responsibilities:
+
+- read PDF input
+- extract embedded or recoverable CVN XML when possible
+- return `pdf_without_extractable_xml` when no XML can be extracted
+- delegate XML interpretation to the XML import path
+
+PDF parsing must not become the domain validator.
+
+### XML
+
+Issue `#49` should implement CVN XML import behind `parse_cvn_xml(...)`.
+
+Responsibilities:
+
+- read CVN XML input
+- classify unreadable input separately from invalid XML
+- preserve CVN XML trace where possible
+- report `xml_semantically_unmappable` when structurally readable XML cannot map
+  to Open CVN/domain representation
+
+### JSON
+
+Issue `#49` should implement Open CVN JSON import behind
+`parse_open_cvn_json(...)` and `validate_open_cvn_json(...)`.
+
+Responsibilities:
+
+- classify malformed JSON as `invalid_json`
+- validate the canonical issue `#46` root shape
+- use the generated `schemas/open_cvn.schema.json` artifact for JSON Schema
+  validation when the validation dependency is introduced
+- distinguish JSON Schema validation failures from Pydantic/runtime validation
+  failures
+
+## Examples
+
+### Successful Open CVN JSON Validation
+
+```json
+{
+  "source_format": "open_cvn_json",
+  "source_identifier": "examples/open_cvn/minimal.json",
+  "data": {
+    "schema_version": "0.1.0"
+  },
+  "validation_status": "valid",
+  "warnings": [],
+  "errors": [],
+  "trace": {
+    "source_format": "open_cvn_json",
+    "source_identifier": "examples/open_cvn/minimal.json",
+    "source_path": "examples/open_cvn/minimal.json",
+    "extracted_from": null,
+    "cvn_codes": [],
+    "xml_paths": [],
+    "schema_version": "0.1.0",
+    "policy_name": "default_cvn_semantic_policy",
+    "policy_version": "0.1.0"
+  }
+}
+```
+
+### Invalid JSON
+
+```json
+{
+  "source_format": "open_cvn_json",
+  "source_identifier": "broken.json",
+  "data": null,
+  "validation_status": "failed",
+  "warnings": [],
+  "errors": [
+    {
+      "code": "invalid_json",
+      "severity": "error",
+      "message": "Input is not valid JSON.",
+      "source_location": "line 1 column 2",
+      "path": [],
+      "details": {}
+    }
+  ],
+  "trace": {
+    "source_format": "open_cvn_json",
+    "source_identifier": "broken.json",
+    "source_path": "broken.json",
+    "extracted_from": null,
+    "cvn_codes": [],
+    "xml_paths": [],
+    "schema_version": null,
+    "policy_name": null,
+    "policy_version": null
+  }
+}
+```
+
+### JSON Schema Validation Failure
+
+```json
+{
+  "source_format": "open_cvn_json",
+  "source_identifier": "wrong-shape.json",
+  "data": null,
+  "validation_status": "invalid",
+  "warnings": [],
+  "errors": [
+    {
+      "code": "json_schema_validation_failure",
+      "severity": "error",
+      "message": "Open CVN JSON does not match the generated schema.",
+      "source_location": null,
+      "path": ["curriculum"],
+      "details": {}
+    }
+  ],
+  "trace": {
+    "source_format": "open_cvn_json",
+    "source_identifier": "wrong-shape.json",
+    "source_path": "wrong-shape.json",
+    "extracted_from": null,
+    "cvn_codes": [],
+    "xml_paths": [],
+    "schema_version": "0.1.0",
+    "policy_name": null,
+    "policy_version": null
+  }
+}
+```
+
+### PDF Without Extractable XML
+
+```json
+{
+  "source_format": "pdf",
+  "source_identifier": "cvn.pdf",
+  "data": null,
+  "validation_status": "failed",
+  "warnings": [],
+  "errors": [
+    {
+      "code": "pdf_without_extractable_xml",
+      "severity": "error",
+      "message": "PDF does not contain extractable CVN XML.",
+      "source_location": null,
+      "path": [],
+      "details": {}
+    }
+  ],
+  "trace": {
+    "source_format": "pdf",
+    "source_identifier": "cvn.pdf",
+    "source_path": "cvn.pdf",
+    "extracted_from": null,
+    "cvn_codes": [],
+    "xml_paths": [],
+    "schema_version": null,
+    "policy_name": null,
+    "policy_version": null
+  }
+}
+```
+
+### XML Semantically Unmappable
+
+```json
+{
+  "source_format": "cvn_xml",
+  "source_identifier": "cvn.xml",
+  "data": null,
+  "validation_status": "invalid",
+  "warnings": [],
+  "errors": [
+    {
+      "code": "xml_semantically_unmappable",
+      "severity": "error",
+      "message": "CVN XML is readable but cannot be mapped to Open CVN JSON.",
+      "source_location": null,
+      "path": ["CVNRoot"],
+      "details": {}
+    }
+  ],
+  "trace": {
+    "source_format": "cvn_xml",
+    "source_identifier": "cvn.xml",
+    "source_path": "cvn.xml",
+    "extracted_from": null,
+    "cvn_codes": [],
+    "xml_paths": ["CVNRoot"],
+    "schema_version": null,
+    "policy_name": null,
+    "policy_version": null
+  }
+}
+```
+
+## Verification
+
+Issue `#47` verification should use contract-only tests:
+
+```bash
+uv run pytest -n auto tests/test_parser_validator_contract_unit.py -v
+```
+
+Default repository verification remains:
+
+```bash
+uv run pytest -n auto tests
+```

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -41,6 +41,9 @@ Goal:
 | `#44` | Generate UML or UML-like diagrams | Completed | PlantUML now emits readable and reference views under `docs/diagrams/`; Mermaid remains optional future output |
 | `#45` | Generate JSON Schema from domain models | Completed | JSON Schema Draft 2020-12 artifact now generated from conceptual inventory under `schemas/open_cvn.schema.json` |
 | `#46` | Define canonical Open CVN JSON format | Completed | Canonical root, metadata, curriculum sections, entries, trace, extensions, examples, and schema alignment implemented |
+| `#47` | Define unified parser and validator contract | Completed | Public `open_cvn` contract package, structured result/error/trace models, deferred parser signatures, docs, and tests implemented |
+| `#48` | Extract CVN XML from PDF inputs | Planned | Should implement PDF XML extraction behind the issue `#47` contract |
+| `#49` | Validate XML and JSON import paths | Planned | Should implement CVN XML and Open CVN JSON import validation behind the issue `#47` contract |
 
 Corrective planning after hotfixes `#4`, `#5`, and `#6`:
 

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -42,7 +42,7 @@ Goal:
 | `#45` | Generate JSON Schema from domain models | Completed | JSON Schema Draft 2020-12 artifact now generated from conceptual inventory under `schemas/open_cvn.schema.json` |
 | `#46` | Define canonical Open CVN JSON format | Completed | Canonical root, metadata, curriculum sections, entries, trace, extensions, examples, and schema alignment implemented |
 | `#47` | Define unified parser and validator contract | Completed | Public `open_cvn` contract package, structured result/error/trace models, deferred parser signatures, docs, and tests implemented |
-| `#48` | Extract CVN XML from PDF inputs | Planned | Should implement PDF XML extraction behind the issue `#47` contract |
+| `#48` | Extract CVN XML from PDF inputs | Completed | Deterministic PDF XML extraction implemented behind `parse_cvn_pdf(...)` with embedded-file and XML metadata support |
 | `#49` | Validate XML and JSON import paths | Planned | Should implement CVN XML and Open CVN JSON import validation behind the issue `#47` contract |
 
 Corrective planning after hotfixes `#4`, `#5`, and `#6`:

--- a/docs/roadmap/issues/issue-47-unified-parser-validator-contract.md
+++ b/docs/roadmap/issues/issue-47-unified-parser-validator-contract.md
@@ -61,11 +61,550 @@ Errors should distinguish:
 6. document examples of success and failure cases
 7. add unit tests if implementation is approved
 
+## Accepted Execution Plan
+
+Issue `#47` is a contract-definition issue. It must not implement real PDF
+extraction, XML import, Open CVN JSON validation, JSON Schema execution, or
+domain mapping. Concrete runtime behavior is deferred to issues `#48` and `#49`.
+
+The accepted public package location for the contract is:
+
+```text
+src/open_cvn/
+```
+
+### Task 1 - Confirm Scope And Boundaries
+
+Summary:
+
+- confirm that this issue defines the parser and validator contract only
+- confirm that concrete parsing and validation implementations remain out of
+  scope
+- confirm that `src/open_cvn/` is the future public runtime package
+
+Subtasks:
+
+1.1. Re-read issue `#47`, issue `#46` format docs, JSON Schema generation docs,
+and current limitations before editing code.
+
+1.2. Record that this issue may create typed structures and public signatures,
+but must not parse real PDF, XML, or JSON inputs beyond contract-level stubs.
+
+1.3. Record that `src/generated/` must not be edited.
+
+User file modifications required:
+
+- none during this task
+
+Next step:
+
+- proceed to the public package and type contract design.
+
+### Task 2 - Define Public Package Shape
+
+Summary:
+
+- create the public namespace that later application code and importers will use
+- keep it separate from code generation internals
+
+Subtasks:
+
+2.1. Create `src/open_cvn/__init__.py`.
+
+2.2. Create `src/open_cvn/parser_contract.py`.
+
+2.3. Export the accepted contract symbols from `src/open_cvn/__init__.py`.
+
+2.4. Do not move existing `src/cvn_codegen/` logic and do not expose generated
+model modules as the parser contract.
+
+User file modifications required:
+
+- code files must be created when implementation begins, unless the user asks the
+  agent to write them
+
+Next step:
+
+- define enums and structured issue models inside the contract module.
+
+### Task 3 - Define Source, Status, Severity, And Error Enums
+
+Summary:
+
+- define stable machine-readable constants for all parser and validator outcomes
+- make later issues depend on enum values instead of ad hoc strings
+
+Subtasks:
+
+3.1. Define `CvnSourceFormat` with at least:
+
+- `pdf`
+- `cvn_xml`
+- `open_cvn_json`
+
+3.2. Define `CvnValidationStatus` with at least:
+
+- `not_run`
+- `valid`
+- `valid_with_warnings`
+- `invalid`
+- `failed`
+
+3.3. Define `CvnIssueSeverity` with at least:
+
+- `warning`
+- `error`
+
+3.4. Define `CvnErrorCode` with at least:
+
+- `unsupported_input_format`
+- `unreadable_file`
+- `pdf_without_extractable_xml`
+- `invalid_xml`
+- `xml_semantically_unmappable`
+- `invalid_json`
+- `json_schema_validation_failure`
+- `pydantic_validation_failure`
+
+3.5. Keep enum values lowercase and stable for JSON serialization.
+
+User file modifications required:
+
+- code edits required during implementation if user keeps manual-code ownership
+
+Next step:
+
+- define typed warning/error, trace, and result structures.
+
+### Task 4 - Define Structured Warning And Error Model
+
+Summary:
+
+- create one common issue structure usable by PDF, XML, and JSON paths
+- preserve location and diagnostic detail without source-specific exception leaks
+
+Subtasks:
+
+4.1. Define `CvnParseIssue` as a Pydantic model or dataclass.
+
+4.2. Include fields:
+
+- `code`
+- `severity`
+- `message`
+- `source_location`
+- `path`
+- `details`
+
+4.3. Make `code` use `CvnErrorCode`.
+
+4.4. Make `severity` use `CvnIssueSeverity`.
+
+4.5. Keep `details` open enough for later parser-specific metadata, but avoid
+raw exception objects.
+
+User file modifications required:
+
+- code edits required during implementation if user keeps manual-code ownership
+
+Next step:
+
+- define trace metadata carried by every parser result.
+
+### Task 5 - Define Trace Preservation Model
+
+Summary:
+
+- make source trace explicit and portable across PDF, XML, and JSON inputs
+- align runtime trace with issue `#46` Open CVN JSON trace rules
+
+Subtasks:
+
+5.1. Define `CvnParseTrace` as a Pydantic model or dataclass.
+
+5.2. Include source-level fields:
+
+- `source_format`
+- `source_identifier`
+- `source_path`
+- `extracted_from`
+
+5.3. Include Open CVN/domain trace fields:
+
+- `cvn_codes`
+- `xml_paths`
+- `schema_version`
+- `policy_name`
+- `policy_version`
+
+5.4. Document that trace is metadata and must not change semantic curriculum
+values.
+
+5.5. Document that PDF extraction should retain both PDF identity and extracted
+XML identity when available.
+
+User file modifications required:
+
+- code edits required during implementation if user keeps manual-code ownership
+
+Next step:
+
+- define unified parser result structure.
+
+### Task 6 - Define Unified Result Contract
+
+Summary:
+
+- create common result envelope for parser and validator functions
+- allow successful, warning, invalid, and failed states to share one shape
+
+Subtasks:
+
+6.1. Define `CvnParseResult` as a Pydantic model or dataclass.
+
+6.2. Include fields:
+
+- `source_format`
+- `source_identifier`
+- `data`
+- `validation_status`
+- `warnings`
+- `errors`
+- `trace`
+
+6.3. Define `data` as deliberately broad for issue `#47`, because concrete
+domain or JSON object types are finalized by later implementation issues.
+
+6.4. Document expected invariants:
+
+- `errors` not empty means `validation_status` is `invalid` or `failed`
+- warnings may coexist with `valid_with_warnings`
+- `failed` means processing could not complete
+- `invalid` means processing completed enough to classify bad input
+
+6.5. Avoid validating the Open CVN JSON Schema in this issue.
+
+User file modifications required:
+
+- code edits required during implementation if user keeps manual-code ownership
+
+Next step:
+
+- define public function signatures.
+
+### Task 7 - Define Public Parser And Validator Function Signatures
+
+Summary:
+
+- expose stable API entry points without implementing parsing logic yet
+- make issues `#48` and `#49` implement behind those signatures
+
+Subtasks:
+
+7.1. Define `parse_cvn_pdf(...) -> CvnParseResult`.
+
+7.2. Define `parse_cvn_xml(...) -> CvnParseResult`.
+
+7.3. Define `parse_open_cvn_json(...) -> CvnParseResult`.
+
+7.4. Define `validate_open_cvn_json(...) -> CvnParseResult`.
+
+7.5. Accept flexible input types for future implementation:
+
+- `Path`
+- `str`
+- `bytes`
+- `Mapping[str, Any]` where applicable
+
+7.6. Each function should raise `NotImplementedError` with a clear message such
+as:
+
+```text
+Parser implementation is deferred to issue #48/#49.
+```
+
+7.7. Do not silently return fake success results from unimplemented functions.
+
+User file modifications required:
+
+- code edits required during implementation if user keeps manual-code ownership
+
+Next step:
+
+- document source-specific responsibilities.
+
+### Task 8 - Document Source-Specific Responsibilities
+
+Summary:
+
+- separate extraction, loading, schema validation, and domain validation concerns
+- prevent later issues from mixing PDF extraction with domain validation
+
+Subtasks:
+
+8.1. Document PDF responsibility:
+
+- detect/read PDF input
+- extract embedded or recoverable CVN XML when possible
+- emit `pdf_without_extractable_xml` when no XML can be extracted
+- delegate XML interpretation to XML import path
+
+8.2. Document XML responsibility:
+
+- read CVN XML input
+- classify unreadable or invalid XML
+- preserve XML paths and CVN trace when possible
+- report `xml_semantically_unmappable` when structure exists but cannot map to
+  Open CVN/domain representation
+
+8.3. Document JSON responsibility:
+
+- read Open CVN JSON input
+- classify invalid JSON separately from schema validation failure
+- validate against canonical issue `#46` root shape and issue `#45/#46` schema in
+  issue `#49`
+
+8.4. Document validator responsibility:
+
+- validate already-loaded Open CVN JSON-like objects
+- distinguish JSON Schema validation failure from Pydantic/runtime validation
+  failure
+
+User file modifications required:
+
+- documentation edits required during implementation if user keeps manual-doc
+  ownership
+
+Next step:
+
+- write examples of expected success and failure results.
+
+### Task 9 - Document Contract Examples
+
+Summary:
+
+- make contract behavior concrete without implementing parser internals
+- give issues `#48` and `#49` regression targets
+
+Subtasks:
+
+9.1. Document successful Open CVN JSON validation result shape.
+
+9.2. Document invalid JSON result shape using `invalid_json`.
+
+9.3. Document JSON Schema failure result shape using
+`json_schema_validation_failure`.
+
+9.4. Document PDF-without-XML failure result shape using
+`pdf_without_extractable_xml`.
+
+9.5. Document XML semantically unmappable result shape using
+`xml_semantically_unmappable`.
+
+9.6. Keep examples deterministic and ASCII-safe.
+
+User file modifications required:
+
+- documentation edits required during implementation if user keeps manual-doc
+  ownership
+
+Next step:
+
+- add contract tests that do not test parser implementation.
+
+### Task 10 - Add Contract-Only Tests
+
+Summary:
+
+- verify the public contract is importable, serializable, and stable
+- avoid false tests for PDF/XML/JSON implementation that does not exist yet
+
+Subtasks:
+
+10.1. Create `tests/test_parser_validator_contract_unit.py`.
+
+10.2. Test imports from `open_cvn`.
+
+10.3. Test enum values are stable lowercase strings.
+
+10.4. Test `CvnParseIssue` serializes structured error data.
+
+10.5. Test `CvnParseTrace` serializes source and policy trace.
+
+10.6. Test `CvnParseResult` supports success, warning, invalid, and failed
+states.
+
+10.7. Test unimplemented public functions raise `NotImplementedError` with the
+deferred-implementation message.
+
+10.8. Do not test real PDF extraction, XML parsing, JSON Schema validation, or
+Pydantic domain mapping in this issue.
+
+User file modifications required:
+
+- test file edits required during implementation if user keeps manual-code
+  ownership
+
+Next step:
+
+- update persistent documentation after contract files and tests exist.
+
+### Task 11 - Update Persistent Documentation
+
+Summary:
+
+- keep repository state aligned with implemented contract
+- make future sessions find the contract without chat history
+
+Subtasks:
+
+11.1. Create or update `docs/pipeline/parser_validator_contract.md`.
+
+11.2. Update this issue document with implementation decisions, artifacts,
+verification, deviations, and final status.
+
+11.3. Update `docs/context/current_status.md` with issue `#47` outcome and next
+planned work.
+
+11.4. Update `docs/roadmap/cvn_generation_roadmap.md` if issue `#47` status
+changes.
+
+11.5. Update `PROJECT_GUIDE.md` if the new parser contract document becomes a
+human-facing project map entry.
+
+11.6. Update `docs/pipeline/known_limitations.md` only if new limitations are
+found.
+
+User file modifications required:
+
+- documentation edits required during implementation if user keeps manual-doc
+  ownership
+
+Next step:
+
+- run targeted and full verification.
+
+### Task 12 - Verification
+
+Summary:
+
+- prove the contract is stable without claiming parser implementation exists
+
+Subtasks:
+
+12.1. Run targeted contract tests:
+
+```bash
+uv run pytest -n auto tests/test_parser_validator_contract_unit.py -v
+```
+
+12.2. Run full suite:
+
+```bash
+uv run pytest -n auto tests
+```
+
+12.3. Confirm no generated files were manually edited.
+
+12.4. Confirm issue `#48` can implement PDF XML extraction behind
+`parse_cvn_pdf(...)`.
+
+12.5. Confirm issue `#49` can implement XML and JSON import validation behind
+`parse_cvn_xml(...)`, `parse_open_cvn_json(...)`, and
+`validate_open_cvn_json(...)`.
+
+User file modifications required:
+
+- none unless verification exposes failures requiring code or documentation fixes
+
+Next step:
+
+- finalize issue status only after implementation and verification are complete.
+
+### Task 13 - Final Completion Criteria
+
+Summary:
+
+- define what must be true before issue `#47` is considered complete
+
+Completion checklist:
+
+- `src/open_cvn/` exists as public runtime contract package
+- parser/validator contract types are importable
+- public parser/validator signatures exist but do not implement real parsing
+- structured error codes cover all issue `#47` planned input paths
+- trace rules align with issue `#46` Open CVN JSON format
+- contract documentation exists and includes success/failure examples
+- contract-only tests pass
+- full repository tests pass
+- persistent documentation is updated
+- `src/generated/` remains untouched by manual edits
+
+User file modifications required:
+
+- none after all implementation tasks are complete unless user chooses to make
+  manual code or doc edits
+
+Next step:
+
+- begin issue `#48` PDF XML extraction implementation after issue `#47` is closed.
+
 ## Expected Output
 
 - parser/validator contract documentation
 - typed result and error structures if implementation is approved
 - tests for contract behavior if implementation is approved
+
+## Implementation Outcome
+
+- public contract package created under:
+  - `src/open_cvn/`
+- contract types and deferred public functions implemented in:
+  - `src/open_cvn/parser_contract.py`
+- public exports defined in:
+  - `src/open_cvn/__init__.py`
+- parser and validator contract documentation added at:
+  - `docs/pipeline/parser_validator_contract.md`
+- contract-only tests added at:
+  - `tests/test_parser_validator_contract_unit.py`
+
+Implemented public functions:
+
+- `parse_cvn_pdf(...)`
+- `parse_cvn_xml(...)`
+- `parse_open_cvn_json(...)`
+- `validate_open_cvn_json(...)`
+
+These functions intentionally raise `NotImplementedError` in issue `#47` because
+real parser and validator implementation is deferred to issues `#48` and `#49`.
+
+Implemented public result and diagnostic structures:
+
+- `CvnSourceFormat`
+- `CvnValidationStatus`
+- `CvnIssueSeverity`
+- `CvnErrorCode`
+- `CvnParseIssue`
+- `CvnParseTrace`
+- `CvnParseResult`
+
+## Implementation Deviations
+
+- The accepted plan chose `src/open_cvn/` as the public runtime package instead
+  of placing the contract under `src/models/cvn/`.
+- The issue remains contract-only; no PDF extraction, XML parsing, JSON Schema
+  validation, or domain mapping was implemented.
+
+## Verification Performed
+
+- targeted contract verification passed with:
+  `uv run pytest -n auto tests/test_parser_validator_contract_unit.py -v`
+- targeted verification result:
+  `14 passed in 2.07s`
+- full-suite verification passed with:
+  `uv run pytest -n auto tests`
+- full-suite verification result:
+  `348 passed in 857.18s (0:14:17)`
 
 ## Verification
 
@@ -82,4 +621,4 @@ Errors should distinguish:
 
 ## Status
 
-- Status: planned
+- Status: completed

--- a/docs/roadmap/issues/issue-48-cvn-pdf-xml-extraction.md
+++ b/docs/roadmap/issues/issue-48-cvn-pdf-xml-extraction.md
@@ -31,12 +31,561 @@ APIs such as embedded file counts, names, extraction, and XML metadata access.
 7. define clear errors for PDFs without extractable XML
 8. add tests with fixtures when sample files are available and safe to commit
 
+## Accepted Execution Plan
+
+Issue `#48` is a deterministic PDF XML extraction issue. It implements the PDF
+entry point behind `parse_cvn_pdf(...)` from issue `#47`, but it must not
+implement OCR, LLM reconstruction, direct XML-to-domain mapping, Open CVN JSON
+validation, or XML import validation. Those parser and validator paths remain in
+issue `#49`.
+
+Every implementation session must state the active task and subtask before work
+continues, using the format `Task N/Subtask N.M`. Each task and subtask below
+records a short summary, the expected user file-modification ownership, and the
+next step.
+
+### Task 1 - Confirm Scope And Boundaries
+
+Summary:
+
+- confirm that issue `#48` only extracts CVN XML deterministically from PDF
+- confirm that domain validation and XML import remain deferred to issue `#49`
+- confirm that `src/generated/` must not be edited manually
+
+Subtasks:
+
+1.1. Re-read issue `#48`, issue `#47`, issue `#49`, and
+`docs/pipeline/parser_validator_contract.md` before implementation.
+
+1.2. Record that `parse_cvn_pdf(...)` may become concrete, while
+`parse_cvn_xml(...)`, `parse_open_cvn_json(...)`, and
+`validate_open_cvn_json(...)` remain deferred unless a later issue changes scope.
+
+1.3. Record that no OCR, page text reconstruction, or LLM fallback is allowed in
+this issue.
+
+User file modifications required:
+
+- none during this task
+
+Next step:
+
+- proceed to dependency and API feasibility confirmation.
+
+### Task 2 - Add Or Confirm PDF Runtime Dependency
+
+Summary:
+
+- introduce the PDF library needed for deterministic embedded-file and XML
+  metadata extraction
+- keep dependency scope explicit and minimal
+
+Subtasks:
+
+2.1. Confirm the target PyMuPDF package name and import style for the current
+Python environment.
+
+2.2. Add `pymupdf` to the project dependency set if it is not already available.
+
+2.3. Prefer `import pymupdf` in implementation code instead of the older `fitz`
+import spelling.
+
+2.4. If PyMuPDF cannot be installed or does not support Python `>=3.14`, record a
+blocker and do not invent a text/OCR workaround.
+
+User file modifications required:
+
+- code/dependency file edit required if `pymupdf` is not already in the project
+- by default, the user should modify `pyproject.toml` unless they delegate the
+  edit
+
+Next step:
+
+- design the internal PDF extraction helper.
+
+### Task 3 - Design Internal PDF XML Extraction Helper
+
+Summary:
+
+- isolate PDF-specific extraction from the public parser contract
+- keep extracted XML traceable to its PDF source
+
+Subtasks:
+
+3.1. Create an internal helper module under `src/open_cvn/`, for example
+`src/open_cvn/pdf_xml_extraction.py`.
+
+3.2. Define an internal extracted-payload structure with fields such as:
+
+- `xml_text`
+- `xml_bytes_size`
+- `source_kind`
+- `source_name`
+- `source_index`
+- `metadata_xref`
+
+3.3. Keep the helper internal unless a concrete public API need appears.
+
+3.4. Do not expose generated structural bindings directly through this helper.
+
+User file modifications required:
+
+- code file creation required
+- by default, the user should create or edit the code file unless they delegate
+  the edit
+
+Next step:
+
+- implement PDF input resolution.
+
+### Task 4 - Resolve PDF Input Sources
+
+Summary:
+
+- accept the issue `#47` flexible input contract for PDF sources
+- classify unreadable and unsupported inputs with structured results
+
+Subtasks:
+
+4.1. Accept `Path`, filesystem `str`, and `bytes` inputs for `parse_cvn_pdf(...)`.
+
+4.2. Open path-like inputs with `pymupdf.open(path)`.
+
+4.3. Open byte inputs with `pymupdf.open(stream=source, filetype="pdf")`.
+
+4.4. Preserve `source_identifier` and file path when available in
+`CvnParseTrace`.
+
+4.5. Convert PyMuPDF open failures into `CvnErrorCode.UNREADABLE_FILE` with
+`CvnValidationStatus.FAILED`.
+
+4.6. Convert unsupported non-PDF input shapes into
+`CvnErrorCode.UNSUPPORTED_INPUT_FORMAT` or `CvnErrorCode.UNREADABLE_FILE`, using
+the most specific result supported by the contract.
+
+User file modifications required:
+
+- code edits required
+- by default, the user should modify code unless they delegate the edit
+
+Next step:
+
+- implement embedded-file candidate extraction.
+
+### Task 5 - Extract Candidate XML From Embedded Files
+
+Summary:
+
+- inspect PDF embedded-file streams before falling back to metadata
+- avoid writing extracted content to disk
+
+Subtasks:
+
+5.1. Use PyMuPDF embedded-file APIs such as `Document.embfile_count()`,
+`Document.embfile_names()`, `Document.embfile_info(...)`, and
+`Document.embfile_get(...)`.
+
+5.2. Iterate over every embedded-file entry deterministically.
+
+5.3. Prioritize candidates whose embedded filename ends with `.xml` or contains
+CVN-like naming evidence.
+
+5.4. Also inspect non-XML-named attachments when their bytes look like XML.
+
+5.5. Preserve candidate source details in extraction metadata.
+
+User file modifications required:
+
+- code edits required
+- by default, the user should modify code unless they delegate the edit
+
+Next step:
+
+- implement XML metadata candidate extraction.
+
+### Task 6 - Extract Candidate XML From PDF XML Metadata
+
+Summary:
+
+- inspect file-level PDF XML metadata as the second deterministic source
+- reject generic XMP metadata unless it contains CVN XML evidence
+
+Subtasks:
+
+6.1. Use PyMuPDF XML metadata APIs such as `Document.get_xml_metadata()`.
+
+6.2. Capture metadata xref when available through the installed PyMuPDF API.
+
+6.3. Treat XML metadata as a candidate only if it contains CVN-like XML evidence.
+
+6.4. Preserve `source_kind="xml_metadata"` and xref details when available.
+
+User file modifications required:
+
+- code edits required
+- by default, the user should modify code unless they delegate the edit
+
+Next step:
+
+- validate candidate XML shape minimally.
+
+### Task 7 - Validate Candidate XML Shape Minimally
+
+Summary:
+
+- prove that extracted bytes are well-formed XML and plausibly CVN-related
+- avoid performing the full XML import path reserved for issue `#49`
+
+Subtasks:
+
+7.1. Decode candidate bytes using `utf-8-sig` or `utf-8`; use fallback decoding
+only when required and record the behavior if it matters.
+
+7.2. Parse candidates with the standard XML parser to confirm well-formed XML.
+
+7.3. Accept a candidate when root name, namespace, or content provides CVN-like
+evidence.
+
+7.4. Reject malformed XML candidates and continue scanning remaining candidates.
+
+7.5. If no candidate is accepted, return the unsupported PDF path rather than
+attempting OCR, page text extraction, or LLM reconstruction.
+
+User file modifications required:
+
+- code edits required
+- by default, the user should modify code unless they delegate the edit
+
+Next step:
+
+- wire the helper into `parse_cvn_pdf(...)`.
+
+### Task 8 - Implement `parse_cvn_pdf(...)`
+
+Summary:
+
+- replace only the PDF stub from issue `#47` with concrete deterministic
+  extraction behavior
+- keep XML and JSON functions deferred
+
+Subtasks:
+
+8.1. Update `parse_cvn_pdf(...)` in `src/open_cvn/parser_contract.py` to call the
+internal PDF extraction helper.
+
+8.2. Return `CvnParseResult` with `source_format=CvnSourceFormat.PDF`.
+
+8.3. For success, use `CvnValidationStatus.NOT_RUN` because XML validation and
+domain mapping are not performed in issue `#48`.
+
+8.4. For success, place extracted XML and extraction metadata in `data` without
+claiming Open CVN JSON or domain validation.
+
+8.5. Populate `CvnParseTrace` with PDF source identity and extracted XML source
+identity through `extracted_from`.
+
+8.6. Leave `parse_cvn_xml(...)`, `parse_open_cvn_json(...)`, and
+`validate_open_cvn_json(...)` raising the issue `#47` deferred implementation
+message.
+
+User file modifications required:
+
+- code edits required
+- by default, the user should modify code unless they delegate the edit
+
+Next step:
+
+- normalize structured error behavior.
+
+### Task 9 - Define Structured Error Results
+
+Summary:
+
+- make unsupported and failed PDF cases deterministic and machine-readable
+- keep diagnostic detail useful without leaking raw exception objects
+
+Subtasks:
+
+9.1. Return `CvnErrorCode.UNREADABLE_FILE` for unreadable, missing, encrypted, or
+invalid PDF inputs when processing cannot begin.
+
+9.2. Return `CvnErrorCode.PDF_WITHOUT_EXTRACTABLE_XML` when the PDF opens but no
+acceptable CVN XML candidate is found.
+
+9.3. Return `CvnValidationStatus.FAILED` for both failure families.
+
+9.4. Include details such as embedded-file count, candidate count, metadata
+presence, and sanitized PyMuPDF error messages where useful.
+
+9.5. Keep `details` values JSON-serializable according to the issue `#47`
+contract.
+
+User file modifications required:
+
+- code edits required
+- by default, the user should modify code unless they delegate the edit
+
+Next step:
+
+- add safe PDF fixtures for tests.
+
+### Task 10 - Create Safe Test Fixtures
+
+Summary:
+
+- test deterministic extraction without committing personal FECYT PDF data
+- use synthetic PDFs where possible
+
+Subtasks:
+
+10.1. Create synthetic PDF fixtures during tests using PyMuPDF.
+
+10.2. Include one PDF with an embedded XML file containing safe CVN-like XML.
+
+10.3. Include one PDF with XML metadata containing safe CVN-like XML if supported
+by the installed PyMuPDF version.
+
+10.4. Include one valid PDF without XML.
+
+10.5. Include one unreadable PDF input case.
+
+10.6. Do not commit real FECYT PDFs unless they are safe, anonymized, and
+explicitly approved.
+
+User file modifications required:
+
+- test fixture code edits required
+- by default, the user should modify tests unless they delegate the edit
+
+Next step:
+
+- add unit tests for extraction and parser results.
+
+### Task 11 - Add PDF Extraction Tests
+
+Summary:
+
+- verify the new PDF behavior without testing future XML/domain validation
+
+Subtasks:
+
+11.1. Add `tests/test_pdf_xml_extraction_unit.py` or equivalent focused test
+module.
+
+11.2. Test extraction from embedded XML file.
+
+11.3. Test extraction from XML metadata when the installed PyMuPDF supports the
+required write/read path.
+
+11.4. Test PDF without XML returns `pdf_without_extractable_xml`.
+
+11.5. Test unreadable input returns `unreadable_file`.
+
+11.6. Test `parse_cvn_pdf(...)` no longer raises `NotImplementedError` for
+supported PDF inputs.
+
+11.7. Test XML and JSON parser functions still raise the deferred implementation
+message.
+
+11.8. Test no OCR, page text extraction, or LLM fallback is attempted.
+
+User file modifications required:
+
+- test edits required
+- by default, the user should modify tests unless they delegate the edit
+
+Next step:
+
+- update issue `#47` contract tests affected by the PDF implementation.
+
+### Task 12 - Adjust Existing Parser Contract Tests
+
+Summary:
+
+- keep issue `#47` tests aligned now that the PDF entry point is implemented
+- avoid changing XML and JSON deferred behavior
+
+Subtasks:
+
+12.1. Remove `parse_cvn_pdf(...)` from tests that expect all public parser
+functions to raise `NotImplementedError`.
+
+12.2. Keep `parse_cvn_xml(...)`, `parse_open_cvn_json(...)`, and
+`validate_open_cvn_json(...)` deferred tests unchanged.
+
+12.3. Add or update contract-level assertions for PDF success and failure result
+shape if needed.
+
+User file modifications required:
+
+- test edits required
+- by default, the user should modify tests unless they delegate the edit
+
+Next step:
+
+- update persistent documentation.
+
+### Task 13 - Update Persistent Documentation
+
+Summary:
+
+- make issue `#48` behavior discoverable without chat history
+- keep repository status synchronized with implementation
+
+Subtasks:
+
+13.1. Update `docs/pipeline/parser_validator_contract.md` with PDF extraction
+order, success payload, failure cases, and explicit non-goals.
+
+13.2. Update this issue document with implementation outcome, deviations,
+artifacts, verification, findings, and final status when complete.
+
+13.3. Update `docs/context/current_status.md` with issue `#48` outcome and next
+planned work.
+
+13.4. Update `docs/roadmap/cvn_generation_roadmap.md` if issue status changes.
+
+13.5. Update `docs/pipeline/known_limitations.md` only if a new limitation is
+found, such as FECYT PDFs without embedded XML or PyMuPDF metadata limitations.
+
+13.6. Update `PROJECT_GUIDE.md` only if human-facing document map or repository
+orientation changes.
+
+User file modifications required:
+
+- documentation edits required
+- agent may update issue plan/status documentation when explicitly requested;
+  user may keep ownership of code changes
+
+Next step:
+
+- run targeted and full verification.
+
+### Task 14 - Verification
+
+Summary:
+
+- prove PDF extraction works and existing parser contract remains stable
+
+Subtasks:
+
+14.1. Run targeted PDF and contract tests:
+
+```bash
+uv run pytest -n auto tests/test_pdf_xml_extraction_unit.py tests/test_parser_validator_contract_unit.py -v
+```
+
+14.2. Run the full repository test suite:
+
+```bash
+uv run pytest -n auto tests
+```
+
+14.3. Confirm `src/generated/` was not manually edited.
+
+14.4. Confirm `parse_cvn_pdf(...)` returns structured results for success,
+unsupported PDF, and unreadable PDF cases.
+
+14.5. Confirm XML and JSON parser/validator functions remain deferred to issue
+`#49`.
+
+User file modifications required:
+
+- none unless verification exposes failures requiring code, test, or
+  documentation fixes
+
+Next step:
+
+- finalize completion criteria.
+
+### Task 15 - Final Completion Criteria
+
+Summary:
+
+- define what must be true before issue `#48` is complete
+
+Completion checklist:
+
+- `parse_cvn_pdf(...)` is implemented behind the issue `#47` contract
+- deterministic extraction supports embedded XML files
+- deterministic extraction supports PDF XML metadata when available
+- PDF without extractable CVN XML returns `pdf_without_extractable_xml`
+- unreadable PDF returns `unreadable_file`
+- no OCR, page text reconstruction, or LLM fallback is attempted
+- extracted XML is well-formed and plausibly CVN-related before being returned
+- XML/domain/Open CVN validation remains deferred to issue `#49`
+- targeted tests pass
+- full repository tests pass
+- persistent documentation is updated
+- `src/generated/` remains untouched by manual edits
+
+User file modifications required:
+
+- none after all implementation, verification, and documentation tasks are
+  complete unless the user chooses to make final manual edits
+
+Next step:
+
+- begin issue `#49` XML and JSON import validation after issue `#48` is closed.
+
 ## Expected Output
 
 - PDF extraction helper or parser implementation if approved
 - documented extraction behavior
 - tests for PDF with extractable XML when fixture exists
 - explicit unsupported-path behavior for PDF without XML
+
+## Implementation Outcome
+
+- PDF runtime dependency added:
+  - `pymupdf>=1.26`
+- internal deterministic extraction helper implemented in:
+  - `src/open_cvn/pdf_xml_extraction.py`
+- public PDF parser implementation added behind the issue `#47` contract in:
+  - `src/open_cvn/parser_contract.py`
+- synthetic PDF extraction tests added in:
+  - `tests/test_pdf_xml_extraction_unit.py`
+- issue `#47` contract tests updated so only XML and JSON parser functions remain
+  deferred:
+  - `tests/test_parser_validator_contract_unit.py`
+
+Implemented PDF extraction behavior:
+
+- accepts PDF paths and PDF bytes through `parse_cvn_pdf(...)`
+- scans embedded-file streams before XML metadata
+- extracts embedded XML files using PyMuPDF embedded-file APIs
+- extracts PDF XML metadata using PyMuPDF XML metadata APIs when it contains CVN
+  XML evidence
+- requires candidates to be well-formed XML and plausibly CVN-related before
+  returning them
+- returns `validation_status=not_run` for successful PDF extraction because XML
+  import and semantic validation are deferred to issue `#49`
+- returns `unreadable_file` for unreadable PDF inputs
+- returns `unsupported_input_format` for non-PDF input shapes such as mappings
+- returns `pdf_without_extractable_xml` for readable PDFs without extractable CVN
+  XML
+- does not attempt OCR, page text reconstruction, LLM reconstruction, or XML
+  domain mapping
+
+## Implementation Deviations
+
+- No real FECYT PDF fixture was committed because safe anonymized sample files
+  were not available in the repository.
+- Tests use synthetic PyMuPDF-generated PDFs with safe CVN-like XML fixtures.
+- `parse_cvn_pdf(...)` returns extracted XML text and extraction metadata instead
+  of delegating to `parse_cvn_xml(...)`, because the XML import path remains
+  deferred to issue `#49`.
+
+## Verification Performed
+
+- targeted PDF and contract verification passed with:
+  `uv run pytest -n auto tests/test_pdf_xml_extraction_unit.py tests/test_parser_validator_contract_unit.py -v`
+- targeted verification result:
+  `20 passed in 2.64s`
+- full-suite verification passed with:
+  `uv run pytest -n auto tests`
+- full-suite verification result:
+  `354 passed in 850.95s (0:14:10)`
 
 ## Verification
 
@@ -58,4 +607,4 @@ APIs such as embedded file counts, names, extraction, and XML metadata access.
 
 ## Status
 
-- Status: planned
+- Status: completed

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-47-unified-parser-validator-contract.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 47. Primero unicamente debes de crear el plan de ejecución
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-48-cvn-pdf-xml-extraction.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 48. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-47-unified-parser-validator-contract.md.
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-48-cvn-pdf-xml-extraction.md.
 
 
 

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 46. Primero unicamente debes de crear el plan de ejecución
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-47-unified-parser-validator-contract.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 47. Primero unicamente debes de crear el plan de ejecución
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-46-define-canonical-open-cvn-json-format.md.
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-47-unified-parser-validator-contract.md.
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "pydantic>=2.12.5",
+    "pymupdf>=1.26",
 ]
 
 [dependency-groups]

--- a/src/open_cvn/__init__.py
+++ b/src/open_cvn/__init__.py
@@ -1,0 +1,29 @@
+from open_cvn.parser_contract import (
+    CvnErrorCode,
+    CvnInput,
+    CvnIssueSeverity,
+    CvnParseIssue,
+    CvnParseResult,
+    CvnParseTrace,
+    CvnSourceFormat,
+    CvnValidationStatus,
+    parse_cvn_pdf,
+    parse_cvn_xml,
+    parse_open_cvn_json,
+    validate_open_cvn_json,
+)
+
+__all__ = [
+    "CvnErrorCode",
+    "CvnInput",
+    "CvnIssueSeverity",
+    "CvnParseIssue",
+    "CvnParseResult",
+    "CvnParseTrace",
+    "CvnSourceFormat",
+    "CvnValidationStatus",
+    "parse_cvn_pdf",
+    "parse_cvn_xml",
+    "parse_open_cvn_json",
+    "validate_open_cvn_json",
+]

--- a/src/open_cvn/parser_contract.py
+++ b/src/open_cvn/parser_contract.py
@@ -96,7 +96,106 @@ class CvnParseResult(BaseModel):
 
 
 def parse_cvn_pdf(source: CvnInput, *, source_identifier: str | None = None) -> CvnParseResult:
-    raise NotImplementedError(DEFERRED_IMPLEMENTATION_MESSAGE)
+    from open_cvn.pdf_xml_extraction import (
+        UnsupportedPdfInputError,
+        UnreadablePdfError,
+        extract_cvn_xml_from_pdf,
+    )
+
+    if isinstance(source, Mapping):
+        return _failed_pdf_result(
+            source_identifier=source_identifier,
+            source_path=None,
+            error_code=CvnErrorCode.UNSUPPORTED_INPUT_FORMAT,
+            message="PDF input must be a path or bytes.",
+            details={"input_type": type(source).__name__},
+        )
+
+    try:
+        extraction_result = extract_cvn_xml_from_pdf(source)  # type: ignore[arg-type]
+    except UnsupportedPdfInputError as exc:
+        return _failed_pdf_result(
+            source_identifier=source_identifier,
+            source_path=None,
+            error_code=CvnErrorCode.UNSUPPORTED_INPUT_FORMAT,
+            message="PDF input must be a path or bytes.",
+            details={"error": str(exc)},
+        )
+    except UnreadablePdfError as exc:
+        return _failed_pdf_result(
+            source_identifier=source_identifier,
+            source_path=exc.source_path,
+            error_code=CvnErrorCode.UNREADABLE_FILE,
+            message="PDF input could not be read.",
+            details={"error": str(exc)},
+        )
+
+    diagnostics = extraction_result.diagnostics
+    extracted_xml = extraction_result.extracted_xml
+    result_identifier = source_identifier or diagnostics.source_path
+    if extracted_xml is None:
+        return _failed_pdf_result(
+            source_identifier=result_identifier,
+            source_path=diagnostics.source_path,
+            error_code=CvnErrorCode.PDF_WITHOUT_EXTRACTABLE_XML,
+            message="PDF does not contain extractable CVN XML.",
+            details=diagnostics.as_details(),
+        )
+
+    extracted_from = extracted_xml.source_kind
+    if extracted_xml.source_name is not None:
+        extracted_from = f"{extracted_from}:{extracted_xml.source_name}"
+
+    return CvnParseResult(
+        source_format=CvnSourceFormat.PDF,
+        source_identifier=result_identifier,
+        data={
+            "xml_text": extracted_xml.xml_text,
+            "extraction": {
+                "source_kind": extracted_xml.source_kind,
+                "source_name": extracted_xml.source_name,
+                "source_index": extracted_xml.source_index,
+                "xml_bytes_size": extracted_xml.xml_bytes_size,
+                "metadata_xref": extracted_xml.metadata_xref,
+                **diagnostics.as_details(),
+            },
+        },
+        validation_status=CvnValidationStatus.NOT_RUN,
+        trace=CvnParseTrace(
+            source_format=CvnSourceFormat.PDF,
+            source_identifier=result_identifier,
+            source_path=diagnostics.source_path,
+            extracted_from=extracted_from,
+        ),
+    )
+
+
+def _failed_pdf_result(
+    *,
+    source_identifier: str | None,
+    source_path: str | None,
+    error_code: CvnErrorCode,
+    message: str,
+    details: dict[str, str | int | float | bool | None],
+) -> CvnParseResult:
+    return CvnParseResult(
+        source_format=CvnSourceFormat.PDF,
+        source_identifier=source_identifier or source_path,
+        validation_status=CvnValidationStatus.FAILED,
+        errors=(
+            CvnParseIssue(
+                code=error_code,
+                severity=CvnIssueSeverity.ERROR,
+                message=message,
+                details=details,
+            ),
+        ),
+        trace=CvnParseTrace(
+            source_format=CvnSourceFormat.PDF,
+            source_identifier=source_identifier or source_path,
+            source_path=source_path,
+        ),
+    )
 
 
 def parse_cvn_xml(source: CvnInput, *, source_identifier: str | None = None) -> CvnParseResult:

--- a/src/open_cvn/parser_contract.py
+++ b/src/open_cvn/parser_contract.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+CvnInput: TypeAlias = Path | str | bytes | Mapping[str, Any]
+DEFERRED_IMPLEMENTATION_MESSAGE = "Parser implementation is deferred to issue #48/#49."
+
+
+class CvnSourceFormat(str, Enum):
+    PDF = "pdf"
+    CVN_XML = "cvn_xml"
+    OPEN_CVN_JSON = "open_cvn_json"
+
+
+class CvnValidationStatus(str, Enum):
+    NOT_RUN = "not_run"
+    VALID = "valid"
+    VALID_WITH_WARNINGS = "valid_with_warnings"
+    INVALID = "invalid"
+    FAILED = "failed"
+
+
+class CvnIssueSeverity(str, Enum):
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class CvnErrorCode(str, Enum):
+    UNSUPPORTED_INPUT_FORMAT = "unsupported_input_format"
+    UNREADABLE_FILE = "unreadable_file"
+    PDF_WITHOUT_EXTRACTABLE_XML = "pdf_without_extractable_xml"
+    INVALID_XML = "invalid_xml"
+    XML_SEMANTICALLY_UNMAPPABLE = "xml_semantically_unmappable"
+    INVALID_JSON = "invalid_json"
+    JSON_SCHEMA_VALIDATION_FAILURE = "json_schema_validation_failure"
+    PYDANTIC_VALIDATION_FAILURE = "pydantic_validation_failure"
+
+
+class CvnParseIssue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: CvnErrorCode
+    severity: CvnIssueSeverity
+    message: str
+    source_location: str | None = None
+    path: tuple[str, ...] = ()
+    details: dict[str, str | int | float | bool | None] = Field(default_factory=dict)
+
+
+class CvnParseTrace(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_format: CvnSourceFormat
+    source_identifier: str | None = None
+    source_path: str | None = None
+    extracted_from: str | None = None
+    cvn_codes: tuple[str, ...] = ()
+    xml_paths: tuple[str, ...] = ()
+    schema_version: str | None = None
+    policy_name: str | None = None
+    policy_version: str | None = None
+
+
+class CvnParseResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_format: CvnSourceFormat
+    source_identifier: str | None = None
+    data: Mapping[str, Any] | None = None
+    validation_status: CvnValidationStatus
+    warnings: tuple[CvnParseIssue, ...] = ()
+    errors: tuple[CvnParseIssue, ...] = ()
+    trace: CvnParseTrace | None = None
+
+    @model_validator(mode="after")
+    def _validate_status_matches_issues(self) -> CvnParseResult:
+        if self.errors and self.validation_status not in {
+            CvnValidationStatus.INVALID,
+            CvnValidationStatus.FAILED,
+        }:
+            raise ValueError("Results with errors must be invalid or failed")
+        if self.validation_status == CvnValidationStatus.VALID_WITH_WARNINGS and not self.warnings:
+            raise ValueError("valid_with_warnings results must include at least one warning")
+        for issue in self.warnings:
+            if issue.severity != CvnIssueSeverity.WARNING:
+                raise ValueError("warnings must contain warning-severity issues")
+        for issue in self.errors:
+            if issue.severity != CvnIssueSeverity.ERROR:
+                raise ValueError("errors must contain error-severity issues")
+        return self
+
+
+def parse_cvn_pdf(source: CvnInput, *, source_identifier: str | None = None) -> CvnParseResult:
+    raise NotImplementedError(DEFERRED_IMPLEMENTATION_MESSAGE)
+
+
+def parse_cvn_xml(source: CvnInput, *, source_identifier: str | None = None) -> CvnParseResult:
+    raise NotImplementedError(DEFERRED_IMPLEMENTATION_MESSAGE)
+
+
+def parse_open_cvn_json(source: CvnInput, *, source_identifier: str | None = None) -> CvnParseResult:
+    raise NotImplementedError(DEFERRED_IMPLEMENTATION_MESSAGE)
+
+
+def validate_open_cvn_json(
+    document: Mapping[str, Any], *, source_identifier: str | None = None
+) -> CvnParseResult:
+    raise NotImplementedError(DEFERRED_IMPLEMENTATION_MESSAGE)

--- a/src/open_cvn/pdf_xml_extraction.py
+++ b/src/open_cvn/pdf_xml_extraction.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+from xml.etree import ElementTree
+
+import pymupdf
+
+
+PdfInput = Path | str | bytes
+PdfXmlSourceKind = Literal["embedded_file", "xml_metadata"]
+
+
+@dataclass(frozen=True)
+class ExtractedCvnXml:
+    xml_text: str
+    xml_bytes_size: int
+    source_kind: PdfXmlSourceKind
+    source_name: str | None = None
+    source_index: int | None = None
+    metadata_xref: int | None = None
+
+
+@dataclass(frozen=True)
+class PdfXmlExtractionDiagnostics:
+    source_path: str | None
+    embedded_file_count: int
+    candidate_count: int
+    metadata_present: bool
+
+    def as_details(self) -> dict[str, str | int | float | bool | None]:
+        return {
+            "embedded_file_count": self.embedded_file_count,
+            "candidate_count": self.candidate_count,
+            "metadata_present": self.metadata_present,
+        }
+
+
+@dataclass(frozen=True)
+class PdfXmlExtractionResult:
+    extracted_xml: ExtractedCvnXml | None
+    diagnostics: PdfXmlExtractionDiagnostics
+
+
+class UnsupportedPdfInputError(TypeError):
+    pass
+
+
+class UnreadablePdfError(RuntimeError):
+    def __init__(self, message: str, *, source_path: str | None = None) -> None:
+        super().__init__(message)
+        self.source_path = source_path
+
+
+def extract_cvn_xml_from_pdf(source: PdfInput) -> PdfXmlExtractionResult:
+    source_path = _source_path(source)
+    try:
+        with _open_pdf(source) as document:
+            candidate_count = 0
+            embedded_file_count = _embedded_file_count(document)
+
+            for candidate in _iter_embedded_file_candidates(document):
+                candidate_count += 1
+                extracted = _validated_cvn_xml(candidate)
+                if extracted is not None:
+                    diagnostics = PdfXmlExtractionDiagnostics(
+                        source_path=source_path,
+                        embedded_file_count=embedded_file_count,
+                        candidate_count=candidate_count,
+                        metadata_present=bool(_get_xml_metadata(document)),
+                    )
+                    return PdfXmlExtractionResult(extracted, diagnostics)
+
+            metadata = _get_xml_metadata(document)
+            if metadata:
+                candidate_count += 1
+                metadata_candidate = ExtractedCvnXml(
+                    xml_text=metadata,
+                    xml_bytes_size=len(metadata.encode("utf-8")),
+                    source_kind="xml_metadata",
+                    source_name="xml_metadata",
+                    metadata_xref=_xml_metadata_xref(document),
+                )
+                extracted = _validated_cvn_xml(metadata_candidate)
+                if extracted is not None:
+                    diagnostics = PdfXmlExtractionDiagnostics(
+                        source_path=source_path,
+                        embedded_file_count=embedded_file_count,
+                        candidate_count=candidate_count,
+                        metadata_present=True,
+                    )
+                    return PdfXmlExtractionResult(extracted, diagnostics)
+
+            diagnostics = PdfXmlExtractionDiagnostics(
+                source_path=source_path,
+                embedded_file_count=embedded_file_count,
+                candidate_count=candidate_count,
+                metadata_present=bool(metadata),
+            )
+            return PdfXmlExtractionResult(None, diagnostics)
+    except UnsupportedPdfInputError:
+        raise
+    except UnreadablePdfError:
+        raise
+    except Exception as exc:
+        raise UnreadablePdfError(str(exc), source_path=source_path) from exc
+
+
+def _open_pdf(source: PdfInput) -> pymupdf.Document:
+    if isinstance(source, bytes):
+        return pymupdf.open(stream=source, filetype="pdf")
+    if isinstance(source, Path):
+        return pymupdf.open(source)
+    if isinstance(source, str):
+        source_path = Path(source)
+        if source_path.exists():
+            return pymupdf.open(source_path)
+        raise UnreadablePdfError(f"PDF path does not exist: {source}", source_path=source)
+    raise UnsupportedPdfInputError(f"Unsupported PDF input type: {type(source).__name__}")
+
+
+def _source_path(source: PdfInput) -> str | None:
+    if isinstance(source, Path):
+        return str(source)
+    if isinstance(source, str) and Path(source).exists():
+        return source
+    return None
+
+
+def _embedded_file_count(document: pymupdf.Document) -> int:
+    try:
+        return int(document.embfile_count())
+    except Exception:
+        return 0
+
+
+def _iter_embedded_file_candidates(document: pymupdf.Document) -> tuple[ExtractedCvnXml, ...]:
+    names = tuple(document.embfile_names())
+    prioritized_names = sorted(
+        names,
+        key=lambda name: (
+            not name.lower().endswith(".xml"),
+            "cvn" not in name.lower(),
+            name.lower(),
+        ),
+    )
+    candidates: list[ExtractedCvnXml] = []
+    for index, name in enumerate(prioritized_names):
+        payload = document.embfile_get(name)
+        text = _decode_xml_candidate(payload)
+        if text is None:
+            continue
+        if not _name_or_payload_looks_xml(name, text):
+            continue
+        candidates.append(
+            ExtractedCvnXml(
+                xml_text=text,
+                xml_bytes_size=len(payload),
+                source_kind="embedded_file",
+                source_name=name,
+                source_index=index,
+            )
+        )
+    return tuple(candidates)
+
+
+def _get_xml_metadata(document: pymupdf.Document) -> str:
+    try:
+        return document.get_xml_metadata() or ""
+    except Exception:
+        return ""
+
+
+def _xml_metadata_xref(document: pymupdf.Document) -> int | None:
+    xref_getter = getattr(document, "xref_xml_metadata", None)
+    if xref_getter is None:
+        return None
+    try:
+        xref = int(xref_getter())
+    except Exception:
+        return None
+    return xref or None
+
+
+def _decode_xml_candidate(payload: bytes) -> str | None:
+    for encoding in ("utf-8-sig", "utf-8", "latin-1"):
+        try:
+            return payload.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return None
+
+
+def _name_or_payload_looks_xml(name: str, text: str) -> bool:
+    stripped = text.lstrip()
+    return name.lower().endswith(".xml") or stripped.startswith("<?xml") or stripped.startswith("<")
+
+
+def _validated_cvn_xml(candidate: ExtractedCvnXml) -> ExtractedCvnXml | None:
+    try:
+        root = ElementTree.fromstring(candidate.xml_text)
+    except ElementTree.ParseError:
+        return None
+    if not _has_cvn_evidence(root, candidate.xml_text):
+        return None
+    return candidate
+
+
+def _has_cvn_evidence(root: ElementTree.Element, text: str) -> bool:
+    root_name = root.tag.lower()
+    text_sample = text[:4096].lower()
+    return any(
+        marker in root_name or marker in text_sample
+        for marker in (
+            "cvn",
+            "curriculumvitaenormalizado",
+            "curriculum vitae normalizado",
+        )
+    )

--- a/tests/test_parser_validator_contract_unit.py
+++ b/tests/test_parser_validator_contract_unit.py
@@ -1,0 +1,208 @@
+import pytest
+from pydantic import ValidationError
+
+from open_cvn import (
+    CvnErrorCode,
+    CvnIssueSeverity,
+    CvnParseIssue,
+    CvnParseResult,
+    CvnParseTrace,
+    CvnSourceFormat,
+    CvnValidationStatus,
+    parse_cvn_pdf,
+    parse_cvn_xml,
+    parse_open_cvn_json,
+    validate_open_cvn_json,
+)
+
+
+DEFERRED_IMPLEMENTATION_MESSAGE = "Parser implementation is deferred to issue #48/#49."
+
+
+def test_contract_enums_have_stable_serialized_values():
+    assert CvnSourceFormat.PDF.value == "pdf"
+    assert CvnSourceFormat.CVN_XML.value == "cvn_xml"
+    assert CvnSourceFormat.OPEN_CVN_JSON.value == "open_cvn_json"
+    assert CvnValidationStatus.NOT_RUN.value == "not_run"
+    assert CvnValidationStatus.VALID.value == "valid"
+    assert CvnValidationStatus.VALID_WITH_WARNINGS.value == "valid_with_warnings"
+    assert CvnValidationStatus.INVALID.value == "invalid"
+    assert CvnValidationStatus.FAILED.value == "failed"
+    assert CvnIssueSeverity.WARNING.value == "warning"
+    assert CvnIssueSeverity.ERROR.value == "error"
+
+
+def test_contract_error_codes_cover_issue_47_cases():
+    assert {error_code.value for error_code in CvnErrorCode} == {
+        "unsupported_input_format",
+        "unreadable_file",
+        "pdf_without_extractable_xml",
+        "invalid_xml",
+        "xml_semantically_unmappable",
+        "invalid_json",
+        "json_schema_validation_failure",
+        "pydantic_validation_failure",
+    }
+
+
+def test_parse_issue_serializes_structured_error_data():
+    issue = CvnParseIssue(
+        code=CvnErrorCode.INVALID_JSON,
+        severity=CvnIssueSeverity.ERROR,
+        message="Input is not valid JSON.",
+        source_location="line 1 column 2",
+        path=("metadata", "policy"),
+        details={"line": 1, "column": 2},
+    )
+
+    assert issue.model_dump(mode="json") == {
+        "code": "invalid_json",
+        "severity": "error",
+        "message": "Input is not valid JSON.",
+        "source_location": "line 1 column 2",
+        "path": ["metadata", "policy"],
+        "details": {"line": 1, "column": 2},
+    }
+
+
+def test_parse_trace_serializes_source_and_policy_metadata():
+    trace = CvnParseTrace(
+        source_format=CvnSourceFormat.OPEN_CVN_JSON,
+        source_identifier="examples/open_cvn/minimal.json",
+        source_path="examples/open_cvn/minimal.json",
+        cvn_codes=("000.010.000.000",),
+        xml_paths=("CVNRoot/PersonalData",),
+        schema_version="0.1.0",
+        policy_name="default_cvn_semantic_policy",
+        policy_version="0.1.0",
+    )
+
+    assert trace.model_dump(mode="json") == {
+        "source_format": "open_cvn_json",
+        "source_identifier": "examples/open_cvn/minimal.json",
+        "source_path": "examples/open_cvn/minimal.json",
+        "extracted_from": None,
+        "cvn_codes": ["000.010.000.000"],
+        "xml_paths": ["CVNRoot/PersonalData"],
+        "schema_version": "0.1.0",
+        "policy_name": "default_cvn_semantic_policy",
+        "policy_version": "0.1.0",
+    }
+
+
+def test_parse_result_supports_valid_result_shape():
+    result = CvnParseResult(
+        source_format=CvnSourceFormat.OPEN_CVN_JSON,
+        source_identifier="minimal.json",
+        data={"schema_version": "0.1.0"},
+        validation_status=CvnValidationStatus.VALID,
+        trace=CvnParseTrace(
+            source_format=CvnSourceFormat.OPEN_CVN_JSON,
+            source_identifier="minimal.json",
+            schema_version="0.1.0",
+        ),
+    )
+
+    assert result.model_dump(mode="json")["validation_status"] == "valid"
+    assert result.model_dump(mode="json")["errors"] == []
+
+
+def test_parse_result_supports_valid_with_warnings_result_shape():
+    warning = CvnParseIssue(
+        code=CvnErrorCode.UNSUPPORTED_INPUT_FORMAT,
+        severity=CvnIssueSeverity.WARNING,
+        message="Best-effort parser warning.",
+    )
+
+    result = CvnParseResult(
+        source_format=CvnSourceFormat.CVN_XML,
+        validation_status=CvnValidationStatus.VALID_WITH_WARNINGS,
+        warnings=(warning,),
+    )
+
+    assert result.model_dump(mode="json")["validation_status"] == "valid_with_warnings"
+    assert result.model_dump(mode="json")["warnings"][0]["severity"] == "warning"
+
+
+def test_parse_result_supports_invalid_result_shape():
+    error = CvnParseIssue(
+        code=CvnErrorCode.JSON_SCHEMA_VALIDATION_FAILURE,
+        severity=CvnIssueSeverity.ERROR,
+        message="Open CVN JSON does not match the generated schema.",
+        path=("curriculum",),
+    )
+
+    result = CvnParseResult(
+        source_format=CvnSourceFormat.OPEN_CVN_JSON,
+        validation_status=CvnValidationStatus.INVALID,
+        errors=(error,),
+    )
+
+    assert result.model_dump(mode="json")["validation_status"] == "invalid"
+    assert result.model_dump(mode="json")["errors"][0]["code"] == (
+        "json_schema_validation_failure"
+    )
+
+
+def test_parse_result_supports_failed_result_shape():
+    error = CvnParseIssue(
+        code=CvnErrorCode.PDF_WITHOUT_EXTRACTABLE_XML,
+        severity=CvnIssueSeverity.ERROR,
+        message="PDF does not contain extractable CVN XML.",
+    )
+
+    result = CvnParseResult(
+        source_format=CvnSourceFormat.PDF,
+        source_identifier="cvn.pdf",
+        validation_status=CvnValidationStatus.FAILED,
+        errors=(error,),
+    )
+
+    assert result.model_dump(mode="json")["validation_status"] == "failed"
+    assert result.model_dump(mode="json")["errors"][0]["code"] == (
+        "pdf_without_extractable_xml"
+    )
+
+
+def test_parse_result_rejects_errors_with_valid_status():
+    error = CvnParseIssue(
+        code=CvnErrorCode.INVALID_JSON,
+        severity=CvnIssueSeverity.ERROR,
+        message="Input is not valid JSON.",
+    )
+
+    with pytest.raises(ValidationError, match="Results with errors must be invalid or failed"):
+        CvnParseResult(
+            source_format=CvnSourceFormat.OPEN_CVN_JSON,
+            validation_status=CvnValidationStatus.VALID,
+            errors=(error,),
+        )
+
+
+def test_parse_result_rejects_warning_status_without_warning():
+    with pytest.raises(
+        ValidationError,
+        match="valid_with_warnings results must include at least one warning",
+    ):
+        CvnParseResult(
+            source_format=CvnSourceFormat.OPEN_CVN_JSON,
+            validation_status=CvnValidationStatus.VALID_WITH_WARNINGS,
+        )
+
+
+@pytest.mark.parametrize(
+    ("parser", "source"),
+    [
+        (parse_cvn_pdf, b"%PDF"),
+        (parse_cvn_xml, "<CVNRoot />"),
+        (parse_open_cvn_json, '{"schema_version": "0.1.0"}'),
+    ],
+)
+def test_public_parser_functions_defer_implementation(parser, source):
+    with pytest.raises(NotImplementedError, match=DEFERRED_IMPLEMENTATION_MESSAGE):
+        parser(source, source_identifier="input")
+
+
+def test_public_validator_function_defers_implementation():
+    with pytest.raises(NotImplementedError, match=DEFERRED_IMPLEMENTATION_MESSAGE):
+        validate_open_cvn_json({"schema_version": "0.1.0"}, source_identifier="input")

--- a/tests/test_parser_validator_contract_unit.py
+++ b/tests/test_parser_validator_contract_unit.py
@@ -9,7 +9,6 @@ from open_cvn import (
     CvnParseTrace,
     CvnSourceFormat,
     CvnValidationStatus,
-    parse_cvn_pdf,
     parse_cvn_xml,
     parse_open_cvn_json,
     validate_open_cvn_json,
@@ -193,7 +192,6 @@ def test_parse_result_rejects_warning_status_without_warning():
 @pytest.mark.parametrize(
     ("parser", "source"),
     [
-        (parse_cvn_pdf, b"%PDF"),
         (parse_cvn_xml, "<CVNRoot />"),
         (parse_open_cvn_json, '{"schema_version": "0.1.0"}'),
     ],

--- a/tests/test_pdf_xml_extraction_unit.py
+++ b/tests/test_pdf_xml_extraction_unit.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+
+import pymupdf
+
+from open_cvn import CvnErrorCode, CvnSourceFormat, CvnValidationStatus, parse_cvn_pdf
+from open_cvn.pdf_xml_extraction import extract_cvn_xml_from_pdf
+
+
+CVN_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<CVNRoot xmlns="https://example.test/cvn">
+  <CVNCode>000.010.000.000</CVNCode>
+</CVNRoot>
+"""
+
+
+def _save_empty_pdf(path: Path) -> None:
+    document = pymupdf.open()
+    document.new_page()
+    document.save(path)
+    document.close()
+
+
+def _save_pdf_with_embedded_xml(path: Path) -> None:
+    document = pymupdf.open()
+    document.new_page()
+    document.embfile_add("cvn.xml", CVN_XML.encode("utf-8"), filename="cvn.xml")
+    document.save(path)
+    document.close()
+
+
+def _save_pdf_with_xml_metadata(path: Path) -> None:
+    document = pymupdf.open()
+    document.new_page()
+    document.set_xml_metadata(CVN_XML)
+    document.save(path)
+    document.close()
+
+
+def test_extracts_cvn_xml_from_embedded_file(tmp_path):
+    pdf_path = tmp_path / "cvn-embedded.pdf"
+    _save_pdf_with_embedded_xml(pdf_path)
+
+    result = extract_cvn_xml_from_pdf(pdf_path)
+
+    assert result.extracted_xml is not None
+    assert result.extracted_xml.source_kind == "embedded_file"
+    assert result.extracted_xml.source_name == "cvn.xml"
+    assert "CVNRoot" in result.extracted_xml.xml_text
+    assert result.diagnostics.embedded_file_count == 1
+
+
+def test_extracts_cvn_xml_from_pdf_xml_metadata(tmp_path):
+    pdf_path = tmp_path / "cvn-metadata.pdf"
+    _save_pdf_with_xml_metadata(pdf_path)
+
+    result = extract_cvn_xml_from_pdf(pdf_path)
+
+    assert result.extracted_xml is not None
+    assert result.extracted_xml.source_kind == "xml_metadata"
+    assert result.extracted_xml.metadata_xref is not None
+    assert "CVNRoot" in result.extracted_xml.xml_text
+    assert result.diagnostics.metadata_present is True
+
+
+def test_parse_cvn_pdf_returns_extracted_xml_result(tmp_path):
+    pdf_path = tmp_path / "cvn.pdf"
+    _save_pdf_with_embedded_xml(pdf_path)
+
+    result = parse_cvn_pdf(pdf_path)
+
+    assert result.source_format == CvnSourceFormat.PDF
+    assert result.validation_status == CvnValidationStatus.NOT_RUN
+    assert result.errors == ()
+    assert result.data is not None
+    assert "CVNRoot" in result.data["xml_text"]
+    assert result.data["extraction"]["source_kind"] == "embedded_file"
+    assert result.trace is not None
+    assert result.trace.extracted_from == "embedded_file:cvn.xml"
+
+
+def test_parse_cvn_pdf_without_xml_returns_structured_failure(tmp_path):
+    pdf_path = tmp_path / "no-xml.pdf"
+    _save_empty_pdf(pdf_path)
+
+    result = parse_cvn_pdf(pdf_path)
+
+    assert result.validation_status == CvnValidationStatus.FAILED
+    assert result.errors[0].code == CvnErrorCode.PDF_WITHOUT_EXTRACTABLE_XML
+    assert result.errors[0].details["embedded_file_count"] == 0
+    assert result.errors[0].details["candidate_count"] == 0
+
+
+def test_parse_cvn_pdf_unreadable_input_returns_structured_failure():
+    result = parse_cvn_pdf(b"not a pdf", source_identifier="broken.pdf")
+
+    assert result.validation_status == CvnValidationStatus.FAILED
+    assert result.errors[0].code == CvnErrorCode.UNREADABLE_FILE
+    assert result.source_identifier == "broken.pdf"
+
+
+def test_parse_cvn_pdf_mapping_input_is_unsupported():
+    result = parse_cvn_pdf({"not": "pdf"}, source_identifier="mapping")
+
+    assert result.validation_status == CvnValidationStatus.FAILED
+    assert result.errors[0].code == CvnErrorCode.UNSUPPORTED_INPUT_FORMAT
+
+
+def test_page_text_is_not_used_as_cvn_xml_fallback(tmp_path):
+    pdf_path = tmp_path / "visible-cvn-text.pdf"
+    document = pymupdf.open()
+    page = document.new_page()
+    page.insert_text((72, 72), CVN_XML)
+    document.save(pdf_path)
+    document.close()
+
+    result = parse_cvn_pdf(pdf_path)
+
+    assert result.validation_status == CvnValidationStatus.FAILED
+    assert result.errors[0].code == CvnErrorCode.PDF_WITHOUT_EXTRACTABLE_XML

--- a/uv.lock
+++ b/uv.lock
@@ -218,6 +218,23 @@ wheels = [
 ]
 
 [[package]]
+name = "pymupdf"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/e9/6d6c5d6c0a3551bffd47681a6240caf941727f195b45593cf20ab36f018f/pymupdf-1.28.0.tar.gz", hash = "sha256:e53f3567403a92da15caa9e7ae0164327fff48817e9f40175367fb9de524258d", size = 87637751, upload-time = "2026-06-29T09:08:47.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/b7/88043e38cc7529de070f0c9bd267fa258035cca0b4ad5260536b994594a7/pymupdf-1.28.0-cp310-abi3-macosx_10_15_x86_64.whl", hash = "sha256:892b89ba88e8f98b53133b62877a9dc9b5e7dc6a4aeb837b612db56a8d2e03ac", size = 24597385, upload-time = "2026-06-29T09:03:30.608Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f4/23775bbda0781b61fc398cc75079a2b0e64696d8fcf93271748883e9627e/pymupdf-1.28.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:4d692dcf44d3566ae96bc6f6346c6ad432274a29ba617bf7a9fe18009e24adb4", size = 23828292, upload-time = "2026-06-29T09:03:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f5/bf75fc7a415722f8b33662054f82d88520c0cbfd4c36d0e08aeaec605e49/pymupdf-1.28.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:47a5c29ed4eb0744de9c4e37bb49b1259b18d4d75fcc8a7c130f7c9fa15956f6", size = 25045507, upload-time = "2026-06-29T09:04:03.86Z" },
+    { url = "https://files.pythonhosted.org/packages/58/69/5d12c9f1f2d76f28383d6110a069c79fbfced5a4f97bb1ee6e8354f52bb7/pymupdf-1.28.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:44f0973f5e5edbaec95bc34b64e71d1959d4ee90b1328de1b4f4f5b4fa78673f", size = 25716599, upload-time = "2026-06-29T09:04:19.367Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b4/ec0e017bc42857cc86bd651441dbc41cc18be48d4698ecd27aac491e0c9a/pymupdf-1.28.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4d61ec323a706e153a12e262e51febfb43eeaa20977785ace135d18d48bcdc83", size = 25940489, upload-time = "2026-06-29T09:04:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/06/86/f831fef09013f33b3c9c09fb3923f2ff53e1e437f6ace14b8ae46392f558/pymupdf-1.28.0-cp310-abi3-win32.whl", hash = "sha256:caea2b3b67347fd79e5d15ed7929b0e886aac594ea228073b6d39de0078189da", size = 18489703, upload-time = "2026-06-29T20:50:30.599Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/5d/1a03f53eb0449900469335fcfc742ca28e3ba159b7d650e0921d50b8b308/pymupdf-1.28.0-cp310-abi3-win_amd64.whl", hash = "sha256:e01e90fd86abfeb37ceb921eddb951f988a11d45ff6ce6b7664f2039849068ec", size = 19773102, upload-time = "2026-06-29T09:04:49.773Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f6/1e52ce243ca792254f6223b4017c5667194c146ce9b88baf37bc5eb3d1c9/pymupdf-1.28.0-cp313-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:74c6d00ba2a9aad3a635db73b07c15db462b480741d831a34a75a56535ebc22b", size = 18357011, upload-time = "2026-06-29T20:50:50.353Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b1/46b5b3d8ef3cc71114667cf10c4d8b33f39af97253af32e9a0986775b638/pymupdf-1.28.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b3e1399c7a64c6914239116a369efcdaac4cfb9e838bde2656d7accc4a85c72d", size = 25753599, upload-time = "2026-06-29T09:05:09.398Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -277,6 +294,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
+    { name = "pymupdf" },
 ]
 
 [package.dev-dependencies]
@@ -290,7 +308,10 @@ testing = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.12.5" }]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "pymupdf", specifier = ">=1.26" },
+]
 
 [package.metadata.requires-dev]
 codegen = [


### PR DESCRIPTION
## Summary

- Implement deterministic CVN XML extraction from PDF inputs behind `parse_cvn_pdf(...)`
- Add PyMuPDF runtime dependency for embedded-file and XML metadata access
- Add structured PDF parser results for extracted XML, unreadable PDFs, unsupported inputs, and PDFs without extractable XML
- Add synthetic PDF tests for embedded XML, XML metadata, no-XML PDFs, unreadable inputs, and no page-text fallback
- Update issue 48 and parser contract documentation

## Scope

- PDF extraction only
- No OCR fallback
- No LLM reconstruction
- No page text reconstruction
- No XML-to-domain or Open CVN JSON validation, deferred to issue 49

## Verification

- `uv run pytest -n auto tests/test_pdf_xml_extraction_unit.py tests/test_parser_validator_contract_unit.py -v`
- `uv run pytest -n auto tests`

closes #47  and #48  