### PR TITLE
docs(parser): close parser workflow epic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ Every new session should read these files in order before making changes:
   `docs/roadmap/issues/issue-48-cvn-pdf-xml-extraction.md`
 - issue `#49`:
   `docs/roadmap/issues/issue-49-xml-json-import-validation.md`
+- issue `#50`:
+  `docs/roadmap/issues/issue-50-parser-workflow-tests-and-documentation.md`
 - hotfix `#1`: `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`
 - hotfix `#2`: `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`
 - hotfix `#3`:
@@ -90,6 +92,7 @@ Every new session should read these files in order before making changes:
 
 - setup and commands: `docs/development/setup.md`
 - complete regeneration workflow: `docs/development/regeneration_workflow.md`
+- parser workflow: `docs/development/parser_workflow.md`
 - code style and conventions: `docs/development/code_style.md`
 - documentation conventions: `docs/documentation/documentation_conventions.md`
 - old AGENTS content migration map:

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -124,6 +124,8 @@ files in order:
   record of issue `#48`
 - `docs/roadmap/issues/issue-49-xml-json-import-validation.md`: planned scope of
   issue `#49`
+- `docs/roadmap/issues/issue-50-parser-workflow-tests-and-documentation.md`:
+  authoritative record of issue `#50`
 - `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`: maintenance
   record for the runner logging convention update
 - `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`: maintenance
@@ -152,6 +154,8 @@ files in order:
 - `docs/development/setup.md`: environment and execution commands
 - `docs/development/regeneration_workflow.md`: complete CVN regeneration and
   verification workflow
+- `docs/development/parser_workflow.md`: contributor guide for using and testing
+  the public PDF/XML/JSON parser workflow
 - `docs/development/code_style.md`: code style, typing, and conventions
 - `docs/documentation/documentation_conventions.md`: documentation taxonomy,
   cross-linking rules, and update protocol

--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -664,6 +664,48 @@
 - full-suite verification result:
   `369 passed in 347.12s (0:05:47)`
 
+### Issue `#50`
+
+- parser workflow tests and documentation closure for epic `#41` is completed
+- a contributor parser workflow guide now exists at:
+  - `docs/development/parser_workflow.md`
+- the guide documents:
+  - public `open_cvn` parser imports
+  - Open CVN JSON parsing and validation
+  - direct CVN XML parsing and trace-only output interpretation
+  - deterministic CVN PDF XML extraction and PDF-to-XML handoff
+  - structured parser errors
+  - parser trace metadata
+  - targeted parser, schema, conceptual, diagram, and full-suite verification
+    commands
+- parser test coverage was audited for:
+  - parser contract invariants
+  - valid and invalid Open CVN JSON import
+  - valid and invalid CVN XML import
+  - PDF with extractable XML and PDF without extractable XML
+  - trace metadata preservation
+- a direct regression test was added for the existing `pydantic_validation_failure`
+  JSON path when syntactically valid JSON is not an object
+- JSON Schema and PlantUML drift checks passed against temporary regenerated
+  outputs under `/tmp/opencode`
+- no new durable limitations were found
+- targeted parser workflow verification passed with:
+  `uv run pytest -n auto tests/test_parser_validator_contract_unit.py tests/test_pdf_xml_extraction_unit.py tests/test_open_cvn_json_import_unit.py tests/test_cvn_xml_import_unit.py -v`
+- targeted parser workflow verification result:
+  `36 passed in 16.61s`
+- targeted JSON Schema and Open CVN example verification passed with:
+  `uv run pytest -n auto tests/test_json_schema_generator_unit.py tests/test_generation_pipeline_json_schema.py tests/test_open_cvn_json_format_examples.py -v`
+- targeted JSON Schema and example verification result:
+  `21 passed in 92.86s (0:01:32)`
+- targeted conceptual model and diagram verification passed with:
+  `uv run pytest -n auto tests/test_conceptual_model_extractor_unit.py tests/test_generation_pipeline_conceptual_model.py tests/test_conceptual_model_diagrams_unit.py tests/test_generation_pipeline_conceptual_diagrams.py -v`
+- targeted conceptual and diagram verification result:
+  `19 passed in 90.61s (0:01:30)`
+- full-suite verification passed with:
+  `uv run pytest -n auto tests`
+- full-suite verification result:
+  `370 passed in 287.52s (0:04:47)`
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -675,9 +717,10 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#49` closure: continue the post-parser Open CVN
-  roadmap, including richer XML semantic mapping or downstream import/export
-  behavior when a later issue defines that scope
+- Next work item after epic `#41` closure: continue the post-parser Open CVN
+  roadmap, including richer XML semantic mapping, downstream import/export
+  behavior, storage, application, or LaTeX workflow only when a later issue defines
+  that scope
 
 ## Blocking Or Relevant Limitations
 
@@ -759,20 +802,21 @@ Then continue with these supporting files as needed:
 4. `docs/roadmap/issues/issue-13-normalization.md`
 5. `docs/roadmap/issues/issue-25-github-actions-ci-pipeline-for-pr-testing-on-main-and-development.md`
 6. `docs/development/regeneration_workflow.md`
-7. `docs/pipeline/known_limitations.md`
-8. `docs/pipeline/parser_validator_contract.md`
-9. `docs/roadmap/hotfixes/`
-10. `docs/cvn_source_package_auxiliary_artifacts.md`
-11. `docs/cvn_source_package_annex_table_coverage.md`
-12. `docs/cvn_annex_priority_table_families.md`
-13. `docs/cvn_annex_table_families_batch3.md`
-14. `docs/cvn_annex_table_families_batch4.md`
-15. `docs/cvn_annex_table_families_batch5.md`
-16. `docs/cvn_annex_table_families_batch6.md`
-17. `docs/cvn_annex_table_families_batch7.md`
-18. `docs/cvn_annex_table_families_batch8.md`
-19. `docs/cvn_serialization_patterns_reference.md`
-20. `docs/cvn_field_reference_traceability.md`
-21. `docs/roadmap/hotfixes/hotfix-4-structural-scope-correction-for-auxiliary-source-package-artifacts.md`
-22. `docs/roadmap/hotfixes/hotfix-5-normalization-resolution-layer-for-auxiliary-reference-sources.md`
-23. `docs/roadmap/hotfixes/hotfix-6-roadmap-realignment-for-auxiliary-catalog-semantic-integration.md`
+7. `docs/development/parser_workflow.md`
+8. `docs/pipeline/known_limitations.md`
+9. `docs/pipeline/parser_validator_contract.md`
+10. `docs/roadmap/hotfixes/`
+11. `docs/cvn_source_package_auxiliary_artifacts.md`
+12. `docs/cvn_source_package_annex_table_coverage.md`
+13. `docs/cvn_annex_priority_table_families.md`
+14. `docs/cvn_annex_table_families_batch3.md`
+15. `docs/cvn_annex_table_families_batch4.md`
+16. `docs/cvn_annex_table_families_batch5.md`
+17. `docs/cvn_annex_table_families_batch6.md`
+18. `docs/cvn_annex_table_families_batch7.md`
+19. `docs/cvn_annex_table_families_batch8.md`
+20. `docs/cvn_serialization_patterns_reference.md`
+21. `docs/cvn_field_reference_traceability.md`
+22. `docs/roadmap/hotfixes/hotfix-4-structural-scope-correction-for-auxiliary-source-package-artifacts.md`
+23. `docs/roadmap/hotfixes/hotfix-5-normalization-resolution-layer-for-auxiliary-reference-sources.md`
+24. `docs/roadmap/hotfixes/hotfix-6-roadmap-realignment-for-auxiliary-catalog-semantic-integration.md`

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -32,9 +32,9 @@ Agents should also read `AGENTS.md` before this file.
   semantic policy, domain generation, conceptual schema, Open CVN JSON format,
   and parser/validator contract completed
 - Last documented issues: `#11`, `#12`, `#13`, `#14`, `#15`, `#16`, `#17`,
