### PR TITLE
feat(open-cvn): add XML and JSON import validation

### DIFF
--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -2,7 +2,7 @@
 
 ## Status Date
 
-- Last updated: 2026-07-05
+- Last updated: 2026-07-06
 
 ## Completed Or Stabilized Work
 
@@ -624,6 +624,46 @@
 - full-suite verification result:
   `354 passed in 850.95s (0:14:10)`
 
+### Issue `#49`
+
+- Open CVN JSON import validation is implemented behind the issue `#47` public
+  parser contract
+- CVN XML import validation is implemented behind the issue `#47` public parser
+  contract
+- new runtime modules exist under:
+  - `src/open_cvn/import_utils.py`
+  - `src/open_cvn/json_import.py`
+  - `src/open_cvn/open_cvn_models.py`
+  - `src/open_cvn/xml_import.py`
+- `parse_open_cvn_json(...)` now accepts path, inline JSON string, JSON bytes, and
+  mapping inputs
+- `validate_open_cvn_json(...)` validates the generated
+  `schemas/open_cvn.schema.json` Draft 2020-12 artifact before applying Pydantic
+  runtime model checks
+- JSON import failures are reported through structured issue `#47` errors:
+  - `invalid_json`
+  - `json_schema_validation_failure`
+  - `pydantic_validation_failure`
+- `parse_cvn_xml(...)` now accepts path, inline XML string, and XML bytes inputs
+- CVN XML import performs well-formedness checks, CVN plausibility checks, XML path
+  trace extraction, and CVN code-like trace extraction
+- plausible CVN XML currently maps to a conservative Open CVN trace-only document
+  with import diagnostics under `extensions["x-open-cvn.import"]`
+- full semantic XML-to-domain mapping remains a documented limitation because the
+  runtime importer does not yet have enough curated mapping behavior for arbitrary
+  CVN XML records
+- synthetic JSON and XML fixtures exist under:
+  - `tests/fixtures/open_cvn/`
+  - `tests/fixtures/cvn_xml/`
+- targeted issue `#49` verification passed with:
+  `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_cvn_xml_import_unit.py tests/test_parser_validator_contract_unit.py -v`
+- targeted verification result:
+  `28 passed in 16.04s`
+- full-suite verification passed with:
+  `uv run pytest -n auto tests`
+- full-suite verification result:
+  `369 passed in 347.12s (0:05:47)`
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -635,8 +675,9 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#48` closure: issue `#49`, implement XML and JSON
-  import validation behind the same issue `#47` contract
+- Next work item after issue `#49` closure: continue the post-parser Open CVN
+  roadmap, including richer XML semantic mapping or downstream import/export
+  behavior when a later issue defines that scope
 
 ## Blocking Or Relevant Limitations
 
@@ -652,6 +693,8 @@
   hotfix `#7` evidence in the normalization-to-semantic handoff
 - wrapper-aware domain attachment requires normalization runs that provide
   `cvn_xsd_path` and `common_xsd_path`; canonical generation provides them
+- issue `#49` XML import is currently trace-only for plausible CVN XML and does
+  not yet perform full semantic XML-to-domain mapping
 
 All of these are documented in:
 

--- a/docs/pipeline/known_limitations.md
+++ b/docs/pipeline/known_limitations.md
@@ -121,6 +121,39 @@ do not need to rediscover them.
   - issue `#49` should distinguish JSON Schema validation from semantic validation
     that depends on external registries or curated project rules
 
+## Parser And Import Limitations
+
+### CVN XML Import Is Trace-Only For Plausible CVN XML
+
+- Confirmed behavior:
+  - issue `#49` can read CVN XML inputs, check XML well-formedness, detect basic
+    CVN evidence, preserve XML paths, and preserve CVN code-like trace values
+  - plausible CVN XML maps to an Open CVN document with empty curriculum sections
+    and import diagnostics under `extensions["x-open-cvn.import"]`
+  - arbitrary CVN XML records are not yet semantically mapped into domain entries
+- Impact:
+  - XML import now provides structured validation and trace preservation, but it is
+    not yet a full CVN XML-to-Open-CVN semantic converter
+  - downstream consumers should treat `mapping_status = "trace_only"` as an import
+    diagnostic, not as proof that all curriculum content was converted
+- Expected follow-up:
+  - a later issue should define curated XML-to-domain mapping rules before the
+    importer converts real CVN XML records into populated Open CVN sections
+
+### JSON Schema Validation Runs Before Runtime Model Validation
+
+- Confirmed behavior:
+  - issue `#49` validates Open CVN JSON against `schemas/open_cvn.schema.json`
+    before applying Pydantic runtime model checks
+  - documents rejected by the generated schema may never reach runtime model
+    validation
+- Impact:
+  - some invalid JSON documents report `json_schema_validation_failure` even when
+    the same payload would also violate runtime model rules
+- Expected follow-up:
+  - later validator UX work may add grouped multi-layer diagnostics if users need
+    schema and runtime errors in the same result
+
 ## Conceptual Extraction Limitations
 
 ### Conceptual Relationships Require Curation

--- a/docs/pipeline/parser_validator_contract.md
+++ b/docs/pipeline/parser_validator_contract.md
@@ -173,7 +173,7 @@ The result `data` contains:
 
 ### XML
 
-Issue `#49` should implement CVN XML import behind `parse_cvn_xml(...)`.
+Issue `#49` implements CVN XML import behind `parse_cvn_xml(...)`.
 
 Responsibilities:
 
@@ -183,10 +183,20 @@ Responsibilities:
 - report `xml_semantically_unmappable` when structurally readable XML cannot map
   to Open CVN/domain representation
 
+Implemented behavior:
+
+- accepts path, inline XML string, and XML bytes inputs
+- rejects mapping inputs as `unsupported_input_format`
+- validates XML well-formedness with `xml.etree.ElementTree`
+- records simplified XML paths and detected CVN code-like values in trace metadata
+- emits a conservative Open CVN JSON document with trace-only import diagnostics
+  for plausible CVN XML
+- does not yet perform full semantic XML-to-domain mapping from real CVN records
+
 ### JSON
 
-Issue `#49` should implement Open CVN JSON import behind
-`parse_open_cvn_json(...)` and `validate_open_cvn_json(...)`.
+Issue `#49` implements Open CVN JSON import behind `parse_open_cvn_json(...)` and
+`validate_open_cvn_json(...)`.
 
 Responsibilities:
 
@@ -196,6 +206,17 @@ Responsibilities:
   validation when the validation dependency is introduced
 - distinguish JSON Schema validation failures from Pydantic/runtime validation
   failures
+
+Implemented behavior:
+
+- accepts path, inline JSON string, JSON bytes, and already-loaded mapping inputs
+- validates the generated Draft 2020-12 schema with `jsonschema`
+- runs JSON Schema validation before Pydantic runtime validation
+- maps malformed JSON to `invalid_json`
+- maps JSON Schema failures to `json_schema_validation_failure`
+- maps runtime model failures to `pydantic_validation_failure`
+- preserves `schema_version`, `metadata.policy.name`, and
+  `metadata.policy.version` in parser trace metadata
 
 ## Examples
 
@@ -386,6 +407,59 @@ Responsibilities:
     "extracted_from": null,
     "cvn_codes": [],
     "xml_paths": ["CVNRoot"],
