### PR TITLE
feat: add SQLite curriculum storage

### DIFF
--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -715,6 +715,7 @@
   - `src/open_cvn_app/config.py`
   - `src/open_cvn_app/results.py`
   - `src/open_cvn_app/cli.py`
+  - `src/open_cvn_app/storage.py`
 - `pyproject.toml` now registers the console command:
   - `open-cvn = "open_cvn_app.cli:main"`
 - the CLI uses standard-library `argparse`; no new CLI dependency was added
@@ -729,9 +730,10 @@
   - `open-cvn versions derive NAME [--from SOURCE] [--store PATH]`
   - `open-cvn latex export OUTPUT [--store PATH] [--version NAME]`
   - `open-cvn pdf generate OUTPUT [--store PATH] [--version NAME]`
-- placeholder commands route deterministically to later issue messages without
-  creating storage, importing/exporting data, creating versions, rendering LaTeX,
-  or generating PDF artifacts
+- after issue `#62`, `store init` creates real local SQLite storage while the
+  remaining later-issue command groups still route deterministically to
+  placeholder messages without importing/exporting data, creating versions,
+  rendering LaTeX, or generating PDF artifacts
 - CLI smoke tests are implemented in:
   - `tests/test_open_cvn_app_cli_unit.py`
 - targeted parser contract verification passed with:
@@ -746,6 +748,59 @@
   - `uv run pytest -n auto tests`
   - result: `379 passed in 334.53s (0:05:34)`
 
+### Issue `#62`
+
+- the local SQLite storage repository issue is implemented under:
+  - `src/open_cvn_app/storage.py`
+- the storage layer uses Python standard-library `sqlite3`; no new database
+  dependency was added
+- the initial local store schema version is `1` and is recorded in
+  `app_metadata`
+- the implemented SQLite tables are:
+  - `app_metadata`
+  - `curricula`
+  - `curriculum_diagnostics`
+- store initialization is exposed through `initialize_store(path)` and is
+  idempotent
+- `open-cvn store init [--path PATH]` now creates a real SQLite store and reports
+  the resolved path plus schema version
+- repository operations are exposed through `CurriculumRepository` for create,
+  read, list, update, payload replacement, delete, and diagnostic listing
+- Open CVN JSON documents are validated with `validate_open_cvn_json(...)` before
+  storage
+- invalid or failed validation results are rejected before insertion
+- valid Open CVN documents are stored as deterministic canonical JSON text while
+  preserving semantic data for later export
+- parser or import diagnostics can be persisted and replaced through repository
+  create and payload replacement operations
+- storage tests are implemented in:
+  - `tests/test_open_cvn_app_storage_unit.py`
+- CLI storage initialization coverage was added to:
+  - `tests/test_open_cvn_app_cli_unit.py`
+- the existing JSON Schema CLI subprocess test now uses the xsdata generation
+  lock to avoid racing with generated artifact regeneration under `pytest -n auto`
+- targeted storage verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py -v`
+  - result: `7 passed in 24.88s`
+- targeted CLI verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `9 passed in 20.66s`
+- targeted parser regression verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`
+  - result: `22 passed in 32.96s`
+- targeted JSON Schema CLI lock verification passed with:
+  - `uv run pytest -n auto tests/test_generation_pipeline_json_schema.py::test_json_schema_generator_cli_writes_output -v`
+  - result: `1 passed in 62.65s`
+- combined app storage and CLI verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `16 passed in 26.62s`
+- console-script store initialization smoke verification passed with:
+  - `uv run open-cvn store init --path /tmp/opencode/open-cvn-issue-62-smoke.sqlite`
+- full-suite verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `386 passed in 371.09s (0:06:11)`
+- no new durable limitations were found
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -757,7 +812,8 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#61`: issue `#62` local SQLite storage repository
+- Next work item after issue `#62`: issue `#63` master and derived curriculum
+  versions
 - Epic `#60` has been expanded into issues `#61` through `#69`
 - MVP direction:
   - CLI-first local prototype
@@ -769,7 +825,7 @@
   - optional PDF generation and preview handoff
   - application MVP tests and user documentation
   - post-MVP LLM-assisted import spike
-- Next implementation issue: `#62` local storage with SQLite
+- Next implementation issue: `#63` master and derived curriculum versions
 
 ## Blocking Or Relevant Limitations
 

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -30,11 +30,12 @@ Agents should also read `AGENTS.md` before this file.
 - Project: open CVN schema and tooling for Spanish academic CV processing
 - Current pipeline stage: structural generation, metadata normalization,
   semantic policy, domain generation, conceptual schema, Open CVN JSON format,
-  and parser/validator contract completed
+  parser/validator contract, CLI shell, and local SQLite storage completed
 - Last documented issues: `#11`, `#12`, `#13`, `#14`, `#15`, `#16`, `#17`,
-  `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, `#47`, `#48`, `#49`, and `#50`
+  `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, `#47`, `#48`, `#49`, `#50`,
+  `#61`, and `#62`
 - Latest documented hotfix records: `#3`, `#4`, `#5`, `#6`, `#7`, `#8`
-- Next planned issue: `#62`
+- Next planned issue: `#63`
 - Canonical source package: `docs/CvnXML_v1.4.3_2.1_17012025/`
 
 ## Documentation Map

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -47,7 +47,7 @@ Goal:
 | `#50` | Add tests and documentation for parser workflow | Completed | Parser workflow docs, coverage audit, `pydantic_validation_failure` regression, drift checks, and full-suite verification completed |
 | `#60` | Epic: CV management application | Planned | MVP application roadmap for local storage, master/derived versions, JSON import/export, LaTeX/PDF export, and post-MVP LLM spike expanded |
 | `#61` | Application MVP scope and CLI shell | Completed | CLI-first prototype shell, command surface, console script, placeholders, and smoke tests implemented |