-  `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, `#47`, and `#48`
+  `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, `#47`, `#48`, `#49`, and `#50`
 - Latest documented hotfix records: `#3`, `#4`, `#5`, `#6`, `#7`, `#8`
-- Next planned issue: `#49`
+- Next planned issue: post-epic Open CVN work to be defined by a later issue
 - Canonical source package: `docs/CvnXML_v1.4.3_2.1_17012025/`
 
 ## Documentation Map
@@ -101,6 +101,8 @@ Agents should also read `AGENTS.md` before this file.
   issue `#48`
 - `docs/roadmap/issues/issue-49-xml-json-import-validation.md`: planned scope of
   issue `#49`
+- `docs/roadmap/issues/issue-50-parser-workflow-tests-and-documentation.md`:
+  implementation record for issue `#50`
 - `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`: maintenance
   record for the runner logging convention update
 - `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`: maintenance
@@ -128,6 +130,8 @@ Agents should also read `AGENTS.md` before this file.
 - `docs/development/setup.md`: environment and execution commands
 - `docs/development/regeneration_workflow.md`: complete CVN regeneration and
   verification workflow
+- `docs/development/parser_workflow.md`: contributor guide for using and testing
+  the public PDF/XML/JSON parser workflow
 - `docs/development/code_style.md`: code style, typing, and documentation rules
 - `docs/documentation/documentation_conventions.md`: documentation taxonomy and
   update protocol
@@ -230,4 +234,6 @@ When starting a new session:
 4. Review `docs/pipeline/known_limitations.md`
 5. Review `docs/development/regeneration_workflow.md` when the work touches
    generated artifacts or pipeline verification
-6. Only then start implementation work
+6. Review `docs/development/parser_workflow.md` when the work touches the public
+   parser or validator workflow
+7. Only then start implementation work