+    "schema_version": null,
+    "policy_name": null,
+    "policy_version": null
+  }
+}
+```
+
+### Successful Trace-Only CVN XML Import
+
+```json
+{
+  "source_format": "cvn_xml",
+  "source_identifier": "minimal_cvn.xml",
+  "data": {
+    "schema_version": "0.1.0",
+    "metadata": {
+      "source": {
+        "format": "cvn_xml",
+        "identifier": "minimal_cvn.xml",
+        "path": "minimal_cvn.xml",
+        "root": "CVNRoot"
+      },
+      "policy": {
+        "name": "default_cvn_semantic_policy",
+        "version": "0.1.0"
+      }
+    },
+    "curriculum": {
+      "identity": {},
+      "education": [],
+      "research": [],
+      "professional_experience": [],
+      "achievements": [],
+      "other": []
+    },
+    "extensions": {
+      "x-open-cvn.import": {
+        "cvn_codes": ["000.010.000.000"],
+        "xml_paths": ["CVNRoot", "CVNRoot/CVNItem[1]"],
+        "mapping_status": "trace_only"
+      }
+    }
+  },
+  "validation_status": "valid",
+  "warnings": [],
+  "errors": [],
+  "trace": {
+    "source_format": "cvn_xml",
+    "source_identifier": "minimal_cvn.xml",
+    "source_path": "minimal_cvn.xml",
+    "extracted_from": null,
+    "cvn_codes": ["000.010.000.000"],
+    "xml_paths": ["CVNRoot", "CVNRoot/CVNItem[1]"],
     "schema_version": null,
     "policy_name": null,
     "policy_version": null

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -43,7 +43,7 @@ Goal:
 | `#46` | Define canonical Open CVN JSON format | Completed | Canonical root, metadata, curriculum sections, entries, trace, extensions, examples, and schema alignment implemented |
 | `#47` | Define unified parser and validator contract | Completed | Public `open_cvn` contract package, structured result/error/trace models, deferred parser signatures, docs, and tests implemented |
 | `#48` | Extract CVN XML from PDF inputs | Completed | Deterministic PDF XML extraction implemented behind `parse_cvn_pdf(...)` with embedded-file and XML metadata support |
-| `#49` | Validate XML and JSON import paths | Planned | Should implement CVN XML and Open CVN JSON import validation behind the issue `#47` contract |
+| `#49` | Validate XML and JSON import paths | Completed | JSON Schema plus Pydantic Open CVN JSON validation implemented; CVN XML well-formedness, trace extraction, and trace-only Open CVN mapping implemented |
 
 Corrective planning after hotfixes `#4`, `#5`, and `#6`:
 

--- a/docs/roadmap/issues/issue-49-xml-json-import-validation.md
+++ b/docs/roadmap/issues/issue-49-xml-json-import-validation.md
@@ -51,6 +51,573 @@ The JSON path should:
 7. add tests for structured errors and trace preservation
 8. document parser examples
 
+## Accepted Execution Protocol
+
+For each execution step, the implementer must report:
+
+1. current task number and task name
+2. current subtask number and subtask name, when a subtask is being executed
+3. short initial summary of what the task or subtask will do
+4. short final result for the task or subtask
+5. whether the user must modify any file manually
+6. next step to follow
+
+File-modification rule:
+
+- documentation changes may be performed when explicitly requested
+- code changes should be left for the user unless the user explicitly authorizes
+  the agent to edit code
+- generated code under `src/generated/` must not be edited manually
+- generated domain code under `src/models/cvn/generated/` must not be edited
+  manually
+
+## Accepted Execution Plan
+
+### Task `1 / 21` - Confirm Baseline
+
+- Task summary:
+  - confirm the existing parser contract, JSON Schema artifact, examples, and test
+    baseline before implementation work starts
+- Files involved:
+  - `src/open_cvn/parser_contract.py`
+  - `schemas/open_cvn.schema.json`
+  - `examples/open_cvn/*.json`
+  - `tests/test_parser_validator_contract_unit.py`
+  - `tests/test_open_cvn_json_format_examples.py`
+- Subtask `1.1 / 21`:
+  - review the current XML and JSON stubs in `parser_contract.py`
+- Subtask `1.2 / 21`:
+  - review the generated Open CVN JSON Schema artifact
+- Subtask `1.3 / 21`:
+  - review representative Open CVN JSON examples
+- Subtask `1.4 / 21`:
+  - review existing parser contract and JSON format tests
+- User manual modifications needed:
+  - none expected; this task is read-only
+- Next step:
+  - design runtime Open CVN validation models
+
+### Task `2 / 21` - Design Runtime Open CVN Models
+
+- Task summary:
+  - define the Pydantic runtime model layer used by JSON import validation without
+    exposing generated structural or generated domain modules as the public JSON
+    contract
+- Files involved if code implementation is authorized:
+  - `src/open_cvn/open_cvn_models.py`
+  - `src/open_cvn/__init__.py` if public exports are needed
+- Subtask `2.1 / 21`:
+  - model the root fields `schema_version`, `metadata`, `curriculum`, and
+    `extensions`
+- Subtask `2.2 / 21`:
+  - model `metadata.policy.name` and `metadata.policy.version`
+- Subtask `2.3 / 21`:
+  - model optional metadata fields such as `language`, `source`, `created_at`,
+    `updated_at`, and `generator`
+- Subtask `2.4 / 21`:
+  - model `curriculum.identity` as a single object and repeated curriculum
+    sections as entry arrays
+- Subtask `2.5 / 21`:
+  - model repeated entries with `id`, `type`, `data`, `trace`, and `extensions`
+- Subtask `2.6 / 21`:
+  - choose open or strict `extra` behavior per model according to issue `#46`
+    extension rules
+- User manual modifications needed:
+  - code files must be modified by the user unless code editing is explicitly
+    authorized
+- Next step:
+  - implement common parser result helpers
+
+### Task `3 / 21` - Implement Common Parser Utilities
+
+- Task summary:
+  - create shared helpers for input classification, trace construction, and
+    structured issue conversion so XML and JSON paths behave consistently
+- Files involved if code implementation is authorized:
+  - `src/open_cvn/parser_contract.py`
+  - optional helper module such as `src/open_cvn/import_utils.py`
+- Subtask `3.1 / 21`:
+  - classify `Path`, `str`, `bytes`, and `Mapping` inputs consistently
+- Subtask `3.2 / 21`:
+  - distinguish existing filesystem paths from inline JSON or XML text
+- Subtask `3.3 / 21`:
+  - create a common `CvnParseTrace` builder
+- Subtask `3.4 / 21`:
+  - create reusable `CvnParseIssue` builders for warning and error cases
+- Subtask `3.5 / 21`:
+  - convert Pydantic validation errors into structured parser issues
+- Subtask `3.6 / 21`:
+  - convert JSON Schema validation errors into structured parser issues
+- User manual modifications needed:
+  - code files must be modified by the user unless code editing is explicitly
+    authorized
+- Next step:
+  - add JSON Schema validation dependency and integration
+
+### Task `4 / 21` - Add JSON Schema Validation Dependency
+
+- Task summary:
+  - add a runtime JSON Schema validator compatible with the generated Draft
+    2020-12 schema artifact
+- Files involved if code implementation is authorized:
+  - `pyproject.toml`
+  - dependency lock files if present after environment sync
+- Subtask `4.1 / 21`:
+  - add `jsonschema>=4.26` to runtime dependencies
+- Subtask `4.2 / 21`:
+  - use `Draft202012Validator.check_schema(...)` for schema sanity checks
+- Subtask `4.3 / 21`:
+  - use `Draft202012Validator(schema).iter_errors(document)` for deterministic
+    multi-error collection
+- Subtask `4.4 / 21`:
+  - avoid optional format extras unless a later validation requirement needs them
+- User manual modifications needed:
+  - dependency files must be modified by the user unless code editing is
+    explicitly authorized
+- Next step:
+  - implement Open CVN JSON loading
+
+### Task `5 / 21` - Implement Open CVN JSON Loading
+
+- Task summary:
+  - implement `parse_open_cvn_json(...)` input loading while preserving the issue
+    `#47` result and error contract
+- Files involved if code implementation is authorized:
+  - `src/open_cvn/parser_contract.py`
+  - optional helper module such as `src/open_cvn/json_import.py`
+- Subtask `5.1 / 21`:
+  - accept JSON from path inputs
+- Subtask `5.2 / 21`:
+  - accept inline JSON strings
+- Subtask `5.3 / 21`:
+  - accept JSON bytes
+- Subtask `5.4 / 21`:
+  - accept already-loaded mappings and route them to `validate_open_cvn_json(...)`
+- Subtask `5.5 / 21`:
+  - return `invalid_json` for malformed JSON with line and column detail when
+    available
+- Subtask `5.6 / 21`:
+  - return `unreadable_file` for unreadable path input
+- Subtask `5.7 / 21`:
+  - preserve `schema_version`, `metadata.policy.name`, and
+    `metadata.policy.version` in trace metadata
+- User manual modifications needed:
+  - code files must be modified by the user unless code editing is explicitly
+    authorized
+- Next step:
+  - implement JSON Schema validation
+
+### Task `6 / 21` - Implement JSON Schema Validation
+
+- Task summary:
+  - validate loaded Open CVN JSON documents against
+    `schemas/open_cvn.schema.json` and normalize validation failures into the
+    common parser contract
+- Files involved if code implementation is authorized:
+  - `src/open_cvn/json_import.py`
+  - `schemas/open_cvn.schema.json` only if regeneration is required by a detected
+    schema issue
+- Subtask `6.1 / 21`:
+  - load the canonical schema artifact from a stable repository-relative path
+- Subtask `6.2 / 21`:
+  - validate the schema artifact against Draft 2020-12 meta-schema
+- Subtask `6.3 / 21`:
+  - validate JSON documents and collect all schema errors deterministically
+- Subtask `6.4 / 21`:
+  - map schema failures to `json_schema_validation_failure`
+- Subtask `6.5 / 21`:
+  - include serializable diagnostics such as validator name, validator value, and
+    message in issue details
+- User manual modifications needed:
+  - code files must be modified by the user unless code editing is explicitly
+    authorized
+- Next step:
+  - implement Pydantic runtime validation
+
+### Task `7 / 21` - Implement Pydantic Runtime Validation
+
+- Task summary:
+  - validate JSON documents against Open CVN runtime models after JSON Schema has
+    accepted the external document shape
+- Files involved if code implementation is authorized:
+  - `src/open_cvn/open_cvn_models.py`
+  - `src/open_cvn/json_import.py`
+  - `src/open_cvn/parser_contract.py`
+- Subtask `7.1 / 21`:
+  - implement `validate_open_cvn_json(document, *, source_identifier=None)`
+- Subtask `7.2 / 21`:
+  - reject non-mapping documents through `pydantic_validation_failure`
+- Subtask `7.3 / 21`:
+  - run JSON Schema validation before Pydantic runtime validation
+- Subtask `7.4 / 21`:
+  - map Pydantic validation errors to `pydantic_validation_failure`
+- Subtask `7.5 / 21`:
+  - return `valid` with normalized data and trace when both validation layers pass
+- Subtask `7.6 / 21`:
+  - return `valid_with_warnings` only when warning issues exist
+- User manual modifications needed:
+  - code files must be modified by the user unless code editing is explicitly
+    authorized
+- Next step:
+  - implement Open CVN JSON versioning rules
+
+### Task `8 / 21` - Implement Open CVN JSON Versioning Rules
+
+- Task summary:
+  - enforce issue `#46` parser expectations for compatible, future, and unknown
+    Open CVN JSON versions
+- Files involved if code implementation is authorized:
+  - `src/open_cvn/open_cvn_models.py`
+  - `src/open_cvn/json_import.py`
+  - tests covering accepted and rejected versions
+- Subtask `8.1 / 21`:
+  - accept the initial canonical version `0.1.0`
+- Subtask `8.2 / 21`:
+  - reject unknown major versions unless a future configuration explicitly allows
+    best-effort parsing
+- Subtask `8.3 / 21`:
+  - emit a warning for newer compatible minor versions if the schema permits them
+- Subtask `8.4 / 21`:
+  - keep Open CVN format versioning separate from JSON Schema draft metadata
+- User manual modifications needed:
+  - code files must be modified by the user unless code editing is explicitly
+    authorized
+- Next step:
+  - implement CVN XML loading
+
+### Task `9 / 21` - Implement CVN XML Loading
+
+- Task summary:
+  - implement `parse_cvn_xml(...)` input loading, XML well-formedness checks, and
+    basic CVN plausibility classification
+- Files involved if code implementation is authorized:
+  - `src/open_cvn/parser_contract.py`
+  - optional helper module such as `src/open_cvn/xml_import.py`
+- Subtask `9.1 / 21`:
+  - accept XML from path inputs
+- Subtask `9.2 / 21`:
+  - accept inline XML strings
+- Subtask `9.3 / 21`:
+  - accept XML bytes
+- Subtask `9.4 / 21`:
+  - reject mapping input as `unsupported_input_format`
+- Subtask `9.5 / 21`:
+  - classify unreadable paths as `unreadable_file`
+- Subtask `9.6 / 21`:
+  - classify malformed XML as `invalid_xml`
+- Subtask `9.7 / 21`:
+  - classify well-formed but non-CVN XML as `xml_semantically_unmappable`
+- User manual modifications needed:
+  - code files must be modified by the user unless code editing is explicitly
+    authorized
+- Next step:
+  - implement XML trace extraction
+
+### Task `10 / 21` - Implement XML Trace Extraction
+
+- Task summary:
+  - extract portable trace metadata from CVN XML without leaking personal data into
+    parser diagnostics
+- Files involved if code implementation is authorized:
+  - `src/open_cvn/xml_import.py`
+  - XML fixture files under `tests/fixtures/` if tests are implemented
+- Subtask `10.1 / 21`:
+  - extract the root XML path
+- Subtask `10.2 / 21`:
+  - collect simplified XML paths for relevant elements
+- Subtask `10.3 / 21`:
+  - detect CVN code-like values from tags, attributes, and text when reliable
+- Subtask `10.4 / 21`:
+  - deduplicate trace values while preserving deterministic order
+- Subtask `10.5 / 21`:
+  - avoid copying full personal XML payloads into errors or trace details
+- User manual modifications needed:
+  - code files and fixtures must be modified by the user unless editing is
+    explicitly authorized
+- Next step:
+  - evaluate structural binding reuse for XML parsing
+
+### Task `11 / 21` - Evaluate XML Structural Binding Reuse
+
+- Task summary:
+  - decide whether existing generated structural bindings can safely support the
+    XML import path without broad new mapping complexity
+- Files involved:
+  - `src/generated/cvn/`
+  - generated binding smoke tests if existing
+  - `src/open_cvn/xml_import.py` if implementation is authorized
+- Subtask `11.1 / 21`:
+  - identify generated CVN root binding classes and parser support already present
+- Subtask `11.2 / 21`:
+  - try structural parse on synthetic XML fixtures if implementation is authorized
+- Subtask `11.3 / 21`:
+  - use structural bindings only if they improve validation without breaking the
+    issue `#47` public contract
+- Subtask `11.4 / 21`:
+  - fall back to ElementTree-based import and document the limitation if binding
+    reuse is not reliable enough
+- User manual modifications needed:
+  - no generated files may be edited manually; code changes require explicit
+    authorization
+- Next step:
+  - implement XML-to-Open-CVN mapping prototype
+
+### Task `12 / 21` - Implement XML-To-Open-CVN Mapping Prototype
+
+- Task summary:
+  - create a conservative XML-to-Open-CVN mapping path that preserves trace and
+    does not invent unavailable semantic mappings
+- Files involved if code implementation is authorized:
+  - `src/open_cvn/xml_import.py`
+  - `src/open_cvn/open_cvn_models.py`
+- Subtask `12.1 / 21`:
+  - produce an Open CVN root document with `schema_version`, `metadata`,
+    `curriculum`, and `extensions`
+- Subtask `12.2 / 21`:
+  - set `metadata.source` from XML source identity
+- Subtask `12.3 / 21`:
+  - preserve import diagnostics under a documented extension key
+- Subtask `12.4 / 21`:
+  - map identity fields only when source evidence is stable
+- Subtask `12.5 / 21`:
+  - return `xml_semantically_unmappable` when XML is readable but current semantic
+    evidence cannot produce trustworthy Open CVN data
+- Subtask `12.6 / 21`:
+  - record any mapping shortfall as a known limitation
+- User manual modifications needed:
+  - code files must be modified by the user unless code editing is explicitly
+    authorized
+- Next step:
+  - document and test PDF-to-XML handoff behavior
+
+### Task `13 / 21` - Integrate PDF-To-XML Handoff
+
+- Task summary:
+  - confirm issue `#48` PDF extraction remains extraction-only and document how to
+    pass extracted XML into the issue `#49` XML import path
+- Files involved if documentation or tests are authorized:
+  - `docs/pipeline/parser_validator_contract.md`
+  - PDF/XML parser tests
+- Subtask `13.1 / 21`:
+  - keep `parse_cvn_pdf(...)` return status as `not_run` on successful extraction
+- Subtask `13.2 / 21`:
+  - document that `data["xml_text"]` can be passed to `parse_cvn_xml(...)`
+- Subtask `13.3 / 21`:
+  - avoid adding OCR, page text reconstruction, or automatic PDF domain validation
+    in this issue
+- User manual modifications needed:
+  - documentation/test files must be modified by the user unless editing is
+    explicitly authorized
+- Next step:
+  - create valid and invalid fixtures
+
+### Task `14 / 21` - Create Import Fixtures
+
+- Task summary:
+  - add deterministic synthetic fixtures for valid and invalid JSON and XML import
+    scenarios without real personal data
+- Files involved if fixture creation is authorized:
+  - `tests/fixtures/open_cvn/`
+  - `tests/fixtures/cvn_xml/`
+- Subtask `14.1 / 21`:
+  - create valid Open CVN JSON fixtures from existing examples
+- Subtask `14.2 / 21`:
+  - create malformed JSON fixture
+- Subtask `14.3 / 21`:
+  - create wrong-shape JSON fixture for schema failure
+- Subtask `14.4 / 21`:
+  - create JSON fixture for runtime Pydantic or version failure
+- Subtask `14.5 / 21`:
+  - create minimal synthetic CVN-like XML fixture
+- Subtask `14.6 / 21`:
+  - create malformed XML fixture
+- Subtask `14.7 / 21`:
+  - create well-formed non-CVN XML fixture
+- User manual modifications needed:
+  - fixture files must be modified by the user unless editing is explicitly
+    authorized
+- Next step:
+  - add JSON import tests
+
+### Task `15 / 21` - Add Open CVN JSON Import Tests
+
+- Task summary:
+  - verify JSON loading, JSON Schema validation, Pydantic validation, structured
+    errors, and trace preservation
+- Files involved if test implementation is authorized:
+  - `tests/test_open_cvn_json_import_unit.py`
+  - JSON fixtures under `tests/fixtures/open_cvn/`
+- Subtask `15.1 / 21`:
+  - test JSON path input
+- Subtask `15.2 / 21`:
+  - test inline JSON string input
+- Subtask `15.3 / 21`:
+  - test JSON bytes input
+- Subtask `15.4 / 21`:
+  - test mapping input
+- Subtask `15.5 / 21`:
+  - test malformed JSON returns `invalid_json`
+- Subtask `15.6 / 21`:
+  - test schema failures return `json_schema_validation_failure`
+- Subtask `15.7 / 21`:
+  - test runtime validation failures return `pydantic_validation_failure`
+- Subtask `15.8 / 21`:
+  - test valid JSON returns `valid` and preserves trace metadata
+- User manual modifications needed:
+  - test files must be modified by the user unless editing is explicitly
+    authorized
+- Next step:
+  - add CVN XML import tests
+
+### Task `16 / 21` - Add CVN XML Import Tests
+
+- Task summary:
+  - verify XML loading, well-formedness errors, semantic-unmappable errors, and
+    trace preservation
+- Files involved if test implementation is authorized:
+  - `tests/test_cvn_xml_import_unit.py`
+  - XML fixtures under `tests/fixtures/cvn_xml/`
+- Subtask `16.1 / 21`:
+  - test XML path input
+- Subtask `16.2 / 21`:
+  - test inline XML string input
+- Subtask `16.3 / 21`:
+  - test XML bytes input
+- Subtask `16.4 / 21`:
+  - test unreadable XML path returns `unreadable_file`
+- Subtask `16.5 / 21`:
+  - test malformed XML returns `invalid_xml`
+- Subtask `16.6 / 21`:
+  - test well-formed non-CVN XML returns `xml_semantically_unmappable`
+- Subtask `16.7 / 21`:
+  - test XML trace preserves paths and detected CVN codes
+- User manual modifications needed:
+  - test files must be modified by the user unless editing is explicitly
+    authorized
+- Next step:
+  - update existing parser contract tests
+
+### Task `17 / 21` - Update Existing Parser Contract Tests
+
+- Task summary:
+  - replace deferred XML and JSON expectations with concrete issue `#49` behavior
+    while preserving issue `#47` result invariants
+- Files involved if test implementation is authorized:
+  - `tests/test_parser_validator_contract_unit.py`
+  - `tests/test_pdf_xml_extraction_unit.py` only if PDF regression coverage needs
+    adjustment
+- Subtask `17.1 / 21`:
+  - remove `NotImplementedError` expectations for XML and JSON functions
+- Subtask `17.2 / 21`:
+  - keep enum and result invariant tests unchanged unless the public contract
+    changes
+- Subtask `17.3 / 21`:
+  - add contract-level smoke tests for XML and JSON result envelopes
+- Subtask `17.4 / 21`:
+  - confirm `parse_cvn_pdf(...)` behavior remains unchanged
+- User manual modifications needed:
+  - test files must be modified by the user unless editing is explicitly
+    authorized
+- Next step:
+  - update parser usage documentation
+
+### Task `18 / 21` - Update Parser Usage Documentation
+
+- Task summary:
+  - document concrete XML and JSON import behavior, examples, validation order,
+    and known mapping limits
+- Files involved if documentation updates are authorized:
+  - `docs/pipeline/parser_validator_contract.md`
+  - optional usage examples under `docs/` if needed
+- Subtask `18.1 / 21`:
+  - update JSON success and failure examples
+- Subtask `18.2 / 21`:
+  - update XML invalid and semantically-unmappable examples
+- Subtask `18.3 / 21`:
+  - document JSON Schema validation before Pydantic runtime validation
+- Subtask `18.4 / 21`:
+  - document dependency on the `jsonschema` package
+- Subtask `18.5 / 21`:
+  - document XML mapping limits if full semantic mapping remains incomplete
+- User manual modifications needed:
+  - documentation files may be modified by the agent when explicitly requested;
+    otherwise user-owned
+- Next step:
+  - update the issue record
+
+### Task `19 / 21` - Update Issue 49 Record
+
+- Task summary:
+  - record final implementation, deviations from the accepted plan, artifacts,
+    verification, and remaining risks in the issue document
+- Files involved:
+  - `docs/roadmap/issues/issue-49-xml-json-import-validation.md`
+- Subtask `19.1 / 21`:
+  - update status from planned to implemented when implementation is complete
+- Subtask `19.2 / 21`:
+  - record files created or changed
+- Subtask `19.3 / 21`:
+  - record implementation adjustments and limitations
+- Subtask `19.4 / 21`:
+  - record exact verification commands and results
+- User manual modifications needed:
+  - documentation may be modified by the agent when explicitly requested;
+    otherwise user-owned
+- Next step:
+  - update global project status documentation
+
+### Task `20 / 21` - Update Global Project Documentation
+
+- Task summary:
+  - align persistent project state and limitation records with the completed issue
+    `#49` implementation
+- Files involved if documentation updates are authorized:
+  - `docs/context/current_status.md`
+  - `docs/pipeline/known_limitations.md`
+  - `docs/roadmap/cvn_generation_roadmap.md`
+  - `PROJECT_GUIDE.md` only if the human-facing map or orientation changes
+- Subtask `20.1 / 21`:
+  - update current status with implemented XML and JSON import validation behavior
+- Subtask `20.2 / 21`:
+  - update known limitations if XML semantic mapping remains partial or binding
+    reuse is not viable
+- Subtask `20.3 / 21`:
+  - update roadmap status if issue `#49` changes state
+- Subtask `20.4 / 21`:
+  - update `PROJECT_GUIDE.md` only if repository orientation or documentation map
+    changes
+- User manual modifications needed:
+  - documentation may be modified by the agent when explicitly requested;
+    otherwise user-owned
+- Next step:
+  - run verification commands
+
+### Task `21 / 21` - Verify Issue 49 Implementation
+
+- Task summary:
+  - run targeted and full verification to prove XML and JSON import validation work
+    and no existing parser behavior regressed
+- Files involved:
+  - test suite under `tests/`
+  - generated schema artifact only if regeneration is required
+- Subtask `21.1 / 21`:
+  - run targeted parser and JSON format tests
+- Subtask `21.2 / 21`:
+  - run new issue `#49` JSON import tests
+- Subtask `21.3 / 21`:
+  - run new issue `#49` XML import tests
+- Subtask `21.4 / 21`:
+  - run the full repository suite with `uv run pytest -n auto tests`
+- Subtask `21.5 / 21`:
+  - regenerate JSON Schema only if implementation finds schema drift or schema
+    artifact defects
+- Subtask `21.6 / 21`:
+  - confirm no generated source files were manually edited
+- User manual modifications needed:
+  - none expected after implementation files are in place
+- Next step:
+  - close issue `#49` documentation with final verification results
+
 ## Expected Output
 
 - XML import implementation if approved
@@ -66,6 +633,66 @@ The JSON path should:
 - invalid JSON produces structured errors
 - trace metadata survives import when available
 
+## Implemented Outcome
+
+- Runtime Open CVN JSON validation models were added under `src/open_cvn/`.
+- `parse_open_cvn_json(...)` now accepts path, inline JSON string, JSON bytes, and
+  mapping inputs.
+- `validate_open_cvn_json(...)` validates Open CVN documents against the generated
+  Draft 2020-12 schema artifact before applying Pydantic runtime model checks.
+- JSON failures are normalized through the issue `#47` contract as:
+  - `invalid_json`
+  - `json_schema_validation_failure`
+  - `pydantic_validation_failure`
+- `parse_cvn_xml(...)` now accepts path, inline XML string, and XML bytes inputs.
+- CVN XML import performs well-formedness checks, CVN plausibility checks, XML path
+  trace extraction, and CVN code-like trace extraction.
+- Plausible CVN XML currently maps to a conservative Open CVN trace-only document
+  with `extensions["x-open-cvn.import"].mapping_status = "trace_only"`.
+- Well-formed XML without CVN evidence returns `xml_semantically_unmappable`.
+- Synthetic fixtures and tests were added for valid and invalid JSON/XML import
+  cases.
+
+## Implementation Adjustments
+
+- Full semantic XML-to-domain mapping was not implemented in this issue because
+  the available runtime layer does not yet expose enough curated mapping behavior
+  to convert arbitrary CVN XML records into trustworthy domain entries.
+- The XML path uses `xml.etree.ElementTree` for deterministic well-formedness and
+  trace extraction instead of generated structural bindings. Generated bindings
+  remain available, but this issue keeps XML import conservative rather than
+  depending on broad structural-to-domain conversion.
+- JSON Schema validation intentionally runs before Pydantic runtime validation.
+  Therefore, some malformed or unsupported documents fail at the schema layer
+  before runtime model checks execute.
+
+## Artifacts Changed
+
+- `pyproject.toml`
+- `uv.lock`
+- `src/open_cvn/import_utils.py`
+- `src/open_cvn/json_import.py`
+- `src/open_cvn/open_cvn_models.py`
+- `src/open_cvn/xml_import.py`
+- `src/open_cvn/parser_contract.py`
+- `tests/fixtures/open_cvn/`
+- `tests/fixtures/cvn_xml/`
+- `tests/test_open_cvn_json_import_unit.py`
+- `tests/test_cvn_xml_import_unit.py`
+- `tests/test_parser_validator_contract_unit.py`
+- `docs/pipeline/parser_validator_contract.md`
+
+## Verification Performed
+
+- Targeted issue `#49` verification passed with:
+  `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_cvn_xml_import_unit.py tests/test_parser_validator_contract_unit.py -v`
+- Targeted verification result:
+  `28 passed in 16.04s`
+- Full-suite verification passed with:
+  `uv run pytest -n auto tests`
+- Full-suite verification result:
+  `369 passed in 347.12s (0:05:47)`
+
 ## Known Risks
 
 - XML-to-domain mapping may require more semantic decisions than current domain
@@ -80,4 +707,4 @@ The JSON path should:
 
 ## Status
 
-- Status: planned
+- Status: implemented

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-48-cvn-pdf-xml-extraction.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 48. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-49-xml-json-import-validation.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 49. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-48-cvn-pdf-xml-extraction.md.
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-49-xml-json-import-validation.md.
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
+    "jsonschema>=4.26",
     "pydantic>=2.12.5",
     "pymupdf>=1.26",
 ]

--- a/src/open_cvn/import_utils.py
+++ b/src/open_cvn/import_utils.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from pydantic import ValidationError
+
+from open_cvn.parser_contract import (
+    CvnErrorCode,
+    CvnIssueSeverity,
+    CvnParseIssue,
+    CvnParseTrace,
+    CvnSourceFormat,
+)
+
+
+JsonScalar = str | int | float | bool | None
+
+
+@dataclass(frozen=True)
+class LoadedText:
+    text: str
+    source_path: str | None
+    source_identifier: str | None
+
+
+def load_text_input(
+    source: Path | str | bytes,
+    *,
+    source_identifier: str | None,
+    missing_path_is_text: bool,
+) -> LoadedText:
+    if isinstance(source, Path):
+        return _load_path(source, source_identifier=source_identifier)
+    if isinstance(source, bytes):
+        return LoadedText(
+            text=source.decode("utf-8"),
+            source_path=None,
+            source_identifier=source_identifier,
+        )
+    if isinstance(source, str):
+        path = Path(source)
+        if path.exists():
+            return _load_path(path, source_identifier=source_identifier)
+        if not missing_path_is_text and _looks_like_path(source):
+            raise OSError(f"Input path does not exist: {source}")
+        return LoadedText(text=source, source_path=None, source_identifier=source_identifier)
+    raise TypeError(f"Unsupported input type: {type(source).__name__}")
+
+
+def make_trace(
+    *,
+    source_format: CvnSourceFormat,
+    source_identifier: str | None,
+    source_path: str | None = None,
+    extracted_from: str | None = None,
+    cvn_codes: tuple[str, ...] = (),
+    xml_paths: tuple[str, ...] = (),
+    schema_version: str | None = None,
+    policy_name: str | None = None,
+    policy_version: str | None = None,
+) -> CvnParseTrace:
+    return CvnParseTrace(
+        source_format=source_format,
+        source_identifier=source_identifier,
+        source_path=source_path,
+        extracted_from=extracted_from,
+        cvn_codes=cvn_codes,
+        xml_paths=xml_paths,
+        schema_version=schema_version,
+        policy_name=policy_name,
+        policy_version=policy_version,
+    )
+
+
+def make_error(
+    *,
+    code: CvnErrorCode,
+    message: str,
+    source_location: str | None = None,
+    path: tuple[str, ...] = (),
+    details: Mapping[str, Any] | None = None,
+) -> CvnParseIssue:
+    return CvnParseIssue(
+        code=code,
+        severity=CvnIssueSeverity.ERROR,
+        message=message,
+        source_location=source_location,
+        path=path,
+        details=serializable_details(details or {}),
+    )
+
+
+def make_warning(
+    *,
+    code: CvnErrorCode,
+    message: str,
+    source_location: str | None = None,
+    path: tuple[str, ...] = (),
+    details: Mapping[str, Any] | None = None,
+) -> CvnParseIssue:
+    return CvnParseIssue(
+        code=code,
+        severity=CvnIssueSeverity.WARNING,
+        message=message,
+        source_location=source_location,
+        path=path,
+        details=serializable_details(details or {}),
+    )
+
+
+def pydantic_errors_to_issues(error: ValidationError) -> tuple[CvnParseIssue, ...]:
+    issues: list[CvnParseIssue] = []
+    for item in error.errors():
+        issues.append(
+            make_error(
+                code=CvnErrorCode.PYDANTIC_VALIDATION_FAILURE,
+                message=str(item.get("msg", "Pydantic validation failed.")),
+                path=tuple(str(part) for part in item.get("loc", ())),
+                details={"type": item.get("type")},
+            )
+        )
+    return tuple(issues)
+
+
+def extract_json_trace_values(document: Mapping[str, Any]) -> tuple[str | None, str | None, str | None]:
+    schema_version = _string_or_none(document.get("schema_version"))
+    metadata = document.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return schema_version, None, None
+    policy = metadata.get("policy")
+    if not isinstance(policy, Mapping):
+        return schema_version, None, None
+    return (
+        schema_version,
+        _string_or_none(policy.get("name")),
+        _string_or_none(policy.get("version")),
+    )
+
+
+def serializable_details(details: Mapping[str, Any]) -> dict[str, JsonScalar]:
+    result: dict[str, JsonScalar] = {}
+    for key, value in details.items():
+        if value is None or isinstance(value, str | int | float | bool):
+            result[str(key)] = value
+        else:
+            result[str(key)] = json.dumps(value, sort_keys=True, default=str)
+    return result
+
+
+def _load_path(path: Path, *, source_identifier: str | None) -> LoadedText:
+    text = path.read_text(encoding="utf-8")
+    source_path = str(path)
+    return LoadedText(
+        text=text,
+        source_path=source_path,
+        source_identifier=source_identifier or source_path,
+    )
+
+
+def _looks_like_path(source: str) -> bool:
+    return source.endswith((".json", ".xml")) or "/" in source or "\\" in source
+
+
+def _string_or_none(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    return None

--- a/src/open_cvn/json_import.py
+++ b/src/open_cvn/json_import.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
+from pydantic import ValidationError
+
+from open_cvn.import_utils import (
+    extract_json_trace_values,
+    load_text_input,
+    make_error,
+    make_trace,
+    make_warning,
+    pydantic_errors_to_issues,
+    serializable_details,
+)
+from open_cvn.open_cvn_models import OpenCvnDocument, is_newer_compatible_version
+from open_cvn.parser_contract import (
+    CvnErrorCode,
+    CvnInput,
+    CvnParseIssue,
+    CvnParseResult,
+    CvnSourceFormat,
+    CvnValidationStatus,
+)
+
+
+def parse_open_cvn_json(source: CvnInput, *, source_identifier: str | None = None) -> CvnParseResult:
+    if isinstance(source, Mapping):
+        return validate_open_cvn_json(source, source_identifier=source_identifier)
+    try:
+        loaded = load_text_input(
+            source,  # type: ignore[arg-type]
+            source_identifier=source_identifier,
+            missing_path_is_text=True,
+        )
+    except (OSError, UnicodeDecodeError) as exc:
+        return _json_failed_result(
+            source_identifier=source_identifier,
+            source_path=str(source) if isinstance(source, Path | str) else None,
+            error=make_error(
+                code=CvnErrorCode.UNREADABLE_FILE,
+                message="JSON input could not be read.",
+                details={"error": str(exc)},
+            ),
+        )
+    except TypeError as exc:
+        return _json_failed_result(
+            source_identifier=source_identifier,
+            source_path=None,
+            error=make_error(
+                code=CvnErrorCode.UNSUPPORTED_INPUT_FORMAT,
+                message="Open CVN JSON input must be a path, bytes, JSON string, or mapping.",
+                details={"error": str(exc)},
+            ),
+        )
+
+    try:
+        document = json.loads(loaded.text)
+    except json.JSONDecodeError as exc:
+        source_location = f"line {exc.lineno} column {exc.colno}"
+        return _json_failed_result(
+            source_identifier=loaded.source_identifier,
+            source_path=loaded.source_path,
+            error=make_error(
+                code=CvnErrorCode.INVALID_JSON,
+                message="Input is not valid JSON.",
+                source_location=source_location,
+                details={"line": exc.lineno, "column": exc.colno, "error": exc.msg},
+            ),
+        )
+
+    if not isinstance(document, Mapping):
+        return _json_invalid_result(
+            source_identifier=loaded.source_identifier,
+            source_path=loaded.source_path,
+            errors=(
+                make_error(
+                    code=CvnErrorCode.PYDANTIC_VALIDATION_FAILURE,
+                    message="Open CVN JSON document must be an object.",
+                    details={"input_type": type(document).__name__},
+                ),
+            ),
+            document=None,
+        )
+    return validate_open_cvn_json(
+        document,
+        source_identifier=loaded.source_identifier,
+        source_path=loaded.source_path,
+    )
+
+
+def validate_open_cvn_json(
+    document: Mapping[str, Any],
+    *,
+    source_identifier: str | None = None,
+    source_path: str | None = None,
+) -> CvnParseResult:
+    schema_version, policy_name, policy_version = extract_json_trace_values(document)
+    trace = make_trace(
+        source_format=CvnSourceFormat.OPEN_CVN_JSON,
+        source_identifier=source_identifier,
+        source_path=source_path,
+        schema_version=schema_version,
+        policy_name=policy_name,
+        policy_version=policy_version,
+    )
+
+    schema_errors = _validate_json_schema(document)
+    if schema_errors:
+        return CvnParseResult(
+            source_format=CvnSourceFormat.OPEN_CVN_JSON,
+            source_identifier=source_identifier,
+            validation_status=CvnValidationStatus.INVALID,
+            errors=schema_errors,
+            trace=trace,
+        )
+
+    try:
+        open_cvn_document = OpenCvnDocument.model_validate(document)
+    except ValidationError as exc:
+        return CvnParseResult(
+            source_format=CvnSourceFormat.OPEN_CVN_JSON,
+            source_identifier=source_identifier,
+            validation_status=CvnValidationStatus.INVALID,
+            errors=pydantic_errors_to_issues(exc),
+            trace=trace,
+        )
+
+    warnings = _version_warnings(open_cvn_document.schema_version)
+    return CvnParseResult(
+        source_format=CvnSourceFormat.OPEN_CVN_JSON,
+        source_identifier=source_identifier,
+        data=open_cvn_document.model_dump(mode="json", exclude_none=True),
+        validation_status=(
+            CvnValidationStatus.VALID_WITH_WARNINGS if warnings else CvnValidationStatus.VALID
+        ),
+        warnings=warnings,
+        trace=trace,
+    )
+
+
+def _validate_json_schema(document: Mapping[str, Any]) -> tuple[CvnParseIssue, ...]:
+    validator = _json_schema_validator()
+    errors = sorted(
+        validator.iter_errors(document),
+        key=lambda error: (tuple(str(part) for part in error.absolute_path), error.message),
+    )
+    return tuple(_json_schema_error_to_issue(error) for error in errors)
+
+
+@lru_cache(maxsize=1)
+def _json_schema_validator() -> Draft202012Validator:
+    schema = json.loads(_schema_path().read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def _schema_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "schemas" / "open_cvn.schema.json"
+
+
+def _json_schema_error_to_issue(error: JsonSchemaValidationError) -> CvnParseIssue:
+    return make_error(
+        code=CvnErrorCode.JSON_SCHEMA_VALIDATION_FAILURE,
+        message="Open CVN JSON does not match the generated schema.",
+        path=tuple(str(part) for part in error.absolute_path),
+        details=serializable_details(
+            {
+                "message": error.message,
+                "validator": error.validator,
+                "validator_value": error.validator_value,
+            }
+        ),
+    )
+
+
+def _version_warnings(schema_version: str) -> tuple[CvnParseIssue, ...]:
+    if not is_newer_compatible_version(schema_version):
+        return ()
+    return (
+        make_warning(
+            code=CvnErrorCode.PYDANTIC_VALIDATION_FAILURE,
+            message="Open CVN JSON schema_version is newer than the current runtime version.",
+            path=("schema_version",),
+            details={"schema_version": schema_version},
+        ),
+    )
+
+
+def _json_failed_result(
+    *, source_identifier: str | None, source_path: str | None, error: CvnParseIssue
+) -> CvnParseResult:
+    return CvnParseResult(
+        source_format=CvnSourceFormat.OPEN_CVN_JSON,
+        source_identifier=source_identifier or source_path,
+        validation_status=CvnValidationStatus.FAILED,
+        errors=(error,),
+        trace=make_trace(
+            source_format=CvnSourceFormat.OPEN_CVN_JSON,
+            source_identifier=source_identifier or source_path,
+            source_path=source_path,
+        ),
+    )
+
+
+def _json_invalid_result(
+    *,
+    source_identifier: str | None,
+    source_path: str | None,
+    errors: tuple[CvnParseIssue, ...],
+    document: Mapping[str, Any] | None,
+) -> CvnParseResult:
+    schema_version = policy_name = policy_version = None
+    if document is not None:
+        schema_version, policy_name, policy_version = extract_json_trace_values(document)
+    return CvnParseResult(
+        source_format=CvnSourceFormat.OPEN_CVN_JSON,
+        source_identifier=source_identifier,
+        validation_status=CvnValidationStatus.INVALID,
+        errors=errors,
+        trace=make_trace(
+            source_format=CvnSourceFormat.OPEN_CVN_JSON,
+            source_identifier=source_identifier,
+            source_path=source_path,
+            schema_version=schema_version,
+            policy_name=policy_name,
+            policy_version=policy_version,
+        ),
+    )

--- a/src/open_cvn/open_cvn_models.py
+++ b/src/open_cvn/open_cvn_models.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+OPEN_CVN_SCHEMA_VERSION = "0.1.0"
+OPEN_CVN_MAJOR_VERSION = 0
+
+
+class OpenCvnPolicyMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    version: str
+
+
+class OpenCvnMetadata(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    language: str | None = None
+    source: dict[str, Any] | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    generator: dict[str, Any] | None = None
+    policy: OpenCvnPolicyMetadata
+
+
+class OpenCvnTrace(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    cvn_codes: list[str] = Field(default_factory=list)
+    xml_paths: list[str] = Field(default_factory=list)
+    source_files: list[str] = Field(default_factory=list)
+    source_artifacts: list[str] = Field(default_factory=list)
+    manual_reference_table: str | None = None
+    semantic_reference_kind: str | None = None
+    serialization_pattern: str | None = None
+    domain_shape_kind: str | None = None
+    confidence: str | None = None
+
+
+class OpenCvnEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str | None = None
+    type: str
+    data: dict[str, Any]
+    trace: OpenCvnTrace | None = None
+    extensions: dict[str, Any] | None = None
+
+
+class OpenCvnCurriculum(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    identity: dict[str, Any] = Field(default_factory=dict)
+    education: list[OpenCvnEntry] = Field(default_factory=list)
+    research: list[OpenCvnEntry] = Field(default_factory=list)
+    professional_experience: list[OpenCvnEntry] = Field(default_factory=list)
+    achievements: list[OpenCvnEntry] = Field(default_factory=list)
+    other: list[OpenCvnEntry] = Field(default_factory=list)
+
+
+class OpenCvnDocument(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str
+    metadata: OpenCvnMetadata
+    curriculum: OpenCvnCurriculum
+    extensions: dict[str, Any] | None = None
+
+    @field_validator("schema_version")
+    @classmethod
+    def _validate_schema_version(cls, value: str) -> str:
+        major_version = _major_version(value)
+        if major_version != OPEN_CVN_MAJOR_VERSION:
+            raise ValueError(
+                f"Unsupported Open CVN major version: {value}. Expected major {OPEN_CVN_MAJOR_VERSION}."
+            )
+        return value
+
+
+def is_newer_compatible_version(schema_version: str) -> bool:
+    if _major_version(schema_version) != OPEN_CVN_MAJOR_VERSION:
+        return False
+    return schema_version != OPEN_CVN_SCHEMA_VERSION
+
+
+def _major_version(schema_version: str) -> int:
+    try:
+        return int(schema_version.split(".", maxsplit=1)[0])
+    except (AttributeError, ValueError) as exc:
+        raise ValueError(f"Invalid Open CVN schema version: {schema_version}") from exc

--- a/src/open_cvn/parser_contract.py
+++ b/src/open_cvn/parser_contract.py
@@ -199,14 +199,20 @@ def _failed_pdf_result(
 
 
 def parse_cvn_xml(source: CvnInput, *, source_identifier: str | None = None) -> CvnParseResult:
-    raise NotImplementedError(DEFERRED_IMPLEMENTATION_MESSAGE)
+    from open_cvn.xml_import import parse_cvn_xml as _parse_cvn_xml
+
+    return _parse_cvn_xml(source, source_identifier=source_identifier)
 
 
 def parse_open_cvn_json(source: CvnInput, *, source_identifier: str | None = None) -> CvnParseResult:
-    raise NotImplementedError(DEFERRED_IMPLEMENTATION_MESSAGE)
+    from open_cvn.json_import import parse_open_cvn_json as _parse_open_cvn_json
+
+    return _parse_open_cvn_json(source, source_identifier=source_identifier)
 
 
 def validate_open_cvn_json(
     document: Mapping[str, Any], *, source_identifier: str | None = None
 ) -> CvnParseResult:
-    raise NotImplementedError(DEFERRED_IMPLEMENTATION_MESSAGE)
+    from open_cvn.json_import import validate_open_cvn_json as _validate_open_cvn_json
+
+    return _validate_open_cvn_json(document, source_identifier=source_identifier)

--- a/src/open_cvn/xml_import.py
+++ b/src/open_cvn/xml_import.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Mapping
+from xml.etree import ElementTree
+
+from open_cvn.import_utils import load_text_input, make_error, make_trace
+from open_cvn.open_cvn_models import OPEN_CVN_SCHEMA_VERSION
+from open_cvn.parser_contract import (
+    CvnErrorCode,
+    CvnInput,
+    CvnParseIssue,
+    CvnParseResult,
+    CvnSourceFormat,
+    CvnValidationStatus,
+)
+
+
+CVN_CODE_RE = re.compile(r"\b\d{3}\.\d{3}\.\d{3}\.\d{3}\b")
+DEFAULT_POLICY_NAME = "default_cvn_semantic_policy"
+DEFAULT_POLICY_VERSION = "0.1.0"
+
+
+def parse_cvn_xml(source: CvnInput, *, source_identifier: str | None = None) -> CvnParseResult:
+    if isinstance(source, Mapping):
+        return _xml_failed_result(
+            source_identifier=source_identifier,
+            source_path=None,
+            error=make_error(
+                code=CvnErrorCode.UNSUPPORTED_INPUT_FORMAT,
+                message="CVN XML input must be a path, bytes, or XML string.",
+                details={"input_type": type(source).__name__},
+            ),
+        )
+    try:
+        loaded = load_text_input(
+            source,  # type: ignore[arg-type]
+            source_identifier=source_identifier,
+            missing_path_is_text=True,
+        )
+    except (OSError, UnicodeDecodeError) as exc:
+        return _xml_failed_result(
+            source_identifier=source_identifier,
+            source_path=str(source) if isinstance(source, Path | str) else None,
+            error=make_error(
+                code=CvnErrorCode.UNREADABLE_FILE,
+                message="CVN XML input could not be read.",
+                details={"error": str(exc)},
+            ),
+        )
+    except TypeError as exc:
+        return _xml_failed_result(
+            source_identifier=source_identifier,
+            source_path=None,
+            error=make_error(
+                code=CvnErrorCode.UNSUPPORTED_INPUT_FORMAT,
+                message="CVN XML input must be a path, bytes, or XML string.",
+                details={"error": str(exc)},
+            ),
+        )
+
+    try:
+        root = ElementTree.fromstring(loaded.text)
+    except ElementTree.ParseError as exc:
+        return _xml_failed_result(
+            source_identifier=loaded.source_identifier,
+            source_path=loaded.source_path,
+            error=make_error(
+                code=CvnErrorCode.INVALID_XML,
+                message="Input is not well-formed XML.",
+                source_location=_xml_error_location(exc),
+                details={"error": str(exc)},
+            ),
+        )
+
+    xml_paths = _xml_paths(root)
+    cvn_codes = _cvn_codes(root)
+    trace = make_trace(
+        source_format=CvnSourceFormat.CVN_XML,
+        source_identifier=loaded.source_identifier,
+        source_path=loaded.source_path,
+        cvn_codes=cvn_codes,
+        xml_paths=xml_paths,
+    )
+    if not _has_cvn_evidence(root, loaded.text, cvn_codes):
+        return CvnParseResult(
+            source_format=CvnSourceFormat.CVN_XML,
+            source_identifier=loaded.source_identifier,
+            validation_status=CvnValidationStatus.INVALID,
+            errors=(
+                make_error(
+                    code=CvnErrorCode.XML_SEMANTICALLY_UNMAPPABLE,
+                    message="XML is readable but does not contain enough CVN evidence for import.",
+                    path=(xml_paths[0],) if xml_paths else (),
+                ),
+            ),
+            trace=trace,
+        )
+
+    document = _map_xml_to_open_cvn(
+        source_identifier=loaded.source_identifier,
+        source_path=loaded.source_path,
+        root=root,
+        cvn_codes=cvn_codes,
+        xml_paths=xml_paths,
+    )
+    return CvnParseResult(
+        source_format=CvnSourceFormat.CVN_XML,
+        source_identifier=loaded.source_identifier,
+        data=document,
+        validation_status=CvnValidationStatus.VALID,
+        trace=trace,
+    )
+
+
+def _map_xml_to_open_cvn(
+    *,
+    source_identifier: str | None,
+    source_path: str | None,
+    root: ElementTree.Element,
+    cvn_codes: tuple[str, ...],
+    xml_paths: tuple[str, ...],
+) -> dict[str, object]:
+    return {
+        "schema_version": OPEN_CVN_SCHEMA_VERSION,
+        "metadata": {
+            "source": {
+                "format": CvnSourceFormat.CVN_XML.value,
+                "identifier": source_identifier,
+                "path": source_path,
+                "root": _local_name(root.tag),
+            },
+            "policy": {
+                "name": DEFAULT_POLICY_NAME,
+                "version": DEFAULT_POLICY_VERSION,
+            },
+        },
+        "curriculum": {
+            "identity": {},
+            "education": [],
+            "research": [],
+            "professional_experience": [],
+            "achievements": [],
+            "other": [],
+        },
+        "extensions": {
+            "x-open-cvn.import": {
+                "cvn_codes": list(cvn_codes),
+                "xml_paths": list(xml_paths),
+                "mapping_status": "trace_only",
+            }
+        },
+    }
+
+
+def _xml_paths(root: ElementTree.Element) -> tuple[str, ...]:
+    paths: list[str] = []
+
+    def visit(element: ElementTree.Element, path: str) -> None:
+        paths.append(path)
+        counts: dict[str, int] = {}
+        for child in list(element):
+            child_name = _local_name(child.tag)
+            counts[child_name] = counts.get(child_name, 0) + 1
+            visit(child, f"{path}/{child_name}[{counts[child_name]}]")
+
+    visit(root, _local_name(root.tag))
+    return tuple(paths[:200])
+
+
+def _cvn_codes(root: ElementTree.Element) -> tuple[str, ...]:
+    codes: list[str] = []
+    seen: set[str] = set()
+    for element in root.iter():
+        values = [str(element.tag), *(str(value) for value in element.attrib.values())]
+        if element.text:
+            values.append(element.text)
+        for value in values:
+            for match in CVN_CODE_RE.findall(value):
+                if match not in seen:
+                    seen.add(match)
+                    codes.append(match)
+    return tuple(codes)
+
+
+def _has_cvn_evidence(root: ElementTree.Element, text: str, cvn_codes: tuple[str, ...]) -> bool:
+    root_name = _local_name(root.tag).lower()
+    text_sample = text[:4096].lower()
+    return bool(cvn_codes) or any(
+        marker in root_name or marker in text_sample
+        for marker in (
+            "cvn",
+            "curriculumvitaenormalizado",
+            "curriculum vitae normalizado",
+        )
+    )
+
+
+def _xml_error_location(error: ElementTree.ParseError) -> str | None:
+    position = getattr(error, "position", None)
+    if not position:
+        return None
+    line, column = position
+    return f"line {line} column {column}"
+
+
+def _xml_failed_result(
+    *, source_identifier: str | None, source_path: str | None, error: CvnParseIssue
+) -> CvnParseResult:
+    return CvnParseResult(
+        source_format=CvnSourceFormat.CVN_XML,
+        source_identifier=source_identifier or source_path,
+        validation_status=CvnValidationStatus.FAILED,
+        errors=(error,),
+        trace=make_trace(
+            source_format=CvnSourceFormat.CVN_XML,
+            source_identifier=source_identifier or source_path,
+            source_path=source_path,
+        ),
+    )
+
+
+def _local_name(tag: object) -> str:
+    text = str(tag)
+    if "}" in text:
+        return text.rsplit("}", maxsplit=1)[1]
+    return text

--- a/tests/fixtures/cvn_xml/malformed.xml
+++ b/tests/fixtures/cvn_xml/malformed.xml
@@ -1,0 +1,1 @@
+<CVNRoot><CVNItem></CVNRoot>

--- a/tests/fixtures/cvn_xml/minimal_cvn.xml
+++ b/tests/fixtures/cvn_xml/minimal_cvn.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CVNRoot>
+  <CVNItem code="000.010.000.000">
+    <Value>synthetic</Value>
+  </CVNItem>
+</CVNRoot>

--- a/tests/fixtures/cvn_xml/non_cvn.xml
+++ b/tests/fixtures/cvn_xml/non_cvn.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document>
+  <Item>synthetic</Item>
+</Document>

--- a/tests/fixtures/open_cvn/malformed.json
+++ b/tests/fixtures/open_cvn/malformed.json
@@ -1,0 +1,1 @@
+{"schema_version": "0.1.0",

--- a/tests/fixtures/open_cvn/unsupported_major.json
+++ b/tests/fixtures/open_cvn/unsupported_major.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.0.0",
+  "metadata": {
+    "policy": {
+      "name": "default_cvn_semantic_policy",
+      "version": "0.1.0"
+    }
+  },
+  "curriculum": {
+    "identity": {},
+    "education": [],
+    "research": [],
+    "professional_experience": [],
+    "achievements": [],
+    "other": []
+  }
+}

--- a/tests/fixtures/open_cvn/valid_minimal.json
+++ b/tests/fixtures/open_cvn/valid_minimal.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {
+    "language": "es",
+    "policy": {
+      "name": "default_cvn_semantic_policy",
+      "version": "0.1.0"
+    }
+  },
+  "curriculum": {
+    "identity": {},
+    "education": [],
+    "research": [],
+    "professional_experience": [],
+    "achievements": [],
+    "other": []
+  }
+}

--- a/tests/fixtures/open_cvn/wrong_shape.json
+++ b/tests/fixtures/open_cvn/wrong_shape.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {},
+  "curriculum": {}
+}

--- a/tests/test_cvn_xml_import_unit.py
+++ b/tests/test_cvn_xml_import_unit.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+from open_cvn import CvnErrorCode, CvnValidationStatus, parse_cvn_xml
+
+
+FIXTURES = Path("tests/fixtures/cvn_xml")
+
+
+def test_parse_cvn_xml_accepts_path_input():
+    result = parse_cvn_xml(FIXTURES / "minimal_cvn.xml")
+
+    assert result.validation_status == CvnValidationStatus.VALID
+    assert result.data is not None
+    assert result.data["schema_version"] == "0.1.0"
+    assert result.trace is not None
+    assert result.trace.source_path == str(FIXTURES / "minimal_cvn.xml")
+    assert "000.010.000.000" in result.trace.cvn_codes
+
+
+def test_parse_cvn_xml_accepts_inline_xml_string():
+    payload = (FIXTURES / "minimal_cvn.xml").read_text(encoding="utf-8")
+
+    result = parse_cvn_xml(payload, source_identifier="inline-xml")
+
+    assert result.validation_status == CvnValidationStatus.VALID
+    assert result.source_identifier == "inline-xml"
+
+
+def test_parse_cvn_xml_accepts_xml_bytes():
+    payload = (FIXTURES / "minimal_cvn.xml").read_bytes()
+
+    result = parse_cvn_xml(payload, source_identifier="bytes-xml")
+
+    assert result.validation_status == CvnValidationStatus.VALID
+    assert result.source_identifier == "bytes-xml"
+
+
+def test_parse_cvn_xml_reports_unreadable_path():
+    result = parse_cvn_xml(Path("tests/fixtures/cvn_xml/missing.xml"))
+
+    assert result.validation_status == CvnValidationStatus.FAILED
+    assert result.errors[0].code == CvnErrorCode.UNREADABLE_FILE
+
+
+def test_parse_cvn_xml_reports_malformed_xml():
+    result = parse_cvn_xml(FIXTURES / "malformed.xml")
+
+    assert result.validation_status == CvnValidationStatus.FAILED
+    assert result.errors[0].code == CvnErrorCode.INVALID_XML
+    assert result.errors[0].source_location == "line 1 column 20"
+
+
+def test_parse_cvn_xml_reports_well_formed_non_cvn_xml_as_unmappable():
+    result = parse_cvn_xml(FIXTURES / "non_cvn.xml")
+
+    assert result.validation_status == CvnValidationStatus.INVALID
+    assert result.errors[0].code == CvnErrorCode.XML_SEMANTICALLY_UNMAPPABLE
+    assert result.trace is not None
+    assert result.trace.xml_paths[0] == "Document"
+
+
+def test_parse_cvn_xml_preserves_xml_paths():
+    result = parse_cvn_xml(FIXTURES / "minimal_cvn.xml")
+
+    assert result.trace is not None
+    assert result.trace.xml_paths[:3] == (
+        "CVNRoot",
+        "CVNRoot/CVNItem[1]",
+        "CVNRoot/CVNItem[1]/Value[1]",
+    )

--- a/tests/test_open_cvn_json_import_unit.py
+++ b/tests/test_open_cvn_json_import_unit.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+
+from open_cvn import (
+    CvnErrorCode,
+    CvnValidationStatus,
+    parse_open_cvn_json,
+    validate_open_cvn_json,
+)
+
+
+FIXTURES = Path("tests/fixtures/open_cvn")
+
+
+def test_parse_open_cvn_json_accepts_path_input():
+    result = parse_open_cvn_json(FIXTURES / "valid_minimal.json")
+
+    assert result.validation_status == CvnValidationStatus.VALID
+    assert result.trace is not None
+    assert result.trace.source_path == str(FIXTURES / "valid_minimal.json")
+    assert result.trace.schema_version == "0.1.0"
+    assert result.trace.policy_name == "default_cvn_semantic_policy"
+    assert result.trace.policy_version == "0.1.0"
+
+
+def test_parse_open_cvn_json_accepts_inline_json_string():
+    payload = (FIXTURES / "valid_minimal.json").read_text(encoding="utf-8")
+
+    result = parse_open_cvn_json(payload, source_identifier="inline-json")
+
+    assert result.validation_status == CvnValidationStatus.VALID
+    assert result.source_identifier == "inline-json"
+
+
+def test_parse_open_cvn_json_accepts_json_bytes():
+    payload = (FIXTURES / "valid_minimal.json").read_bytes()
+
+    result = parse_open_cvn_json(payload, source_identifier="bytes-json")
+
+    assert result.validation_status == CvnValidationStatus.VALID
+    assert result.source_identifier == "bytes-json"
+
+
+def test_parse_open_cvn_json_accepts_mapping_input():
+    payload = json.loads((FIXTURES / "valid_minimal.json").read_text(encoding="utf-8"))
+
+    result = parse_open_cvn_json(payload, source_identifier="mapping-json")
+
+    assert result.validation_status == CvnValidationStatus.VALID
+    assert result.source_identifier == "mapping-json"
+
+
+def test_parse_open_cvn_json_reports_malformed_json():
+    result = parse_open_cvn_json(FIXTURES / "malformed.json")
+
+    assert result.validation_status == CvnValidationStatus.FAILED
+    assert result.errors[0].code == CvnErrorCode.INVALID_JSON
+    assert result.errors[0].source_location == "line 2 column 1"
+
+
+def test_validate_open_cvn_json_reports_schema_failures():
+    payload = json.loads((FIXTURES / "wrong_shape.json").read_text(encoding="utf-8"))
+
+    result = validate_open_cvn_json(payload, source_identifier="wrong-shape")
+
+    codes = {error.code for error in result.errors}
+
+    assert result.validation_status == CvnValidationStatus.INVALID
+    assert CvnErrorCode.JSON_SCHEMA_VALIDATION_FAILURE in codes
+    assert result.trace is not None
+    assert result.trace.schema_version == "0.1.0"
+
+
+def test_validate_open_cvn_json_reports_schema_version_failures():
+    payload = json.loads((FIXTURES / "unsupported_major.json").read_text(encoding="utf-8"))
+
+    result = validate_open_cvn_json(payload, source_identifier="unsupported-major")
+
+    assert result.validation_status == CvnValidationStatus.INVALID
+    assert result.errors[0].code == CvnErrorCode.JSON_SCHEMA_VALIDATION_FAILURE
+    assert ("schema_version",) in {error.path for error in result.errors}
+
+
+def test_validate_open_cvn_json_returns_normalized_data():
+    payload = json.loads((FIXTURES / "valid_minimal.json").read_text(encoding="utf-8"))
+
+    result = validate_open_cvn_json(payload, source_identifier="valid")
+
+    dumped = result.model_dump(mode="json")
+
+    assert result.validation_status == CvnValidationStatus.VALID
+    assert dumped["data"]["schema_version"] == "0.1.0"
+    assert dumped["errors"] == []

--- a/tests/test_parser_validator_contract_unit.py
+++ b/tests/test_parser_validator_contract_unit.py
@@ -1,5 +1,6 @@
 import pytest
 from pydantic import ValidationError
+from pathlib import Path
 
 from open_cvn import (
     CvnErrorCode,
@@ -13,9 +14,6 @@ from open_cvn import (
     parse_open_cvn_json,
     validate_open_cvn_json,
 )
-
-
-DEFERRED_IMPLEMENTATION_MESSAGE = "Parser implementation is deferred to issue #48/#49."
 
 
 def test_contract_enums_have_stable_serialized_values():
@@ -189,18 +187,52 @@ def test_parse_result_rejects_warning_status_without_warning():
         )
 
 
-@pytest.mark.parametrize(
-    ("parser", "source"),
-    [
-        (parse_cvn_xml, "<CVNRoot />"),
-        (parse_open_cvn_json, '{"schema_version": "0.1.0"}'),
-    ],
-)
-def test_public_parser_functions_defer_implementation(parser, source):
-    with pytest.raises(NotImplementedError, match=DEFERRED_IMPLEMENTATION_MESSAGE):
-        parser(source, source_identifier="input")
+def test_parse_cvn_xml_returns_contract_result():
+    result = parse_cvn_xml("<CVNRoot />", source_identifier="input")
+
+    assert result.source_format == CvnSourceFormat.CVN_XML
+    assert result.source_identifier == "input"
+    assert result.validation_status == CvnValidationStatus.VALID
 
 
-def test_public_validator_function_defers_implementation():
-    with pytest.raises(NotImplementedError, match=DEFERRED_IMPLEMENTATION_MESSAGE):
-        validate_open_cvn_json({"schema_version": "0.1.0"}, source_identifier="input")
+def test_parse_open_cvn_json_returns_contract_result():
+    payload = Path("tests/fixtures/open_cvn/valid_minimal.json").read_text(encoding="utf-8")
+
+    result = parse_open_cvn_json(
+        payload,
+        source_identifier="input",
+    )
+
+    assert result.source_format == CvnSourceFormat.OPEN_CVN_JSON
+    assert result.source_identifier == "input"
+    assert result.validation_status == CvnValidationStatus.VALID
+
+
+def test_validate_open_cvn_json_returns_contract_result():
+    payload = {
+        "schema_version": "0.1.0",
+        "metadata": {
+            "language": "es",
+            "policy": {
+                "name": "default_cvn_semantic_policy",
+                "version": "0.1.0",
+            },
+        },
+        "curriculum": {
+            "identity": {},
+            "education": [],
+            "research": [],
+            "professional_experience": [],
+            "achievements": [],
+            "other": [],
+        },
+    }
+
+    result = validate_open_cvn_json(
+        payload,
+        source_identifier="input",
+    )
+
+    assert result.source_format == CvnSourceFormat.OPEN_CVN_JSON
+    assert result.source_identifier == "input"
+    assert result.validation_status == CvnValidationStatus.VALID

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -60,6 +69,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -264,6 +300,85 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.7"
 source = { registry = "https://pypi.org/simple" }
@@ -293,6 +408,7 @@ name = "tfg-open-cvn-schema"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pymupdf" },
 ]
@@ -309,6 +425,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
+    { name = "jsonschema", specifier = ">=4.26" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pymupdf", specifier = ">=1.26" },
 ]


### PR DESCRIPTION
## Summary
- Implement Open CVN JSON import validation via `jsonschema` Draft 2020-12 and runtime Pydantic models
- Implement conservative CVN XML import with well-formedness checks, CVN evidence detection, XML path trace, and CVN code trace
- Add synthetic fixtures, parser tests, and persistent documentation for issue #49
## Notes
- CVN XML import is intentionally trace-only for plausible CVN XML.
- Full semantic XML-to-domain mapping remains documented as future work.
## Verification
- `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_cvn_xml_import_unit.py tests/test_parser_validator_contract_unit.py -v`
- `uv run pytest -n auto tests`

close #49