-| `#62` | Local storage with SQLite | Planned | Local single-user Open CVN document persistence |
+| `#62` | Local storage with SQLite | Completed | SQLite store initialization, schema metadata, curriculum repository, diagnostics, CLI store init, and tests implemented |
 | `#63` | Master and derived curriculum versions | Planned | Master curriculum plus target-specific derived CV versions |
 | `#64` | Open CVN JSON import/export workflow | Planned | Application import/export using epic `#41` parser and validator |
 | `#65` | Curriculum editing and selection MVP | Planned | Basic include/exclude customization for derived versions |

--- a/docs/roadmap/issues/issue-62-local-storage-sqlite-repository.md
+++ b/docs/roadmap/issues/issue-62-local-storage-sqlite-repository.md
@@ -48,6 +48,274 @@ inside SQLite while storing enough metadata for listing, selection, and versioni
 6. add unit tests with temporary SQLite files
 7. document the local storage file and backup expectations
 
+## Detailed Execution Plan
+
+This plan is the accepted execution plan for implementing issue `#62`.
+During execution, each work update must identify the active task and, when
+applicable, the active subtask. Each task or subtask update should include:
+
+- initial summary of the task or subtask goal
+- current task and subtask identifier
+- whether the user must modify any file manually
+- next step to follow
+
+Unless explicitly requested otherwise, code edits are expected to be performed by
+the user. Documentation edits may be applied when the user asks to establish or
+update the issue plan.
+
+### Task 1 - Confirm Scope And Constraints
+
+- Subtask 1.1: confirm issue `#62` is limited to local SQLite storage and schema
+  initialization.
+- Subtask 1.2: confirm issue `#62` does not implement full Open CVN JSON
+  import/export behavior, which remains planned for issue `#64`.
+- Subtask 1.3: confirm issue `#62` does not implement master or derived version
+  management, which remains planned for issue `#63`.
+- Subtask 1.4: confirm issue `#62` does not implement LaTeX or PDF export
+  behavior.
+- Subtask 1.5: confirm `src/generated/` remains untouched.
+- Subtask 1.6: confirm `open-cvn store init` is the only CLI placeholder from
+  issue `#61` that becomes functional during this issue.
+
+Expected output: final implementation boundary for issue `#62` before code work.
+
+### Task 2 - Define Storage Contract
+
+- Subtask 2.1: create application-level storage types such as
+  `CurriculumRecord`, `CurriculumCreate`, `CurriculumUpdate`, and
+  `CurriculumDiagnostic`.
+- Subtask 2.2: define storage errors such as `StoreNotInitialized`,
+  `CurriculumNotFound`, and `InvalidCurriculumDocument`.
+- Subtask 2.3: use UUID values for internal curriculum IDs.
+- Subtask 2.4: use UTC ISO-8601 strings for `created_at` and `updated_at`
+  timestamps.
+- Subtask 2.5: keep the public repository API small enough for later issues
+  `#63` and `#64` to consume without redesign.
+
+Expected output: stable local storage API contract for the MVP application layer.
+
+### Task 3 - Create SQLite Storage Module
+
+- Subtask 3.1: create `src/open_cvn_app/storage.py`.
+- Subtask 3.2: use Python standard-library `sqlite3`; do not add a new database
+  dependency.
+- Subtask 3.3: implement a connection helper for local store files.
+- Subtask 3.4: enable `PRAGMA foreign_keys = ON` for repository connections.
+- Subtask 3.5: use `sqlite3.Row` or equivalent row mapping for deterministic
+  record loading.
+- Subtask 3.6: ensure store initialization creates the parent directory for the
+  SQLite file when needed.
+
+Expected output: hand-maintained SQLite module under `src/open_cvn_app/`.
+
+### Task 4 - Implement Schema Initialization
+
+- Subtask 4.1: define an initial application storage schema version, such as
+  `SCHEMA_VERSION = "1"`.
+- Subtask 4.2: create an `app_metadata` table for schema metadata.
+- Subtask 4.3: create a `curricula` table for stored Open CVN documents.
+- Subtask 4.4: create a `curriculum_diagnostics` table for parser warnings,
+  errors, and import diagnostics.
+- Subtask 4.5: create indexes needed for MVP listing and diagnostic lookup.
+- Subtask 4.6: implement `initialize_store(path)` as an idempotent operation.
+- Subtask 4.7: detect incompatible future schema versions and fail clearly.
+
+Expected output: repeatable SQLite schema initialization for local stores.
+
+### Task 5 - Validate Documents Before Storage
+
+- Subtask 5.1: accept Open CVN documents as `Mapping[str, Any]` values in the
+  repository create and update paths.
+- Subtask 5.2: call `validate_open_cvn_json(...)` from `src/open_cvn/` before
+  storing a document.
+- Subtask 5.3: reject validation results with `invalid` or `failed` status.
+- Subtask 5.4: allow `valid` and `valid_with_warnings` results to be stored.
+- Subtask 5.5: extract `schema_version`, `metadata.policy.name`, and
+  `metadata.policy.version` from the validated document.
+- Subtask 5.6: serialize the payload with deterministic JSON settings, such as
+  `sort_keys=True` and compact separators.
+
+Expected output: invalid Open CVN JSON cannot be stored as a valid curriculum
+record.
+
+### Task 6 - Preserve Open CVN JSON Payload Semantics
+
+- Subtask 6.1: store the Open CVN document payload as canonical JSON text inside
+  SQLite.
+- Subtask 6.2: read stored payloads back as Python mappings.
+- Subtask 6.3: verify semantic round-trip equality for representative Open CVN
+  JSON documents.
+- Subtask 6.4: document that original JSON whitespace and object ordering are not
+  preserved, while data content is preserved for export.
+
+Expected output: stored Open CVN JSON remains usable for later issue `#64`
+export.
+
+### Task 7 - Implement Curriculum Repository Operations
+
+- Subtask 7.1: implement `create_curriculum(...)`.
+- Subtask 7.2: implement `get_curriculum(...)`.
+- Subtask 7.3: implement `list_curricula(...)`.
+- Subtask 7.4: implement `update_curriculum(...)` for editable metadata such as
+  display name.
+- Subtask 7.5: implement `replace_curriculum_payload(...)` or equivalent payload
+  update behavior.
+- Subtask 7.6: implement `delete_curriculum(...)`.
+- Subtask 7.7: wrap write operations in transactions and update `updated_at`
+  deterministically.
+
+Expected output: MVP CRUD repository for stored curriculum documents.
+
+### Task 8 - Preserve Parser Diagnostics
+
+- Subtask 8.1: convert warnings and errors from `CvnParseResult` into diagnostic
+  rows.
+- Subtask 8.2: store diagnostic severity, code, message, source location, path,
+  and details.
+- Subtask 8.3: store diagnostic `path` and `details` as JSON text.
+- Subtask 8.4: clear and replace diagnostics when a curriculum payload is
+  replaced.
+- Subtask 8.5: expose diagnostic loading by curriculum ID.
+
+Expected output: parser validation status and trace metadata remain available
+after persistence.
+
+### Task 9 - Wire Store Initialization Into CLI
+
+- Subtask 9.1: replace the issue `#61` placeholder behavior for
+  `open-cvn store init`.
+- Subtask 9.2: resolve the configured store path through `OpenCvnAppConfig`.
+- Subtask 9.3: call `initialize_store(...)` from the CLI handler.
+- Subtask 9.4: return a success message with the resolved store path and schema
+  version.
+- Subtask 9.5: convert storage initialization failures into `AppResult.failed(...)`.
+- Subtask 9.6: keep the JSON, versions, LaTeX, and PDF command groups as
+  placeholders for their later issues.
+
+Expected output: `open-cvn store init [--path PATH]` creates a real local SQLite
+store.
+
+### Task 10 - Add Storage Unit Tests
+
+- Subtask 10.1: create `tests/test_open_cvn_app_storage_unit.py`.
+- Subtask 10.2: use `tmp_path` for isolated temporary SQLite files.
+- Subtask 10.3: test schema initialization creates the expected tables and
+  metadata.
+- Subtask 10.4: test schema initialization is idempotent.
+- Subtask 10.5: test create, read, list, update, and delete repository behavior.
+- Subtask 10.6: test payload round-trip equality with a valid Open CVN fixture.
+- Subtask 10.7: test invalid Open CVN JSON is rejected.
+- Subtask 10.8: test diagnostic storage and loading.
+- Subtask 10.9: test missing curriculum IDs raise or return the documented not
+  found behavior.
+
+Expected output: temporary database tests prove the repository behavior.
+
+### Task 11 - Update CLI Tests
+
+- Subtask 11.1: update the existing `store init` CLI test that currently expects
+  the issue `#62` placeholder message.
+- Subtask 11.2: verify `store init --path <tmp>` creates the SQLite database.
+- Subtask 11.3: verify the success output includes the resolved path.
+- Subtask 11.4: keep tests for later issue placeholders unchanged where those
+  commands are still placeholders.
+
+Expected output: CLI tests reflect the real storage initialization behavior.
+
+### Task 12 - Verify Parser Integration
+
+- Subtask 12.1: use an existing valid Open CVN JSON fixture from
+  `tests/fixtures/open_cvn/` or `examples/open_cvn/`.
+- Subtask 12.2: store the fixture through the repository and verify
+  `validation_status` metadata.
+- Subtask 12.3: use invalid JSON or wrong-shape fixtures to verify rejection.
+- Subtask 12.4: confirm no parallel parser or validator code is introduced in
+  `src/open_cvn_app/`.
+
+Expected output: storage consumes the public epic `#41` parser/validator contract.
+
+### Task 13 - Run Issue Verification
+
+- Subtask 13.1: run targeted storage tests:
+  `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py -v`.
+- Subtask 13.2: run targeted CLI tests:
+  `uv run pytest -n auto tests/test_open_cvn_app_cli_unit.py -v`.
+- Subtask 13.3: run parser integration regression tests:
+  `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`.
+- Subtask 13.4: run full repository verification:
+  `uv run pytest -n auto tests`.
+- Subtask 13.5: record any skipped or failed verification with reason.
+
+Expected output: issue `#62` verification evidence.
+
+### Task 14 - Update Persistent Documentation
+
+- Subtask 14.1: update this issue document with actual implementation artifacts,
+  deviations, verification, and status.
+- Subtask 14.2: update `docs/context/current_status.md` so issue `#62` is recorded
+  accurately and issue `#63` becomes the next implementation issue if `#62` is
+  completed.
+- Subtask 14.3: update `docs/roadmap/cvn_generation_roadmap.md` if it tracks issue
+  `#62` status.
+- Subtask 14.4: update `docs/pipeline/known_limitations.md` only if a new durable
+  limitation is found.
+- Subtask 14.5: update `PROJECT_GUIDE.md` only if repository orientation,
+  contributor reading order, or the documentation map changes.
+
+Expected output: repository context remains resumable after issue completion.
+
+## Planned Initial SQLite Shape
+
+The first storage schema should remain intentionally small and focused on local
+single-user MVP storage:
+
+```text
+app_metadata
+- key
+- value
+
+curricula
+- id
+- display_name
+- payload_json
+- schema_version
+- policy_name
+- policy_version
+- source_format
+- source_identifier
+- validation_status
+- created_at
+- updated_at
+
+curriculum_diagnostics
+- id
+- curriculum_id
+- severity
+- code
+- message
+- source_location
+- path_json
+- details_json
+- created_at
+```
+
+The exact SQL names may change during implementation if a smaller or clearer
+schema is found. Any deviation must be recorded in this issue document.
+
+## Definition Of Done
+
+- `src/open_cvn_app/` contains the local SQLite storage module.
+- `open-cvn store init [--path PATH]` creates a real local SQLite database.
+- The store schema records a schema version.
+- Valid Open CVN JSON can be stored and read back without semantic data loss.
+- Invalid Open CVN JSON cannot be stored as a valid curriculum record.
+- Parser diagnostics can be persisted and loaded.
+- Repository create, read, update, list, and delete behavior is covered by tests.
+- CLI storage initialization behavior is covered by tests.
+- Existing parser/validator contract tests still pass.
+- Full repository verification passes or a documented reason is recorded.
+- Persistent documentation is updated in the same session as the implementation.
+
 ## Expected Output
 
 - storage module under `src/open_cvn_app/`