--- a/docs/development/parser_workflow.md
+++ b/docs/development/parser_workflow.md
@@ -1,0 +1,296 @@
+# Parser Workflow
+
+## Purpose
+
+This guide shows contributors how to use and verify the public Open CVN parser
+and validator workflow implemented by issues `#47`, `#48`, and `#49`.
+
+Use this guide when you need to:
+
+- validate an Open CVN JSON document
+- import direct CVN XML into the current trace-only Open CVN shape
+- extract embedded CVN XML from a PDF
+- inspect structured parser errors and trace metadata
+- run parser-focused regression tests
+
+This guide does not define new parser behavior. The public contract remains
+documented in `docs/pipeline/parser_validator_contract.md`.
+
+## Public API
+
+Import parser entry points from `open_cvn`:
+
+```python
+from open_cvn import (
+    CvnErrorCode,
+    CvnValidationStatus,
+    parse_cvn_pdf,
+    parse_cvn_xml,
+    parse_open_cvn_json,
+    validate_open_cvn_json,
+)
+```
+
+Each parser returns `CvnParseResult` with:
+
+- `source_format`
+- `source_identifier`
+- `data`
+- `validation_status`
+- `warnings`
+- `errors`
+- `trace`
+
+Treat `validation_status` as the workflow decision point:
+
+- `valid`: input was accepted
+- `valid_with_warnings`: input was accepted, but warning issues exist
+- `invalid`: input was read and classified as invalid
+- `failed`: processing could not complete
+- `not_run`: extraction succeeded, but validation was intentionally not executed
+
+## Open CVN JSON
+
+Parse JSON from a path:
+
+```python
+from pathlib import Path
+
+from open_cvn import CvnValidationStatus, parse_open_cvn_json
+
+result = parse_open_cvn_json(Path("examples/open_cvn/minimal.json"))
+
+if result.validation_status == CvnValidationStatus.VALID:
+    document = result.data
+```
+
+Parse inline JSON text or bytes:
+
+```python
+from open_cvn import parse_open_cvn_json
+
+result_from_text = parse_open_cvn_json(
+    '{"schema_version":"0.1.0","metadata":{"language":"es","policy":{"name":"default_cvn_semantic_policy","version":"0.1.0"}},"curriculum":{"identity":{},"education":[],"research":[],"professional_experience":[],"achievements":[],"other":[]}}',
+    source_identifier="inline-json",
+)
+
+result_from_bytes = parse_open_cvn_json(
+    b'{"schema_version":"0.1.0","metadata":{"language":"es","policy":{"name":"default_cvn_semantic_policy","version":"0.1.0"}},"curriculum":{"identity":{},"education":[],"research":[],"professional_experience":[],"achievements":[],"other":[]}}',
+    source_identifier="bytes-json",
+)
+```
+
+Validate an already-loaded mapping:
+
+```python
+from open_cvn import validate_open_cvn_json
+
+document = {
+    "schema_version": "0.1.0",
+    "metadata": {
+        "language": "es",
+        "policy": {
+            "name": "default_cvn_semantic_policy",
+            "version": "0.1.0",
+        },
+    },
+    "curriculum": {
+        "identity": {},
+        "education": [],
+        "research": [],
+        "professional_experience": [],
+        "achievements": [],
+        "other": [],
+    },
+}
+
+result = validate_open_cvn_json(document, source_identifier="loaded-document")
+```
+
+Validation order is:
+
+1. JSON decoding for string, bytes, or path inputs
+2. generated JSON Schema validation against `schemas/open_cvn.schema.json`
+3. Pydantic runtime validation through `src/open_cvn/open_cvn_models.py`
+
+JSON errors use these codes:
+
+- `invalid_json`: malformed JSON text
+- `json_schema_validation_failure`: document does not match the generated schema
+- `pydantic_validation_failure`: document reaches runtime model validation but
+  violates runtime rules, or the loaded JSON value is not an object
+- `unreadable_file`: path-like input cannot be read
+- `unsupported_input_format`: unsupported source shape
+
+## Direct CVN XML
+
+Parse direct XML from a path:
+
+```python
+from pathlib import Path
+
+from open_cvn import CvnValidationStatus, parse_cvn_xml
+
+result = parse_cvn_xml(Path("tests/fixtures/cvn_xml/minimal_cvn.xml"))
+
+if result.validation_status == CvnValidationStatus.VALID:
+    open_cvn_document = result.data
+    cvn_codes = result.trace.cvn_codes if result.trace else ()
+```
+
+Parse inline XML text or bytes:
+
+```python
+from open_cvn import parse_cvn_xml
+
+result_from_text = parse_cvn_xml(
+    "<CVNRoot><CVNItem><Value>000.010.000.000</Value></CVNItem></CVNRoot>",
+    source_identifier="inline-xml",
+)
+
+result_from_bytes = parse_cvn_xml(
+    b"<CVNRoot><CVNItem><Value>000.010.000.000</Value></CVNItem></CVNRoot>",
+    source_identifier="bytes-xml",
+)
+```
+
+Current XML import behavior is conservative:
+
+- validates XML well-formedness
+- checks for plausible CVN evidence
+- preserves simplified XML paths
+- preserves CVN code-like values when detected
+- returns a trace-only Open CVN document for plausible CVN XML
+- does not perform full semantic XML-to-domain mapping
+
+For plausible CVN XML, `data["extensions"]["x-open-cvn.import"]` records
+`mapping_status = "trace_only"`. Treat that as an import diagnostic, not proof
+that all curriculum content was converted.
+
+XML errors use these codes:
+
+- `invalid_xml`: XML is malformed
+- `xml_semantically_unmappable`: XML is well-formed but lacks enough CVN evidence
+  for the current importer
+- `unreadable_file`: path-like input cannot be read
+- `unsupported_input_format`: unsupported source shape
+
+## CVN PDF
+
+Parse a PDF path or PDF bytes:
+
+```python
+from pathlib import Path
+
+from open_cvn import CvnValidationStatus, parse_cvn_pdf, parse_cvn_xml
+
+pdf_result = parse_cvn_pdf(Path("cvn.pdf"))
+
+if pdf_result.validation_status == CvnValidationStatus.NOT_RUN:
+    xml_text = pdf_result.data["xml_text"]
+    xml_result = parse_cvn_xml(xml_text, source_identifier="cvn.pdf:extracted-xml")
+```
+
+PDF handling is extraction-only:
+
+- scans embedded PDF files first
+- scans PDF XML metadata second
+- accepts only well-formed XML with plausible CVN evidence
+- returns `validation_status = not_run` for successful extraction
+- stores extracted XML in `data["xml_text"]`
+- stores extraction metadata in `data["extraction"]`
+- leaves XML interpretation to `parse_cvn_xml(...)`
+
+PDF handling does not attempt OCR, page text reconstruction, LLM reconstruction,
+or direct XML-to-domain mapping.
+
+PDF errors use these codes:
+
+- `pdf_without_extractable_xml`: readable PDF has no acceptable CVN XML candidate
+- `unreadable_file`: PDF input cannot be opened or read
+- `unsupported_input_format`: unsupported source shape, such as a mapping
+
+## Structured Errors
+
+Inspect `errors` for machine-readable handling:
+
+```python
+from open_cvn import CvnErrorCode, CvnValidationStatus, parse_open_cvn_json
+
+result = parse_open_cvn_json("{", source_identifier="broken-json")
+
+if result.validation_status in {CvnValidationStatus.INVALID, CvnValidationStatus.FAILED}:
+    for issue in result.errors:
+        if issue.code == CvnErrorCode.INVALID_JSON:
+            print(issue.source_location)
+```
+
+Each issue includes:
+
+- `code`
+- `severity`
+- `message`
+- `source_location`
+- `path`
+- `details`
+
+Do not parse exception strings as control flow. Use `code` and `path` first.
+
+## Trace Metadata
+
+Parser trace is audit metadata. It does not change curriculum values.
+
+Common trace fields include:
+
+- `source_format`
+- `source_identifier`
+- `source_path`
+- `extracted_from`
+- `cvn_codes`
+- `xml_paths`
+- `schema_version`
+- `policy_name`
+- `policy_version`
+
+Expected trace behavior:
+
+- JSON import preserves `schema_version` and `metadata.policy` values when present
+- XML import preserves simplified XML paths and detected CVN code-like values
+- PDF import preserves PDF identity and extracted XML source identity
+- error results should keep source trace where available without copying full
+  personal payloads into diagnostics
+
+## Verification Commands
+
+Run parser-focused tests:
+
+```bash
+uv run pytest -n auto tests/test_parser_validator_contract_unit.py tests/test_pdf_xml_extraction_unit.py tests/test_open_cvn_json_import_unit.py tests/test_cvn_xml_import_unit.py -v
+```
+
+Run JSON Schema and Open CVN example tests:
+
+```bash
+uv run pytest -n auto tests/test_json_schema_generator_unit.py tests/test_generation_pipeline_json_schema.py tests/test_open_cvn_json_format_examples.py -v
+```
+
+Run conceptual model and diagram tests:
+
+```bash
+uv run pytest -n auto tests/test_conceptual_model_extractor_unit.py tests/test_generation_pipeline_conceptual_model.py tests/test_conceptual_model_diagrams_unit.py tests/test_generation_pipeline_conceptual_diagrams.py -v
+```
+
+Run full repository verification:
+
+```bash
+uv run pytest -n auto tests
+```
+
+## Related Documentation
+
+- parser contract: `docs/pipeline/parser_validator_contract.md`
+- Open CVN JSON format: `docs/pipeline/open_cvn_json_format.md`
+- JSON Schema generation: `docs/pipeline/json_schema_generation.md`
+- conceptual extraction: `docs/pipeline/conceptual_model_extraction.md`
+- regeneration workflow: `docs/development/regeneration_workflow.md`
+- known limitations: `docs/pipeline/known_limitations.md`