@@ -62,6 +330,134 @@ inside SQLite while storing enough metadata for listing, selection, and versioni
 - invalid JSON cannot be stored as a valid curriculum record
 - full repository verification passes or a reason is documented
 
+## Implementation Notes
+
+- The local storage module is implemented at:
+  - `src/open_cvn_app/storage.py`
+- The implementation uses Python standard-library `sqlite3`; no new database
+  dependency was added.
+- The initial store schema version is `1` and is recorded in `app_metadata`.
+- Store initialization is idempotent through `initialize_store(path)`.
+- Repository operations are exposed through `CurriculumRepository` and cover:
+  - `create_curriculum(...)`
+  - `get_curriculum(...)`
+  - `list_curricula(...)`
+  - `update_curriculum(...)`
+  - `replace_curriculum_payload(...)`
+  - `delete_curriculum(...)`
+  - `list_diagnostics(...)`
+- Application storage records are represented through dataclasses including:
+  - `StoreInfo`
+  - `CurriculumCreate`
+  - `CurriculumUpdate`
+  - `CurriculumRecord`
+  - `CurriculumDiagnostic`
+- Storage errors are represented through explicit exception types including:
+  - `StoreNotInitialized`
+  - `IncompatibleStoreSchema`
+  - `CurriculumNotFound`
+  - `InvalidCurriculumDocument`
+- Open CVN documents are validated with `validate_open_cvn_json(...)` from
+  `src/open_cvn/` before storage.
+- Invalid or failed validation results are rejected before insertion.
+- Valid documents are stored as deterministic canonical JSON text using compact
+  separators and sorted object keys.
+- Parser or import diagnostics can be passed into create and replace operations
+  and are stored under `curriculum_diagnostics`.
+- Diagnostic `path` and `details` values are serialized as JSON text.
+- `open-cvn store init [--path PATH]` now creates a real SQLite store and reports
+  the resolved store path plus schema version.
+- The other CLI command groups remain placeholders for their later issues.
+- `src/generated/` was not modified.
+
+## Implemented SQLite Shape
+
+```text
+app_metadata
+- key
+- value
+
+curricula
+- id
+- display_name
+- payload_json
+- schema_version
+- policy_name
+- policy_version
+- source_format
+- source_identifier
+- validation_status
+- created_at
+- updated_at
+
+curriculum_diagnostics
+- id
+- curriculum_id
+- severity
+- code
+- message
+- source_location
+- path_json
+- details_json
+- created_at
+```
+
+Implemented indexes:
+
+- `idx_curricula_display_name`
+- `idx_curricula_updated_at`
+- `idx_curriculum_diagnostics_curriculum_id`
+
+## Tests Added Or Updated
+
+- Added `tests/test_open_cvn_app_storage_unit.py`.
+- Updated `tests/test_open_cvn_app_cli_unit.py` so `store init` expects real store
+  initialization instead of issue `#62` placeholder routing.
+- Updated `tests/test_generation_pipeline_json_schema.py` so the JSON Schema CLI
+  subprocess test uses the existing xsdata generation lock and does not race with
+  generated artifact regeneration under `pytest -n auto`.
+
+The storage tests cover:
+
+- schema initialization and metadata creation
+- idempotent initialization
+- repository create, read, list, update, replace, delete, and missing-record
+  behavior
+- Open CVN JSON payload round-trip semantics
+- rejection of invalid Open CVN JSON
+- diagnostic persistence and replacement
+
+## Verification Performed
+
+- `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py -v`
+  - result: `7 passed in 24.88s`
+- `uv run pytest -n auto tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `9 passed in 20.66s`
+- `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`
+  - result: `22 passed in 32.96s`
+- `uv run pytest -n auto tests/test_generation_pipeline_json_schema.py::test_json_schema_generator_cli_writes_output -v`
+  - result: `1 passed in 62.65s`
+- `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `16 passed in 26.62s`
+- `uv run open-cvn store init --path /tmp/opencode/open-cvn-issue-62-smoke.sqlite`
+  - result: command initialized a SQLite store and reported schema version `1`
+- `uv run pytest -n auto tests`
+  - result: `386 passed in 371.09s (0:06:11)`
+
+## Deviations From Planned Scope
+
+- No functional deviations.
+- The implementation stores deterministic JSON text and does not preserve original
+  input whitespace or object ordering. This matches the planned semantic payload
+  preservation requirement for later export.
+- Verification required a test-infrastructure stabilization in the existing JSON
+  Schema CLI subprocess test so it cooperates with the repository's xsdata
+  generation lock under xdist.
+
+## New Limitations Found
+
+- No new durable limitations were found.
+
 ## Impact On Later Issues
 
 - issue `#63` builds master and derived versions on top of stored documents