--- a/docs/development/regeneration_workflow.md
+++ b/docs/development/regeneration_workflow.md
@@ -142,7 +142,9 @@ The implemented pipeline stages are:
    evidence
 9. conceptual PlantUML diagram generation from `ConceptualModelInventory`
 10. JSON Schema generation from the conceptual inventory
-11. repository verification through tests and CI
+11. public parser and validator workflow verification for PDF, XML, and Open CVN
+    JSON inputs
+12. repository verification through tests and CI
 
 The semantic handoff is:
 
@@ -258,6 +260,8 @@ The implemented tests cover:
 - conceptual model extraction and conceptual PlantUML diagram rendering
 - JSON Schema generation, metadata, enum/open-reference treatment, determinism,
   and CLI output
+- parser contract, deterministic PDF XML extraction, Open CVN JSON validation,
+  trace-only CVN XML import, structured errors, and trace preservation
 - source coverage for manual, tree, auxiliary, semantic, and generated artifacts
 
 Tests that regenerate `src/generated/*` use `tests/xsdata_generation_lock.py` so
@@ -283,3 +287,12 @@ through `.github/workflows/pr-tests.yml`. The workflow job is named `tests`.
 
 See `docs/pipeline/known_limitations.md` for the authoritative limitation
 register.
+
+## Parser Workflow
+
+For public parser and validator usage examples, structured error handling, trace
+metadata expectations, and parser-focused test commands, see:
+
+```text
+docs/development/parser_workflow.md
+```

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -35,7 +35,7 @@ Goal:
 | `#17` | Document and automate the complete workflow | Completed | Complete workflow guide, architecture updates, command sequence, verification matrix, and known limitations documented |
 | `#26` | Epic for remaining Open CVN work | Planned | Placeholder epic only; details intentionally deferred after issue `#17` closure |
 | `#25` | GitHub Actions CI pipeline for PR testing on main and development | Completed | PRs to `main` and `development` now run the `tests` check |
-| `#41` | Epic: agnostic CVN schema, JSON schema, and parser | Planned | Post-generation epic for conceptual schema, JSON schema, and parser work |
+| `#41` | Epic: agnostic CVN schema, JSON schema, and parser | Completed | Conceptual IR, PlantUML diagrams, JSON Schema, Open CVN JSON format, parser contract, PDF/XML/JSON parser paths, tests, and workflow docs implemented |
 | `#42` | Research Pydantic-to-UML options | Completed | Recommends conceptual IR first, PlantUML primary target, Mermaid secondary target, Pyreverse diagnostic only |
 | `#43` | Define agnostic conceptual model extraction layer | Completed | Conceptual IR, extractor, targeted/full-suite tests, and extraction documentation implemented |
 | `#44` | Generate UML or UML-like diagrams | Completed | PlantUML now emits readable and reference views under `docs/diagrams/`; Mermaid remains optional future output |
@@ -44,6 +44,7 @@ Goal:
 | `#47` | Define unified parser and validator contract | Completed | Public `open_cvn` contract package, structured result/error/trace models, deferred parser signatures, docs, and tests implemented |
 | `#48` | Extract CVN XML from PDF inputs | Completed | Deterministic PDF XML extraction implemented behind `parse_cvn_pdf(...)` with embedded-file and XML metadata support |
 | `#49` | Validate XML and JSON import paths | Completed | JSON Schema plus Pydantic Open CVN JSON validation implemented; CVN XML well-formedness, trace extraction, and trace-only Open CVN mapping implemented |
+| `#50` | Add tests and documentation for parser workflow | Completed | Parser workflow docs, coverage audit, `pydantic_validation_failure` regression, drift checks, and full-suite verification completed |
 
 Corrective planning after hotfixes `#4`, `#5`, and `#6`:
 

--- a/docs/roadmap/issues/issue-41-epic-agnostic-schema-json-parser.md
+++ b/docs/roadmap/issues/issue-41-epic-agnostic-schema-json-parser.md
@@ -175,10 +175,13 @@ The detailed issue records for this epic are:
 
 ### Issue `#50` - Add Tests And Documentation For Parser Workflow
 
-- add fixtures for XML, JSON, and PDF-with-embedded-XML when available
-- test parser contracts and error reporting
-- document commands and examples for contributors
-- update current status, roadmap, and known limitations
+- audited parser, schema, conceptual, and diagram regression coverage after issues
+  `#42` through `#49`
+- added direct coverage for the existing `pydantic_validation_failure` JSON path
+- documented the public parser workflow for contributors in
+  `docs/development/parser_workflow.md`
+- verified parser, schema, conceptual, diagram, drift-check, and full-suite
+  workflows
 
 ## Expected Outputs
 
@@ -228,5 +231,7 @@ Those concerns belong to the later application epic.
 
 ## Status
 
-- Status: planned
-- Details for child issues should be expanded when epic `#41` starts
+- Status: completed
+- Issues `#42` through `#50` are implemented or documented with verification
+  records. Later application, storage, export, and richer XML semantic-mapping
+  work remain outside this epic.

--- a/docs/roadmap/issues/issue-50-parser-workflow-tests-and-documentation.md
+++ b/docs/roadmap/issues/issue-50-parser-workflow-tests-and-documentation.md
@@ -53,12 +53,537 @@ Potential documentation updates include:
 6. run full repository verification
 7. update epic `#41` and current status documentation
 
+## Accepted Execution Protocol
+
+For every execution step, report:
+
+1. active task number and task name
+2. active subtask number and subtask name when a subtask is being executed
+3. short initial summary of what the task or subtask will do
+4. short final result for the task or subtask
+5. whether the user must modify any file manually
+6. next step to follow
+
+File-modification rule:
+
+- documentation changes may be performed by the agent when explicitly requested
+- code, test, fixture, dependency, generated schema, and generated diagram changes
+  should be left for the user unless the user explicitly authorizes the agent to
+  edit them
+- generated structural code under `src/generated/` must not be edited manually
+- generated domain code under `src/models/cvn/generated/` must not be edited
+  manually
+- generated artifacts such as `schemas/open_cvn.schema.json` and
+  `docs/diagrams/*.puml` must be changed only through their documented generator
+  commands, not by hand
+
+## Accepted Execution Plan
+
+### Task `1 / 14` - Confirm Issue 50 Scope
+
+- Task summary:
+  - confirm that issue `#50` is a regression-test and contributor-documentation
+    closure issue for epic `#41`, not a new parser feature issue
+- Files involved:
+  - `docs/roadmap/issues/issue-41-epic-agnostic-schema-json-parser.md`
+  - `docs/roadmap/issues/issue-50-parser-workflow-tests-and-documentation.md`
+  - `docs/context/current_status.md`
+  - `docs/pipeline/parser_validator_contract.md`
+- Subtask `1.1 / 14`:
+  - confirm implemented scope from issues `#42` through `#49`
+- Subtask `1.2 / 14`:
+  - confirm that full XML-to-domain semantic mapping remains outside issue `#50`
+    unless a later issue reopens it
+- Subtask `1.3 / 14`:
+  - confirm that PDF import remains deterministic XML extraction only, with no OCR,
+    page-text reconstruction, or LLM fallback
+- Subtask `1.4 / 14`:
+  - confirm that issue `#50` must close documentation and verification gaps before
+    epic `#41` can be treated as stable
+- User manual modifications needed:
+  - none expected; this task is read-only
+- Next step:
+  - inventory current parser, schema, diagram, and workflow artifacts
+
+### Task `2 / 14` - Inventory Implemented Artifacts
+
+- Task summary:
+  - list the real implementation and documentation artifacts that issue `#50` must
+    protect or document
+- Files involved:
+  - `src/open_cvn/`
+  - `src/cvn_codegen/conceptual_model_extractor.py`
+  - `src/cvn_codegen/conceptual_model_diagrams.py`
+  - `src/cvn_codegen/json_schema_generator.py`
+  - `schemas/open_cvn.schema.json`
+  - `docs/diagrams/`
+  - `examples/open_cvn/`
+  - `tests/`
+- Subtask `2.1 / 14`:
+  - inventory public parser exports from `open_cvn`
+- Subtask `2.2 / 14`:
+  - inventory JSON import, XML import, PDF extraction, and common import utility
+    modules
+- Subtask `2.3 / 14`:
+  - inventory JSON Schema and Open CVN example artifacts
+- Subtask `2.4 / 14`:
+  - inventory conceptual IR and PlantUML diagram generation artifacts
+- Subtask `2.5 / 14`:
+  - inventory existing tests covering parser contract, PDF extraction, JSON import,
+    XML import, schema generation, examples, conceptual extraction, and diagrams
+- User manual modifications needed:
+  - none expected; this task is read-only
+- Next step:
+  - perform coverage-gap audit against the issue `#50` planned coverage list
+
+### Task `3 / 14` - Audit Coverage Gaps
+
+- Task summary:
+  - compare current tests with the required issue `#50` coverage matrix and decide
+    whether new tests are needed
+- Files involved:
+  - `tests/test_parser_validator_contract_unit.py`
+  - `tests/test_pdf_xml_extraction_unit.py`
+  - `tests/test_open_cvn_json_import_unit.py`
+  - `tests/test_cvn_xml_import_unit.py`
+  - `tests/test_generation_pipeline_json_schema.py`
+  - `tests/test_generation_pipeline_conceptual_model.py`
+  - `tests/test_generation_pipeline_conceptual_diagrams.py`
+  - `tests/test_open_cvn_json_format_examples.py`
+- Subtask `3.1 / 14`:
+  - audit conceptual IR extraction coverage
+- Subtask `3.2 / 14`:
+  - audit UML or PlantUML generation determinism coverage
+- Subtask `3.3 / 14`:
+  - audit JSON Schema generation, validity, and artifact-drift coverage
+- Subtask `3.4 / 14`:
+  - audit valid and invalid Open CVN JSON import coverage
+- Subtask `3.5 / 14`:
+  - audit valid and invalid CVN XML import coverage
+- Subtask `3.6 / 14`:
+  - audit PDF with extractable XML and PDF without extractable XML coverage
+- Subtask `3.7 / 14`:
+  - audit parser result, error contract, and trace metadata preservation coverage
+- Subtask `3.8 / 14`:
+  - record each gap as either `covered`, `needs test`, `needs documentation`, or
+    `out of scope`
+- User manual modifications needed:
+  - none for audit itself; test changes may be needed after gaps are confirmed
+- Next step:
+  - define the test additions or confirmations needed for contract-level behavior
+
+### Task `4 / 14` - Strengthen Parser Contract Tests
+
+- Task summary:
+  - ensure the public parser result envelope, errors, warnings, and trace rules are
+    regression-tested after issues `#48` and `#49`
+- Files involved if test edits are authorized:
+  - `tests/test_parser_validator_contract_unit.py`
+  - `src/open_cvn/parser_contract.py` only if a test exposes a contract defect
+- Subtask `4.1 / 14`:
+  - verify public imports from `open_cvn` remain stable
+- Subtask `4.2 / 14`:
+  - verify enum values remain stable lowercase strings
+- Subtask `4.3 / 14`:
+  - verify result invariants for `valid`, `valid_with_warnings`, `invalid`, and
+    `failed`
+- Subtask `4.4 / 14`:
+  - verify error-bearing results cannot use successful validation statuses
+- Subtask `4.5 / 14`:
+  - verify warning-bearing results use warning severity
+- Subtask `4.6 / 14`:
+  - verify trace metadata serializes source identity, source path, extraction
+    source, CVN codes, XML paths, schema version, and policy values
+- User manual modifications needed:
+  - test/code edits needed only if audit finds missing coverage or failing behavior;
+    by default the user owns those edits unless explicitly delegated
+- Next step:
+  - confirm parser input integration tests for JSON, XML, and PDF
+
+### Task `5 / 14` - Strengthen Parser Input Integration Tests
+
+- Task summary:
+  - verify all supported input families behave through the public parser API, not
+    only through internal helpers
+- Files involved if test edits are authorized:
+  - `tests/test_open_cvn_json_import_unit.py`
+  - `tests/test_cvn_xml_import_unit.py`
+  - `tests/test_pdf_xml_extraction_unit.py`
+  - `tests/fixtures/open_cvn/`
+  - `tests/fixtures/cvn_xml/`
+- Subtask `5.1 / 14`:
+  - verify Open CVN JSON path, inline string, bytes, and mapping inputs
+- Subtask `5.2 / 14`:
+  - verify malformed JSON returns `invalid_json`
+- Subtask `5.3 / 14`:
+  - verify schema failures return `json_schema_validation_failure`
+- Subtask `5.4 / 14`:
+  - verify runtime model failures return `pydantic_validation_failure` when schema
+    permits the document to reach runtime validation
+- Subtask `5.5 / 14`:
+  - verify CVN XML path, inline string, and bytes inputs
+- Subtask `5.6 / 14`:
+  - verify malformed XML returns `invalid_xml`
+- Subtask `5.7 / 14`:
+  - verify well-formed non-CVN XML returns `xml_semantically_unmappable`
+- Subtask `5.8 / 14`:
+  - verify PDF embedded XML, PDF XML metadata, unreadable PDF, unsupported input,
+    and PDF-without-XML cases
+- User manual modifications needed:
+  - test/fixture edits needed only if gaps are confirmed; by default the user owns
+    those edits unless explicitly delegated
+- Next step:
+  - confirm trace preservation across parser paths
+
+### Task `6 / 14` - Strengthen Trace Metadata Tests
+
+- Task summary:
+  - make trace preservation an explicit regression target for PDF, XML, and JSON
+    import paths
+- Files involved if test edits are authorized:
+  - `tests/test_open_cvn_json_import_unit.py`
+  - `tests/test_cvn_xml_import_unit.py`
+  - `tests/test_pdf_xml_extraction_unit.py`
+  - `tests/test_parser_validator_contract_unit.py`
+- Subtask `6.1 / 14`:
+  - verify Open CVN JSON trace preserves `schema_version`, `metadata.policy.name`,
+    and `metadata.policy.version`
+- Subtask `6.2 / 14`:
+  - verify XML trace preserves deterministic XML paths
+- Subtask `6.3 / 14`:
+  - verify XML trace preserves detected CVN code-like values
+- Subtask `6.4 / 14`:
+  - verify PDF trace preserves original PDF identity and extracted XML source
+- Subtask `6.5 / 14`:
+  - verify error results keep trace metadata without leaking personal payloads
+- User manual modifications needed:
+  - test edits needed only if current tests do not already cover these assertions;
+    by default the user owns those edits unless explicitly delegated
+- Next step:
+  - confirm generated schema and conceptual artifact reproducibility
+
+### Task `7 / 14` - Verify Generated Artifact Determinism
+
+- Task summary:
+  - prove generated JSON Schema and PlantUML source artifacts are reproducible or
+    clearly document why a check is not applicable
+- Files involved if test edits or regeneration are authorized:
+  - `src/cvn_codegen/json_schema_generator.py`
+  - `schemas/open_cvn.schema.json`
+  - `src/cvn_codegen/conceptual_model_diagrams.py`
+  - `docs/diagrams/`
+  - `tests/test_generation_pipeline_json_schema.py`
+  - `tests/test_generation_pipeline_conceptual_diagrams.py`
+- Subtask `7.1 / 14`:
+  - verify JSON Schema generator writes deterministic bytes for the same inventory
+- Subtask `7.2 / 14`:
+  - verify committed `schemas/open_cvn.schema.json` has no drift after canonical
+    regeneration
+- Subtask `7.3 / 14`:
+  - verify generated schema declares Draft 2020-12 and contains expected `$defs`
+- Subtask `7.4 / 14`:
+  - verify PlantUML generation writes deterministic `.puml` sources for canonical
+    diagrams
+- Subtask `7.5 / 14`:
+  - verify rendered PNGs remain optional derived review artifacts, not mandatory
+    repository outputs
+- User manual modifications needed:
+  - generated artifact or test edits needed only if drift or gaps are found; by
+    default the user owns those edits unless explicitly delegated
+- Next step:
+  - create or update contributor-facing parser workflow documentation
+
+### Task `8 / 14` - Document Parser Workflow For Contributors
+
+- Task summary:
+  - provide runnable parser usage guidance and examples without requiring readers
+    to inspect tests or chat history
+- Files involved if documentation edits are authorized:
+  - preferred new guide: `docs/development/parser_workflow.md`
+  - existing contract doc: `docs/pipeline/parser_validator_contract.md`
+  - `PROJECT_GUIDE.md` if the document map changes
+  - `docs/context/project_context_index.md` if the document map changes
+- Subtask `8.1 / 14`:
+  - document public imports from `open_cvn`
+- Subtask `8.2 / 14`:
+  - document parsing Open CVN JSON from path, string, bytes, and mapping inputs
+- Subtask `8.3 / 14`:
+  - document validating already-loaded Open CVN JSON mappings
+- Subtask `8.4 / 14`:
+  - document parsing direct CVN XML and interpreting trace-only output
+- Subtask `8.5 / 14`:
+  - document extracting XML from CVN PDFs and handing `data["xml_text"]` to
+    `parse_cvn_xml(...)`
+- Subtask `8.6 / 14`:
+  - document structured error handling for `invalid_json`,
+    `json_schema_validation_failure`, `pydantic_validation_failure`,
+    `invalid_xml`, `xml_semantically_unmappable`, `unreadable_file`,
+    `unsupported_input_format`, and `pdf_without_extractable_xml`
+- Subtask `8.7 / 14`:
+  - document commands for targeted parser tests and full suite verification
+- User manual modifications needed:
+  - documentation edits may be performed by the agent when explicitly requested;
+    otherwise the user owns them
+- Next step:
+  - align regeneration workflow and project maps with parser workflow docs
+
+### Task `9 / 14` - Align Workflow And Project Documentation
+
+- Task summary:
+  - ensure repository entry points mention parser workflow, schema regeneration,
+    diagrams, and verification in the correct places
+- Files involved if documentation edits are authorized:
+  - `docs/development/regeneration_workflow.md`
+  - `PROJECT_GUIDE.md`
+  - `docs/context/project_context_index.md`
+  - `README.md` only if the top-level human entry point changes
+- Subtask `9.1 / 14`:
+  - add parser workflow guide to document maps if a new guide is created
+- Subtask `9.2 / 14`:
+  - ensure regeneration workflow mentions conceptual diagrams, JSON Schema, parser
+    tests, and full suite verification after epic `#41`
+- Subtask `9.3 / 14`:
+  - ensure `PROJECT_GUIDE.md` points to parser contract/workflow docs when useful
+    for contributors
+- Subtask `9.4 / 14`:
+  - ensure `docs/context/project_context_index.md` reflects completed issues
+    `#49` and `#50` when issue `#50` closes
+- Subtask `9.5 / 14`:
+  - update `README.md` only if human onboarding changes materially
+- User manual modifications needed:
+  - documentation edits may be performed by the agent when explicitly requested;
+    otherwise the user owns them
+- Next step:
+  - update limitation records if new durable limitations are found
+
+### Task `10 / 14` - Update Known Limitations If Needed
+
+- Task summary:
+  - record only durable limitations found during test/documentation work, not
+    temporary local setup failures
+- Files involved if documentation edits are authorized:
+  - `docs/pipeline/known_limitations.md`
+  - issue `#50` document
+- Subtask `10.1 / 14`:
+  - confirm existing limitation for trace-only CVN XML import remains accurate
+- Subtask `10.2 / 14`:
+  - confirm existing limitation for JSON Schema-before-Pydantic validation remains
+    accurate
+- Subtask `10.3 / 14`:
+  - add a new limitation only if verification reveals an unrecorded parser,
+    schema, diagram, or workflow boundary
+- Subtask `10.4 / 14`:
+  - link any new limitation back to issue `#50` and expected future follow-up
+- User manual modifications needed:
+  - none unless a new limitation is found and the user wants to own the docs edit
+- Next step:
+  - run targeted verification commands
+
+### Task `11 / 14` - Run Targeted Verification
+
+- Task summary:
+  - execute the smallest useful verification commands for issue `#50` scope before
+    full-suite execution
+- Commands:
+  - `uv run pytest -n auto tests/test_parser_validator_contract_unit.py tests/test_pdf_xml_extraction_unit.py tests/test_open_cvn_json_import_unit.py tests/test_cvn_xml_import_unit.py -v`
+  - `uv run pytest -n auto tests/test_json_schema_generator_unit.py tests/test_generation_pipeline_json_schema.py tests/test_open_cvn_json_format_examples.py -v`
+  - `uv run pytest -n auto tests/test_conceptual_model_extractor_unit.py tests/test_generation_pipeline_conceptual_model.py tests/test_conceptual_model_diagrams_unit.py tests/test_generation_pipeline_conceptual_diagrams.py -v`
+- Subtask `11.1 / 14`:
+  - run targeted parser contract and parser input tests
+- Subtask `11.2 / 14`:
+  - run targeted JSON Schema and Open CVN JSON example tests
+- Subtask `11.3 / 14`:
+  - run targeted conceptual model and diagram tests
+- Subtask `11.4 / 14`:
+  - record exact commands and results in issue `#50`
+- Subtask `11.5 / 14`:
+  - if any command fails, classify failure as test gap, implementation bug,
+    environment issue, or documented limitation before editing files
+- User manual modifications needed:
+  - none to run commands; code/test edits may be needed if verification fails and
+    the user does not delegate them
+- Next step:
+  - run regeneration drift checks when safe
+
+### Task `12 / 14` - Run Regeneration Drift Checks
+
+- Task summary:
+  - confirm canonical generated schema and diagram sources are reproducible through
+    documented commands
+- Commands:
+  - `uv run python -m cvn_codegen.json_schema_generator`
+  - `uv run python -m cvn_codegen.conceptual_model_diagrams --output-dir docs/diagrams`
+- Subtask `12.1 / 14`:
+  - regenerate canonical JSON Schema and inspect whether `schemas/open_cvn.schema.json`
+    changes
+- Subtask `12.2 / 14`:
+  - regenerate canonical PlantUML sources and inspect whether `docs/diagrams/*.puml`
+    changes
+- Subtask `12.3 / 14`:
+  - if generated artifacts change, stop and report drift before deciding whether
+    the user or agent should keep regenerated outputs
+- Subtask `12.4 / 14`:
+  - record commands and drift/no-drift result in issue `#50`
+- User manual modifications needed:
+  - generated artifacts may change through commands; user approval is required
+    before keeping drift unless explicitly delegated
+- Next step:
+  - run full repository verification
+
+### Task `13 / 14` - Run Full Repository Verification
+
+- Task summary:
+  - prove issue `#50` closure does not regress earlier pipeline or parser work
+- Command:
+  - `uv run pytest -n auto tests`
+- Subtask `13.1 / 14`:
+  - run the full test suite
+- Subtask `13.2 / 14`:
+  - record exact command, pass/fail status, count, and duration
+- Subtask `13.3 / 14`:
+  - if full suite cannot be run, record the exact reason and strongest substitute
+    verification already executed
+- Subtask `13.4 / 14`:
+  - confirm no manual edits were made under `src/generated/` or
+    `src/models/cvn/generated/`
+- User manual modifications needed:
+  - none unless verification exposes failures requiring code, tests, fixtures, or
+    documentation changes
+- Next step:
+  - update issue, epic, roadmap, and current status documentation
+
+### Task `14 / 14` - Close Issue 50 And Epic 41 Documentation
+
+- Task summary:
+  - record final issue `#50` outcome and align persistent project state after all
+    tests and docs are complete
+- Files involved if documentation edits are authorized:
+  - `docs/roadmap/issues/issue-50-parser-workflow-tests-and-documentation.md`
+  - `docs/roadmap/issues/issue-41-epic-agnostic-schema-json-parser.md`
+  - `docs/context/current_status.md`
+  - `docs/roadmap/cvn_generation_roadmap.md`
+  - `docs/pipeline/known_limitations.md` only if new limitations were found
+  - `PROJECT_GUIDE.md` and `docs/context/project_context_index.md` if document maps
+    changed
+- Subtask `14.1 / 14`:
+  - update issue `#50` with implemented outcome, artifacts changed, verification,
+    deviations, limitations, and status
+- Subtask `14.2 / 14`:
+  - update epic `#41` with completed child issue status and final parser/schema
+    workflow summary
+- Subtask `14.3 / 14`:
+  - update `docs/context/current_status.md` with issue `#50` closure and next
+    planned roadmap direction
+- Subtask `14.4 / 14`:
+  - update `docs/roadmap/cvn_generation_roadmap.md` if issue or epic status
+    changes
+- Subtask `14.5 / 14`:
+  - update document maps if new parser workflow documentation was created
+- Subtask `14.6 / 14`:
+  - keep issue `#50` open if required verification did not pass or was not run
+- User manual modifications needed:
+  - documentation edits may be performed by the agent when explicitly requested;
+    code/test/generated artifact edits remain user-owned unless delegated
+- Next step:
+  - proceed to post-epic application/import-export roadmap only after issue `#50`
+    verification and documentation closure are accepted
+
+## Completion Criteria
+
+- implemented artifacts from issues `#42` through `#49` are inventoried
+- coverage matrix for parser, schema, conceptual, and diagram workflow is audited
+- parser contract tests protect result invariants and structured errors
+- parser input tests cover valid and invalid JSON, XML, and PDF paths
+- trace preservation is tested for JSON, XML, and PDF paths
+- JSON Schema generation is deterministic and validates expected Open CVN examples
+- conceptual IR and PlantUML generation determinism are tested or documented
+- contributor parser workflow documentation exists or current docs fully cover it
+- targeted verification commands pass or failures are documented with next actions
+- full repository verification passes with `uv run pytest -n auto tests`, or the
+  strongest substitute verification and blocker are recorded
+- issue `#50`, epic `#41`, current status, roadmap, and limitation docs are updated
+  as needed
+- no generated structural or generated domain code is manually edited
+
 ## Expected Output
 
 - parser and schema test coverage
 - contributor documentation for parser workflow
 - verification record for epic `#41`
 - documented limitations and follow-up work