@@ -69,4 +465,4 @@ inside SQLite while storing enough metadata for listing, selection, and versioni
 
 ## Status
 
-- Status: planned
+- Status: completed

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-61-application-mvp-scope-and-cli-shell.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 61. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-62-local-storage-sqlite-repository.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 62. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-61-application-mvp-scope-and-cli-shell.md.
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-62-local-storage-sqlite-repository.md.
 
 
 

--- a/src/open_cvn_app/cli.py
+++ b/src/open_cvn_app/cli.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from open_cvn_app import __version__
 from open_cvn_app.config import OpenCvnAppConfig
 from open_cvn_app.results import AppResult
+from open_cvn_app.storage import SCHEMA_VERSION, StorageError, initialize_store
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -127,7 +128,15 @@ def _handle_version(args: argparse.Namespace) -> AppResult:
 
 
 def _handle_store_init(args: argparse.Namespace) -> AppResult:
-    return _planned_result("Store initialization", "#62", args)
+    config = _config_from_args(args)
+    try:
+        store_info = initialize_store(config.store_path)
+    except StorageError as exc:
+        return AppResult.failed("Store initialization failed.", error=str(exc))
+    return AppResult.ok(
+        f"Initialized Open CVN store at {store_info.path}. "
+        f"Schema version: {SCHEMA_VERSION}"
+    )
 
 
 def _handle_json_import(args: argparse.Namespace) -> AppResult:

--- a/src/open_cvn_app/storage.py
+++ b/src/open_cvn_app/storage.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+from open_cvn.parser_contract import (
+    CvnParseIssue,
+    CvnValidationStatus,
+    validate_open_cvn_json,
+)
+
+
+SCHEMA_VERSION = "1"
+
+
+class StorageError(RuntimeError):
+    """Base error for local Open CVN storage failures."""
+
+
+class StoreNotInitialized(StorageError):
+    """Raised when a SQLite file is not an initialized Open CVN store."""
+
+
+class IncompatibleStoreSchema(StorageError):
+    """Raised when the store schema is newer than this application supports."""
+
+
+class CurriculumNotFound(StorageError):
+    """Raised when a curriculum ID does not exist in the local store."""
+
+
+class InvalidCurriculumDocument(StorageError):
+    """Raised when an Open CVN document fails validation before storage."""
+
+
+@dataclass(frozen=True)
+class StoreInfo:
+    path: Path
+    schema_version: str
+
+
+@dataclass(frozen=True)
+class CurriculumCreate:
+    display_name: str
+    document: Mapping[str, Any]
+    source_identifier: str | None = None
+    diagnostics: tuple[CvnParseIssue, ...] = ()
+
+
+@dataclass(frozen=True)
+class CurriculumUpdate:
+    display_name: str | None = None
+
+
+@dataclass(frozen=True)
+class CurriculumDiagnostic:
+    id: str
+    curriculum_id: str
+    severity: str
+    code: str
+    message: str
+    source_location: str | None
+    path: tuple[str, ...]
+    details: dict[str, str | int | float | bool | None]
+    created_at: str
+
+
+@dataclass(frozen=True)
+class CurriculumRecord:
+    id: str
+    display_name: str
+    document: Mapping[str, Any]
+    schema_version: str
+    policy_name: str
+    policy_version: str
+    source_format: str
+    source_identifier: str | None
+    validation_status: str
+    created_at: str
+    updated_at: str
+
+
+def initialize_store(path: str | Path) -> StoreInfo:
+    store_path = _normalize_store_path(path)
+    _ensure_parent_dir(store_path)
+    with _connect(store_path) as connection:
+        _configure_connection(connection)
+        connection.executescript(_SCHEMA_SQL)
+        current_version = _read_schema_version(connection)
+        if current_version is None:
+            connection.execute(
+                "INSERT INTO app_metadata(key, value) VALUES (?, ?)",
+                ("schema_version", SCHEMA_VERSION),
+            )
+        elif _schema_version_number(current_version) > _schema_version_number(SCHEMA_VERSION):
+            raise IncompatibleStoreSchema(
+                f"Store schema version {current_version} is newer than supported {SCHEMA_VERSION}."
+            )
+        connection.commit()
+    return StoreInfo(path=store_path, schema_version=SCHEMA_VERSION)
+
+
+class CurriculumRepository:
+    def __init__(self, path: str | Path) -> None:
+        self.path = _normalize_store_path(path)
+
+    def create_curriculum(self, create: CurriculumCreate) -> CurriculumRecord:
+        prepared = _prepare_document(
+            create.document,
+            source_identifier=create.source_identifier,
+            diagnostics=create.diagnostics,
+        )
+        curriculum_id = str(uuid.uuid4())
+        now = _utc_now()
+        with self._connection() as connection:
+            connection.execute(
+                """
+                INSERT INTO curricula(
+                    id,
+                    display_name,
+                    payload_json,
+                    schema_version,
+                    policy_name,
+                    policy_version,
+                    source_format,
+                    source_identifier,
+                    validation_status,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    curriculum_id,
+                    create.display_name,
+                    prepared.payload_json,
+                    prepared.schema_version,
+                    prepared.policy_name,
+                    prepared.policy_version,
+                    prepared.source_format,
+                    prepared.source_identifier,
+                    prepared.validation_status,
+                    now,
+                    now,
+                ),
+            )
+            _replace_diagnostics(
+                connection,
+                curriculum_id=curriculum_id,
+                issues=prepared.issues,
+                created_at=now,
+            )
+            connection.commit()
+        return self.get_curriculum(curriculum_id)
+
+    def get_curriculum(self, curriculum_id: str) -> CurriculumRecord:
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT * FROM curricula WHERE id = ?",
+                (curriculum_id,),
+            ).fetchone()
+        if row is None:
+            raise CurriculumNotFound(f"Curriculum not found: {curriculum_id}")
+        return _row_to_record(row)
+
+    def list_curricula(self) -> tuple[CurriculumRecord, ...]:
+        with self._connection() as connection:
+            rows = connection.execute(
+                "SELECT * FROM curricula ORDER BY updated_at DESC, display_name ASC, id ASC"
+            ).fetchall()
+        return tuple(_row_to_record(row) for row in rows)
+
+    def update_curriculum(self, curriculum_id: str, update: CurriculumUpdate) -> CurriculumRecord:
+        existing = self.get_curriculum(curriculum_id)
+        display_name = update.display_name if update.display_name is not None else existing.display_name
+        now = _utc_now()
+        with self._connection() as connection:
+            cursor = connection.execute(
+                "UPDATE curricula SET display_name = ?, updated_at = ? WHERE id = ?",
+                (display_name, now, curriculum_id),
+            )
+            if cursor.rowcount == 0:
+                raise CurriculumNotFound(f"Curriculum not found: {curriculum_id}")
+            connection.commit()
+        return self.get_curriculum(curriculum_id)
+
+    def replace_curriculum_payload(
+        self,
+        curriculum_id: str,
+        document: Mapping[str, Any],
+        *,
+        source_identifier: str | None = None,
+        diagnostics: tuple[CvnParseIssue, ...] = (),
+    ) -> CurriculumRecord:
+        prepared = _prepare_document(
+            document,
+            source_identifier=source_identifier,
+            diagnostics=diagnostics,
+        )
+        now = _utc_now()
+        with self._connection() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE curricula
+                SET payload_json = ?,
+                    schema_version = ?,
+                    policy_name = ?,
+                    policy_version = ?,
+                    source_format = ?,
+                    source_identifier = ?,
+                    validation_status = ?,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    prepared.payload_json,
+                    prepared.schema_version,
+                    prepared.policy_name,
+                    prepared.policy_version,
+                    prepared.source_format,
+                    prepared.source_identifier,
+                    prepared.validation_status,
+                    now,
+                    curriculum_id,
+                ),
+            )
+            if cursor.rowcount == 0:
+                raise CurriculumNotFound(f"Curriculum not found: {curriculum_id}")
+            _replace_diagnostics(
+                connection,
+                curriculum_id=curriculum_id,
+                issues=prepared.issues,
+                created_at=now,
+            )
+            connection.commit()
+        return self.get_curriculum(curriculum_id)
+
+    def delete_curriculum(self, curriculum_id: str) -> None:
+        with self._connection() as connection:
+            cursor = connection.execute("DELETE FROM curricula WHERE id = ?", (curriculum_id,))
+            if cursor.rowcount == 0:
+                raise CurriculumNotFound(f"Curriculum not found: {curriculum_id}")
+            connection.commit()
+
+    def list_diagnostics(self, curriculum_id: str) -> tuple[CurriculumDiagnostic, ...]:
+        self.get_curriculum(curriculum_id)
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM curriculum_diagnostics
+                WHERE curriculum_id = ?
+                ORDER BY created_at ASC, id ASC
+                """,
+                (curriculum_id,),
+            ).fetchall()
+        return tuple(_row_to_diagnostic(row) for row in rows)
+
+    def _connection(self) -> sqlite3.Connection:
+        connection = _connect(self.path)
+        try:
+            _configure_connection(connection)
+            _verify_initialized(connection)
+        except Exception:
+            connection.close()
+            raise
+        return connection
+
+
+@dataclass(frozen=True)
+class _PreparedDocument:
+    payload_json: str
+    schema_version: str
+    policy_name: str
+    policy_version: str
+    source_format: str
+    source_identifier: str | None
+    validation_status: str
+    issues: tuple[CvnParseIssue, ...]
+
+
+def _prepare_document(
+    document: Mapping[str, Any], *, source_identifier: str | None, diagnostics: tuple[CvnParseIssue, ...]
+) -> _PreparedDocument:
+    validation_result = validate_open_cvn_json(document, source_identifier=source_identifier)
+    if validation_result.validation_status in {CvnValidationStatus.INVALID, CvnValidationStatus.FAILED}:
+        messages = "; ".join(issue.message for issue in validation_result.errors)
+        raise InvalidCurriculumDocument(messages or "Open CVN document is invalid.")
+    if validation_result.data is None:
+        raise InvalidCurriculumDocument("Open CVN validation did not return document data.")
+
+    metadata = validation_result.data["metadata"]
+    policy = metadata["policy"]
+    payload_json = json.dumps(
+        validation_result.data,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return _PreparedDocument(
+        payload_json=payload_json,
+        schema_version=str(validation_result.data["schema_version"]),
+        policy_name=str(policy["name"]),
+        policy_version=str(policy["version"]),
+        source_format=validation_result.source_format.value,
+        source_identifier=validation_result.source_identifier,
+        validation_status=validation_result.validation_status.value,
+        issues=validation_result.warnings + diagnostics,
+    )
+
+
+def _replace_diagnostics(
+    connection: sqlite3.Connection,
+    *,
+    curriculum_id: str,
+    issues: tuple[CvnParseIssue, ...],
+    created_at: str,
+) -> None:
+    connection.execute("DELETE FROM curriculum_diagnostics WHERE curriculum_id = ?", (curriculum_id,))
+    connection.executemany(
+        """
+        INSERT INTO curriculum_diagnostics(
+            id,
+            curriculum_id,
+            severity,
+            code,
+            message,
+            source_location,
+            path_json,
+            details_json,
+            created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            (
+                str(uuid.uuid4()),
+                curriculum_id,
+                issue.severity.value,
+                issue.code.value,
+                issue.message,
+                issue.source_location,
+                json.dumps(list(issue.path), ensure_ascii=False, separators=(",", ":")),
+                json.dumps(issue.details, ensure_ascii=False, sort_keys=True, separators=(",", ":")),
+                created_at,
+            )
+            for issue in issues
+        ),
+    )
+
+
+def _row_to_record(row: sqlite3.Row) -> CurriculumRecord:
+    return CurriculumRecord(
+        id=row["id"],
+        display_name=row["display_name"],
+        document=json.loads(row["payload_json"]),
+        schema_version=row["schema_version"],
+        policy_name=row["policy_name"],
+        policy_version=row["policy_version"],
+        source_format=row["source_format"],
+        source_identifier=row["source_identifier"],
+        validation_status=row["validation_status"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _row_to_diagnostic(row: sqlite3.Row) -> CurriculumDiagnostic:
+    return CurriculumDiagnostic(
+        id=row["id"],
+        curriculum_id=row["curriculum_id"],
+        severity=row["severity"],
+        code=row["code"],
+        message=row["message"],
+        source_location=row["source_location"],
+        path=tuple(json.loads(row["path_json"])),
+        details=json.loads(row["details_json"]),
+        created_at=row["created_at"],
+    )
+
+
+def _verify_initialized(connection: sqlite3.Connection) -> None:
+    schema_version = _read_schema_version(connection)
+    if schema_version is None:
+        raise StoreNotInitialized("SQLite file is not an initialized Open CVN store.")
+    if _schema_version_number(schema_version) > _schema_version_number(SCHEMA_VERSION):
+        raise IncompatibleStoreSchema(
+            f"Store schema version {schema_version} is newer than supported {SCHEMA_VERSION}."
+        )
+
+
+def _read_schema_version(connection: sqlite3.Connection) -> str | None:
+    table_exists = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'app_metadata'"
+    ).fetchone()
+    if table_exists is None:
+        return None
+    row = connection.execute(
+        "SELECT value FROM app_metadata WHERE key = ?",
+        ("schema_version",),
+    ).fetchone()
+    return None if row is None else str(row["value"])
+
+
+def _schema_version_number(value: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise IncompatibleStoreSchema(f"Invalid store schema version: {value}") from exc
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    return sqlite3.connect(path)
+
+
+def _configure_connection(connection: sqlite3.Connection) -> None:
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+
+
+def _normalize_store_path(path: str | Path) -> Path:
+    return Path(path).expanduser()
+
+
+def _ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS app_metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS curricula (
+    id TEXT PRIMARY KEY,
+    display_name TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    schema_version TEXT NOT NULL,
+    policy_name TEXT NOT NULL,
+    policy_version TEXT NOT NULL,
+    source_format TEXT NOT NULL,
+    source_identifier TEXT,
+    validation_status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS curriculum_diagnostics (
+    id TEXT PRIMARY KEY,
+    curriculum_id TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    code TEXT NOT NULL,
+    message TEXT NOT NULL,
+    source_location TEXT,
+    path_json TEXT NOT NULL,
+    details_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (curriculum_id) REFERENCES curricula(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_curricula_display_name ON curricula(display_name);
+CREATE INDEX IF NOT EXISTS idx_curricula_updated_at ON curricula(updated_at);
+CREATE INDEX IF NOT EXISTS idx_curriculum_diagnostics_curriculum_id
+    ON curriculum_diagnostics(curriculum_id);
+"""

--- a/tests/test_generation_pipeline_json_schema.py
+++ b/tests/test_generation_pipeline_json_schema.py
@@ -16,6 +16,7 @@ from cvn_codegen.json_schema_generator import (
 )
 from cvn_codegen.normalization_types import NormalizationResult
 from cvn_codegen.semantic_policy import build_default_semantic_policy_bundle
+from xsdata_generation_lock import locked_xsdata_generation
 
 
 def build_canonical_schema(normalization_result: NormalizationResult):
@@ -119,18 +120,19 @@ def test_json_schema_pipeline_written_output_is_deterministic(
 def test_json_schema_generator_cli_writes_output(tmp_path: Path):
     output_path = tmp_path / "open_cvn.schema.json"
 
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "cvn_codegen.json_schema_generator",
-            "--output-path",
-            str(output_path),
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    with locked_xsdata_generation():
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "cvn_codegen.json_schema_generator",
+                "--output-path",
+                str(output_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
 
     assert "Generated JSON Schema" in result.stdout
     assert output_path.exists()

--- a/tests/test_open_cvn_app_cli_unit.py
+++ b/tests/test_open_cvn_app_cli_unit.py
@@ -26,15 +26,16 @@ def test_cli_version_command_outputs_project_version(capsys: pytest.CaptureFixtu
     assert capsys.readouterr().out.strip() == f"open-cvn {__version__}"
 
 
-def test_store_init_routes_to_issue_62_placeholder(capsys: pytest.CaptureFixture[str], tmp_path):
+def test_store_init_creates_local_store(capsys: pytest.CaptureFixture[str], tmp_path):
     store_path = tmp_path / "open-cvn.sqlite"
 
     exit_code = run(["store", "init", "--path", str(store_path)])
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert "Store initialization is planned for issue #62" in output
+    assert "Initialized Open CVN store" in output
     assert str(store_path) in output
+    assert store_path.exists()
 
 
 def test_json_import_routes_to_issue_64_placeholder(capsys: pytest.CaptureFixture[str]):

--- a/tests/test_open_cvn_app_storage_unit.py
+++ b/tests/test_open_cvn_app_storage_unit.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from open_cvn.parser_contract import CvnErrorCode, CvnIssueSeverity, CvnParseIssue
+from open_cvn_app.storage import (
+    SCHEMA_VERSION,
+    CurriculumCreate,
+    CurriculumNotFound,
+    CurriculumRepository,
+    CurriculumUpdate,
+    InvalidCurriculumDocument,
+    initialize_store,
+)
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "open_cvn"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_initialize_store_creates_schema_and_metadata(tmp_path: Path):
+    store_path = tmp_path / "nested" / "open-cvn.sqlite"
+
+    store_info = initialize_store(store_path)
+
+    assert store_info.path == store_path
+    assert store_info.schema_version == SCHEMA_VERSION
+    assert store_path.exists()
+
+    with sqlite3.connect(store_path) as connection:
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        schema_version = connection.execute(
+            "SELECT value FROM app_metadata WHERE key = 'schema_version'"
+        ).fetchone()[0]
+
+    assert {"app_metadata", "curricula", "curriculum_diagnostics"} <= tables
+    assert schema_version == SCHEMA_VERSION
+
+
+def test_initialize_store_is_idempotent(tmp_path: Path):
+    store_path = tmp_path / "open-cvn.sqlite"
+
+    first = initialize_store(store_path)
+    second = initialize_store(store_path)
+
+    assert first == second
+
+
+def test_repository_creates_reads_lists_updates_and_deletes_curriculum(tmp_path: Path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    document = _load_fixture("valid_minimal.json")
+
+    created = repository.create_curriculum(
+        CurriculumCreate(
+            display_name="Master CV",
+            document=document,
+            source_identifier="valid_minimal.json",
+        )
+    )
+
+    fetched = repository.get_curriculum(created.id)
+    listed = repository.list_curricula()
+    updated = repository.update_curriculum(created.id, CurriculumUpdate(display_name="Updated CV"))
+
+    assert fetched == created
+    assert listed == (created,)
+    assert updated.display_name == "Updated CV"
+    assert updated.updated_at >= created.updated_at
+    assert updated.schema_version == "0.1.0"
+    assert updated.policy_name == "default_cvn_semantic_policy"
+    assert updated.policy_version == "0.1.0"
+    assert updated.source_format == "open_cvn_json"
+    assert updated.source_identifier == "valid_minimal.json"
+    assert updated.validation_status == "valid"
+
+    repository.delete_curriculum(created.id)
+
+    assert repository.list_curricula() == ()
+    with pytest.raises(CurriculumNotFound):
+        repository.get_curriculum(created.id)
+
+
+def test_repository_round_trips_open_cvn_document_semantics(tmp_path: Path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    document = _load_fixture("valid_minimal.json")
+
+    created = repository.create_curriculum(CurriculumCreate(display_name="Master CV", document=document))
+
+    assert created.document == document
+
+
+def test_repository_rejects_invalid_open_cvn_document(tmp_path: Path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    document = _load_fixture("wrong_shape.json")
+
+    with pytest.raises(InvalidCurriculumDocument):
+        repository.create_curriculum(CurriculumCreate(display_name="Broken CV", document=document))
+
+    assert repository.list_curricula() == ()
+
+
+def test_repository_replaces_payload_and_diagnostics(tmp_path: Path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    document = _load_fixture("valid_minimal.json")
+    first_issue = CvnParseIssue(
+        code=CvnErrorCode.PYDANTIC_VALIDATION_FAILURE,
+        severity=CvnIssueSeverity.WARNING,
+        message="First diagnostic.",
+        source_location="line 1 column 1",
+        path=("metadata", "policy"),
+        details={"field": "policy"},
+    )
+    second_issue = CvnParseIssue(
+        code=CvnErrorCode.JSON_SCHEMA_VALIDATION_FAILURE,
+        severity=CvnIssueSeverity.WARNING,
+        message="Second diagnostic.",
+        path=("schema_version",),
+        details={"field": "schema_version"},
+    )
+
+    created = repository.create_curriculum(
+        CurriculumCreate(display_name="Master CV", document=document, diagnostics=(first_issue,))
+    )
+    initial_diagnostics = repository.list_diagnostics(created.id)
+    replaced = repository.replace_curriculum_payload(
+        created.id,
+        document,
+        source_identifier="replacement.json",
+        diagnostics=(second_issue,),
+    )
+    replaced_diagnostics = repository.list_diagnostics(created.id)
+
+    assert replaced.source_identifier == "replacement.json"
+    assert len(initial_diagnostics) == 1
+    assert initial_diagnostics[0].message == "First diagnostic."
+    assert initial_diagnostics[0].path == ("metadata", "policy")
+    assert initial_diagnostics[0].details == {"field": "policy"}
+    assert len(replaced_diagnostics) == 1
+    assert replaced_diagnostics[0].message == "Second diagnostic."
+    assert replaced_diagnostics[0].path == ("schema_version",)
+
+
+def test_repository_raises_for_missing_curriculum_operations(tmp_path: Path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    document = _load_fixture("valid_minimal.json")
+
+    with pytest.raises(CurriculumNotFound):
+        repository.update_curriculum("missing", CurriculumUpdate(display_name="Missing"))
+    with pytest.raises(CurriculumNotFound):
+        repository.replace_curriculum_payload("missing", document)
+    with pytest.raises(CurriculumNotFound):
+        repository.delete_curriculum("missing")
+    with pytest.raises(CurriculumNotFound):
+        repository.list_diagnostics("missing")


### PR DESCRIPTION
## Summary
- Add local SQLite storage module for Open CVN curriculum documents.
- Make `open-cvn store init` create real schema-versioned stores.
- Add repository tests for CRUD, validation, payload round-trip, and diagnostics.
- Stabilize JSON Schema CLI test under xdist with existing generation lock.
## Verification
- `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py -v`
- `uv run pytest -n auto tests/test_open_cvn_app_cli_unit.py -v`
- `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`
- `uv run pytest -n auto tests`
Closes #62