+
+## Implementation Outcome
+
+- Issue `#50` audited the completed epic `#41` parser, schema, conceptual model,
+  and diagram workflow after issues `#42` through `#49`.
+- Existing regression coverage was confirmed for:
+  - conceptual IR extraction
+  - PlantUML generation determinism
+  - JSON Schema generation and Open CVN example validation
+  - valid and invalid Open CVN JSON import
+  - valid and invalid CVN XML import
+  - PDF extraction with embedded XML and XML metadata
+  - PDF without extractable XML
+  - parser result and error contract invariants
+  - trace metadata preservation for JSON, XML, and PDF paths
+- A missing direct regression assertion for the `pydantic_validation_failure` JSON
+  path was added to:
+  - `tests/test_open_cvn_json_import_unit.py`
+- Contributor parser workflow documentation was added at:
+  - `docs/development/parser_workflow.md`
+- Documentation maps were updated so future sessions can find the parser workflow
+  guide.
+
+## Implementation Adjustments
+
+- No new parser behavior was added. The only test change covers existing runtime
+  behavior for syntactically valid JSON whose loaded value is not an object.
+- Regeneration drift checks were executed against temporary outputs under
+  `/tmp/opencode` to avoid changing canonical artifacts while comparing outputs.
+- No new durable limitations were found; the existing trace-only CVN XML import
+  and JSON Schema-before-Pydantic validation limitations remain accurate.
+
+## Artifacts Changed
+
+- `docs/development/parser_workflow.md`
+- `tests/test_open_cvn_json_import_unit.py`
+- `PROJECT_GUIDE.md`
+- `AGENTS.md`
+- `docs/context/project_context_index.md`
+- `docs/development/regeneration_workflow.md`
+- `docs/roadmap/issues/issue-50-parser-workflow-tests-and-documentation.md`
+- `docs/roadmap/issues/issue-41-epic-agnostic-schema-json-parser.md`
+- `docs/context/current_status.md`
+- `docs/roadmap/cvn_generation_roadmap.md`
+
+## Verification Performed
+
+- Targeted parser workflow verification passed with:
+  `uv run pytest -n auto tests/test_parser_validator_contract_unit.py tests/test_pdf_xml_extraction_unit.py tests/test_open_cvn_json_import_unit.py tests/test_cvn_xml_import_unit.py -v`
+- Targeted parser verification result:
+  `36 passed in 16.61s`
+- Targeted JSON Schema and Open CVN example verification passed with:
+  `uv run pytest -n auto tests/test_json_schema_generator_unit.py tests/test_generation_pipeline_json_schema.py tests/test_open_cvn_json_format_examples.py -v`
+- Targeted JSON Schema and example verification result:
+  `21 passed in 92.86s (0:01:32)`
+- Targeted conceptual model and diagram verification passed with:
+  `uv run pytest -n auto tests/test_conceptual_model_extractor_unit.py tests/test_generation_pipeline_conceptual_model.py tests/test_conceptual_model_diagrams_unit.py tests/test_generation_pipeline_conceptual_diagrams.py -v`
+- Targeted conceptual and diagram verification result:
+  `19 passed in 90.61s (0:01:30)`
+- Temporary JSON Schema drift check passed with:
+  `uv run python -m cvn_codegen.json_schema_generator --output-path /tmp/opencode/issue50-schema/open_cvn.schema.json`
+- Temporary PlantUML drift check passed with:
+  `uv run python -m cvn_codegen.conceptual_model_diagrams --output-dir /tmp/opencode/issue50-diagrams`
+- Drift check result:
+  - `schemas/open_cvn.schema.json` matched the temporary regenerated schema
+  - canonical `.puml` files under `docs/diagrams/` matched the temporary
+    regenerated PlantUML sources
+  - `docs/diagrams/README.md` and rendered `.png` files are non-generated or
+    optional review artifacts and were not emitted to the temporary directory
+- Full-suite verification passed with:
+  `uv run pytest -n auto tests`
+- Full-suite verification result:
+  `370 passed in 287.52s (0:04:47)`
 
 ## Verification
 
@@ -73,4 +598,4 @@ Potential documentation updates include:
 
 ## Status
 
-- Status: planned
+- Status: completed

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-49-xml-json-import-validation.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 49. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-50-parser-workflow-tests-and-documentation.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 50. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-49-xml-json-import-validation.md.
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-50-parser-workflow-tests-and-documentation.md.
 
 
 

--- a/tests/test_open_cvn_json_import_unit.py
+++ b/tests/test_open_cvn_json_import_unit.py
@@ -58,6 +58,14 @@ def test_parse_open_cvn_json_reports_malformed_json():
     assert result.errors[0].source_location == "line 2 column 1"
 
 
+def test_parse_open_cvn_json_reports_runtime_validation_failure_for_non_object():
+    result = parse_open_cvn_json("[]", source_identifier="json-list")
+
+    assert result.validation_status == CvnValidationStatus.INVALID
+    assert result.errors[0].code == CvnErrorCode.PYDANTIC_VALIDATION_FAILURE
+    assert result.errors[0].details["input_type"] == "list"
+
+
 def test_validate_open_cvn_json_reports_schema_failures():
     payload = json.loads((FIXTURES / "wrong_shape.json").read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## Summary
- add contributor parser workflow guide for PDF, XML, and Open CVN JSON inputs
- close issue #50 and epic #41 documentation with verification records
- add regression coverage for `pydantic_validation_failure` JSON input handling
## Verification
- `uv run pytest -n auto tests/test_parser_validator_contract_unit.py tests/test_pdf_xml_extraction_unit.py tests/test_open_cvn_json_import_unit.py tests/test_cvn_xml_import_unit.py -v`
- `uv run pytest -n auto tests/test_json_schema_generator_unit.py tests/test_generation_pipeline_json_schema.py tests/test_open_cvn_json_format_examples.py -v`
- `uv run pytest -n auto tests/test_conceptual_model_extractor_unit.py tests/test_generation_pipeline_conceptual_model.py tests/test_conceptual_model_diagrams_unit.py tests/test_generation_pipeline_conceptual_diagrams.py -v`
- `uv run pytest -n auto tests`
## Notes
- full suite passed: `370 passed in 287.52s`
- XML import remains trace-only by design and is documented as future work

closes #50, #41 