### PR TITLE
Add master and derived curriculum versioning PR Body

### DIFF
--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -801,6 +801,59 @@
   - result: `386 passed in 371.09s (0:06:11)`
 - no new durable limitations were found
 
+### Issue `#63`
+
+- the master and derived curriculum versioning issue is implemented under:
+  - `src/open_cvn_app/storage.py`
+  - `src/open_cvn_app/cli.py`
+- the local store schema version is now `2`
+- schema version `1` stores from issue `#62` migrate additively to schema version
+  `2` without losing existing curricula or diagnostics
+- the implemented versioning table is:
+  - `curriculum_versions`
+- versioning repository operations are exposed through `CurriculumRepository` for:
+  - master assignment
+  - master lookup
+  - version lookup
+  - version listing
+  - derived version creation
+  - include selection edits
+  - exclude selection edits
+  - materialized version generation
+- derived selections use deterministic JSON with `include_all` and `include_only`
+  modes plus JSON Pointer-style paths under `/curriculum`
+- materialized versions are validated through `validate_open_cvn_json(...)` before
+  being returned
+- materialized version metadata is recorded under
+  `extensions["x-open-cvn.versioning"]`
+- issue `#63` replaces versioning CLI placeholders with functional commands:
+  - `open-cvn versions list [--store PATH]`
+  - `open-cvn versions master CURRICULUM_ID [--store PATH]`
+  - `open-cvn versions show NAME [--store PATH]`
+  - `open-cvn versions derive NAME [--from SOURCE] [--store PATH]`
+  - `open-cvn versions include NAME POINTER [--store PATH]`
+  - `open-cvn versions exclude NAME POINTER [--store PATH]`
+- JSON import/export, LaTeX, and PDF command groups remain scoped to later issues
+- versioning tests are implemented in:
+  - `tests/test_open_cvn_app_versioning_unit.py`
+- CLI versioning coverage was added to:
+  - `tests/test_open_cvn_app_cli_unit.py`
+- targeted versioning verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_versioning_unit.py -v`
+  - result: `11 passed in 34.52s`
+- targeted storage and CLI verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `18 passed in 32.47s`
+- targeted parser regression verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`
+  - result: `22 passed in 34.91s`
+- console-script versioning smoke verification passed with:
+  - `uv run open-cvn store init --path /tmp/opencode/open-cvn-issue-63-smoke.sqlite && uv run open-cvn versions list --store /tmp/opencode/open-cvn-issue-63-smoke.sqlite`
+- full-suite verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `399 passed in 431.30s (0:07:11)`
+- no new durable limitations were found
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -812,8 +865,8 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#62`: issue `#63` master and derived curriculum
-  versions
+- Next work item after issue `#63`: issue `#64` Open CVN JSON import/export
+  workflow
 - Epic `#60` has been expanded into issues `#61` through `#69`
 - MVP direction:
   - CLI-first local prototype
@@ -825,7 +878,7 @@
   - optional PDF generation and preview handoff
   - application MVP tests and user documentation
   - post-MVP LLM-assisted import spike
-- Next implementation issue: `#63` master and derived curriculum versions
+- Next implementation issue: `#64` Open CVN JSON import/export workflow
 
 ## Blocking Or Relevant Limitations
 

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -30,12 +30,13 @@ Agents should also read `AGENTS.md` before this file.
 - Project: open CVN schema and tooling for Spanish academic CV processing
 - Current pipeline stage: structural generation, metadata normalization,
   semantic policy, domain generation, conceptual schema, Open CVN JSON format,
-  parser/validator contract, CLI shell, and local SQLite storage completed
+  parser/validator contract, CLI shell, local SQLite storage, and master/derived
+  curriculum versioning completed
 - Last documented issues: `#11`, `#12`, `#13`, `#14`, `#15`, `#16`, `#17`,
   `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, `#47`, `#48`, `#49`, `#50`,
-  `#61`, and `#62`
+  `#61`, `#62`, and `#63`
 - Latest documented hotfix records: `#3`, `#4`, `#5`, `#6`, `#7`, `#8`
-- Next planned issue: `#63`
+- Next planned issue: `#64`
 - Canonical source package: `docs/CvnXML_v1.4.3_2.1_17012025/`
 
 ## Documentation Map

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -48,7 +48,7 @@ Goal:
 | `#60` | Epic: CV management application | Planned | MVP application roadmap for local storage, master/derived versions, JSON import/export, LaTeX/PDF export, and post-MVP LLM spike expanded |
 | `#61` | Application MVP scope and CLI shell | Completed | CLI-first prototype shell, command surface, console script, placeholders, and smoke tests implemented |
 | `#62` | Local storage with SQLite | Completed | SQLite store initialization, schema metadata, curriculum repository, diagnostics, CLI store init, and tests implemented |
-| `#63` | Master and derived curriculum versions | Planned | Master curriculum plus target-specific derived CV versions |
+| `#63` | Master and derived curriculum versions | Completed | Schema v2 migration, master/derived repository operations, selection materialization, CLI commands, and tests implemented |
 | `#64` | Open CVN JSON import/export workflow | Planned | Application import/export using epic `#41` parser and validator |
 | `#65` | Curriculum editing and selection MVP | Planned | Basic include/exclude customization for derived versions |
 | `#66` | LaTeX export from Open CVN | Planned | Jinja-style LaTeX rendering from stored Open CVN data |

--- a/docs/roadmap/issues/issue-63-master-and-derived-curriculum-versions.md
+++ b/docs/roadmap/issues/issue-63-master-and-derived-curriculum-versions.md
@@ -48,6 +48,324 @@ overrides are implemented, they must be explicit and auditable.
 7. add tests for master, derived, clone, include, exclude, and export behavior
 8. document the MVP versioning model and known limits
 
+## Detailed Execution Plan
+
+This plan is the accepted execution plan for implementing issue `#63`.
+During execution, each work update must identify the active task and, when
+applicable, the active subtask. Each task or subtask update should include:
+
+- initial summary of the task or subtask goal
+- current task and subtask identifier
+- whether the user must modify any file manually
+- next step to follow
+
+Unless explicitly requested otherwise, code edits are expected to be performed by
+the user. Documentation edits may be applied when the user asks to establish or
+update the issue plan.
+
+### Task 1 - Confirm Scope And Constraints
+
+- Subtask 1.1: confirm issue `#63` is limited to master and derived curriculum
+  versioning.
+- Subtask 1.2: confirm Open CVN JSON import and export remain planned for issue
+  `#64`.
+- Subtask 1.3: confirm LaTeX and PDF behavior remain planned for issues `#66`
+  and `#67`.
+- Subtask 1.4: confirm fine-grained editing remains planned for issue `#65`.
+- Subtask 1.5: confirm `src/generated/` remains untouched.
+- Subtask 1.6: confirm the MVP stores one master curriculum version per local
+  SQLite store.
+
+Expected output: final implementation boundary for issue `#63` before code work.
+
+### Task 2 - Define Versioning Data Model
+
+- Subtask 2.1: add a `curriculum_versions` SQLite table.
+- Subtask 2.2: store version identifiers, names, kind, master curriculum link,
+  optional source version link, selection JSON, and timestamps.
+- Subtask 2.3: support version kinds `master` and `derived`.
+- Subtask 2.4: enforce unique version names.
+- Subtask 2.5: enforce at most one master version per store, preferably through a
+  partial unique index when supported by SQLite.
+- Subtask 2.6: link `master_curriculum_id` to `curricula(id)`.
+- Subtask 2.7: link `source_version_id` to `curriculum_versions(id)` for cloned
+  or derived versions.
+- Subtask 2.8: create indexes for name, kind, updated timestamp, and master
+  curriculum lookup.
+
+Expected output: stable SQLite versioning model layered over the issue `#62`
+curriculum storage table.
+
+### Task 3 - Define Derived Selection Contract
+
+- Subtask 3.1: define application-level versioning records such as
+  `CurriculumVersionCreate`, `CurriculumVersionRecord`, `DerivedSelection`,
+  `SelectionRule`, and `MaterializedVersion` where needed.
+- Subtask 3.2: use JSON Pointer syntax from RFC 6901 for section and entry
+  selection paths.
+- Subtask 3.3: define the MVP selection modes `include_all` and `include_only`.
+- Subtask 3.4: represent selection data as deterministic JSON with
+  `included_pointers` and `excluded_pointers` arrays.
+- Subtask 3.5: support section pointers such as `/curriculum/education`.
+- Subtask 3.6: support entry pointers such as `/curriculum/research/0`.
+- Subtask 3.7: validate pointer syntax before storing selection changes.
+- Subtask 3.8: validate that pointers resolve against the master document when
+  materializing a version or updating selection.
+
+Expected output: auditable selection model without Git-like history or implicit
+field overrides.
+
+### Task 4 - Migrate SQLite Schema
+
+- Subtask 4.1: update the application storage schema version from `1` to `2`.
+- Subtask 4.2: implement an additive migration from schema version `1` to schema
+  version `2`.
+- Subtask 4.3: keep initialization idempotent for fresh schema version `2`
+  stores.
+- Subtask 4.4: keep existing future-schema rejection behavior for unsupported
+  schema versions newer than the application.
+- Subtask 4.5: preserve existing `curricula` and `curriculum_diagnostics` records
+  during migration.
+- Subtask 4.6: test migration from an issue `#62`-style schema version `1` store.
+
+Expected output: existing local stores can receive versioning support without data
+loss.
+
+### Task 5 - Implement Version Repository Operations
+
+- Subtask 5.1: extend `CurriculumRepository` or introduce a small versioning
+  repository in `src/open_cvn_app/storage.py`.
+- Subtask 5.2: define versioning errors such as `CurriculumVersionNotFound`,
+  `MasterCurriculumNotFound`, `DuplicateCurriculumVersionName`, and
+  `InvalidSelectionRule`.
+- Subtask 5.3: implement master assignment from an existing stored curriculum.
+- Subtask 5.4: reject master assignment when the referenced curriculum does not
+  exist.
+- Subtask 5.5: enforce one master version per store and fail clearly on
+  duplicates unless an explicit replacement operation is later introduced.
+- Subtask 5.6: implement master lookup.
+- Subtask 5.7: implement version lookup by ID or name.
+- Subtask 5.8: implement version listing with deterministic ordering.
+- Subtask 5.9: implement derived version creation from master by default.
+- Subtask 5.10: implement derived version cloning from another derived version by
+  copying its selection state.
+- Subtask 5.11: wrap version writes in transactions and update timestamps.
+
+Expected output: repository-level API for creating and listing master and derived
+curriculum versions.
+
+### Task 6 - Implement Derived Materialization
+
+- Subtask 6.1: implement materialization of a named or identified version into an
+  Open CVN JSON document.
+- Subtask 6.2: return the master curriculum payload unchanged for the master
+  version, except for any versioning metadata explicitly added to the materialized
+  copy.
+- Subtask 6.3: load the master curriculum payload for derived versions.
+- Subtask 6.4: apply `include_all` selection by removing excluded pointers from a
+  deep copy of the master payload.
+- Subtask 6.5: apply `include_only` selection by building a canonical Open CVN
+  document from included pointers.
+- Subtask 6.6: preserve canonical root fields `schema_version`, `metadata`,
+  `curriculum`, and `extensions`.
+- Subtask 6.7: record versioning metadata under a namespaced extension such as
+  `extensions["x-open-cvn.versioning"]`.
+- Subtask 6.8: preserve existing entry-level and field-level trace metadata.
+- Subtask 6.9: validate materialized Open CVN JSON through
+  `validate_open_cvn_json(...)`.
+- Subtask 6.10: fail clearly when selection rules produce an invalid Open CVN JSON
+  document.
+
+Expected output: derived versions can produce export-ready Open CVN JSON payloads
+for later issue `#64`.
+
+### Task 7 - Implement Include And Exclude Selection Edits
+
+- Subtask 7.1: implement exclusion of a JSON Pointer from a derived version.
+- Subtask 7.2: implement inclusion of a JSON Pointer in a derived version.
+- Subtask 7.3: reject selection edits against the master version.
+- Subtask 7.4: reject selection edits for missing versions.
+- Subtask 7.5: reject selection pointers that do not resolve against the master
+  payload.
+- Subtask 7.6: avoid duplicate pointers in stored selection arrays.
+- Subtask 7.7: update derived version `updated_at` after selection edits.
+- Subtask 7.8: keep serialized selection JSON deterministic.
+
+Expected output: MVP include/exclude behavior for sections and entries without
+mutating master curriculum data.
+
+### Task 8 - Wire Versioning Into CLI
+
+- Subtask 8.1: replace the issue `#63` placeholder behavior for
+  `open-cvn versions list`.
+- Subtask 8.2: replace the issue `#63` placeholder behavior for
+  `open-cvn versions derive NAME [--from SOURCE]`.
+- Subtask 8.3: add a command for assigning a stored curriculum as master, such as
+  `open-cvn versions master CURRICULUM_ID [--store PATH]`.
+- Subtask 8.4: add a command for showing a version, such as
+  `open-cvn versions show NAME [--store PATH]`, if useful for testable CLI
+  behavior.
+- Subtask 8.5: add commands for selection edits, such as
+  `open-cvn versions exclude NAME POINTER [--store PATH]` and
+  `open-cvn versions include NAME POINTER [--store PATH]`.
+- Subtask 8.6: format version listing output with name, kind, ID, source, and
+  timestamps.
+- Subtask 8.7: convert storage and versioning errors into `AppResult.failed(...)`.
+- Subtask 8.8: keep JSON import/export, LaTeX, and PDF commands scoped to their
+  later issues.
+
+Expected output: CLI can create and manage master and derived version records.
+
+### Task 9 - Add Versioning Unit Tests
+
+- Subtask 9.1: create `tests/test_open_cvn_app_versioning_unit.py`.
+- Subtask 9.2: test master assignment from an existing curriculum.
+- Subtask 9.3: test single-master enforcement.
+- Subtask 9.4: test version listing includes the master version.
+- Subtask 9.5: test derived version creation from master.
+- Subtask 9.6: test derived version cloning from another derived version.
+- Subtask 9.7: test duplicate version names are rejected.
+- Subtask 9.8: test missing master and missing source version behavior.
+- Subtask 9.9: test section exclusion removes selected data from materialized
+  output.
+- Subtask 9.10: test entry exclusion removes only the selected entry.
+- Subtask 9.11: test selection edits do not mutate the stored master payload.
+- Subtask 9.12: test materialized JSON validates through the public Open CVN
+  validator.
+- Subtask 9.13: test trace metadata survives materialization.
+- Subtask 9.14: test schema version `1` stores migrate to schema version `2`.
+
+Expected output: temporary SQLite tests prove master, derived, clone, include,
+exclude, migration, and materialization behavior.
+
+### Task 10 - Update CLI Tests
+
+- Subtask 10.1: update the existing `versions list` CLI test that currently
+  expects placeholder behavior.
+- Subtask 10.2: update the existing `versions derive` CLI test that currently
+  expects placeholder behavior.
+- Subtask 10.3: test `versions list` against an initialized store.
+- Subtask 10.4: test master assignment command.
+- Subtask 10.5: test derived version creation command.
+- Subtask 10.6: test include and exclude command behavior if those commands are
+  added.
+- Subtask 10.7: test errors for uninitialized store, missing master, and duplicate
+  names.
+- Subtask 10.8: keep JSON, LaTeX, and PDF placeholder tests unchanged.
+
+Expected output: CLI tests reflect real issue `#63` versioning behavior.
+
+### Task 11 - Prepare Or Extend Test Fixtures
+
+- Subtask 11.1: reuse `tests/fixtures/open_cvn/valid_minimal.json` where enough.
+- Subtask 11.2: add a richer Open CVN JSON fixture only if section or entry
+  selection cannot be tested clearly with the existing fixture.
+- Subtask 11.3: include stable entry `id` values in any new repeated-section
+  fixture where useful.
+- Subtask 11.4: keep fixtures deterministic and ASCII unless existing fixture
+  content requires otherwise.
+
+Expected output: representative test data for section and entry selection without
+overbuilding fixtures.
+
+### Task 12 - Run Issue Verification
+
+- Subtask 12.1: run targeted versioning tests:
+  `uv run pytest -n auto tests/test_open_cvn_app_versioning_unit.py -v`.
+- Subtask 12.2: run storage and CLI tests:
+  `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_cli_unit.py -v`.
+- Subtask 12.3: run parser integration regressions:
+  `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`.
+- Subtask 12.4: run a console-script smoke check for the implemented versioning
+  commands.
+- Subtask 12.5: run full repository verification:
+  `uv run pytest -n auto tests`.
+- Subtask 12.6: record any skipped or failed verification with reason.
+
+Expected output: issue `#63` verification evidence.
+
+### Task 13 - Update Persistent Documentation
+
+- Subtask 13.1: update this issue document with actual implementation artifacts,
+  deviations, verification, and status.
+- Subtask 13.2: update `docs/context/current_status.md` so issue `#63` is recorded
+  accurately and issue `#64` becomes the next implementation issue if `#63` is
+  completed.
+- Subtask 13.3: update `docs/roadmap/cvn_generation_roadmap.md` if it tracks issue
+  `#63` status.
+- Subtask 13.4: update `docs/pipeline/known_limitations.md` only if a new durable
+  limitation is found.
+- Subtask 13.5: update `PROJECT_GUIDE.md` only if repository orientation,
+  contributor reading order, or the documentation map changes.
+
+Expected output: repository context remains resumable after issue completion.
+
+## Planned Versioning SQLite Shape
+
+The issue should add a small versioning layer over the existing issue `#62`
+storage schema:
+
+```text
+curriculum_versions
+- id
+- name
+- kind
+- master_curriculum_id
+- source_version_id
+- selection_json
+- created_at
+- updated_at
+```
+
+Planned indexes and constraints:
+
+- unique version name
+- at most one master version per store
+- lookup by kind
+- lookup by updated timestamp
+- lookup by master curriculum ID
+
+The exact SQL names may change during implementation if a smaller or clearer
+schema is found. Any deviation must be recorded in this issue document.
+
+## Planned Selection JSON Shape
+
+The preferred MVP selection model is selection-based derivation. A derived
+version should store deterministic JSON similar to:
+
+```json
+{
+  "mode": "include_all",
+  "included_pointers": [],
+  "excluded_pointers": []
+}
+```
+
+Selection pointers should use JSON Pointer syntax from RFC 6901 and target the
+Open CVN JSON document, especially `curriculum` sections and repeated entries.
+The implementation should not introduce implicit field overrides in issue `#63`.
+If overrides become necessary, they must be explicit, auditable, and documented as
+a deviation from the preferred MVP selection approach.
+
+## Definition Of Done
+
+- Local store schema supports master and derived curriculum versions.
+- Existing issue `#62` schema version `1` stores can migrate to the issue `#63`
+  schema without data loss.
+- One master version can be assigned from an existing stored curriculum.
+- Multiple derived versions can reference the master curriculum.
+- Derived versions can be cloned from master or another derived version.
+- Include and exclude selection rules can be stored and updated for derived
+  versions.
+- Materialized derived Open CVN JSON contains selected data only.
+- Master curriculum data remains unchanged after derived selection edits.
+- Existing trace metadata is preserved where selected data is retained.
+- CLI version commands are functional and deterministic.
+- Tests cover master, derived, clone, include, exclude, migration, and
+  materialization behavior.
+- Full repository verification passes or a documented reason is recorded.
+- Persistent documentation is updated in the same session as the implementation.
+
 ## Expected Output
 
 - versioning service or repository module
@@ -62,11 +380,145 @@ overrides are implemented, they must be explicit and auditable.
 - master data remains unchanged after derived selection edits
 - full repository verification passes or a reason is documented
 
+## Implementation Notes
+
+- The versioning implementation extends the existing local storage module at:
+  - `src/open_cvn_app/storage.py`
+- The application storage schema version is now `2`.
+- Existing schema version `1` stores from issue `#62` are migrated additively to
+  schema version `2`.
+- The implementation uses Python standard-library `sqlite3`; no new database
+  dependency was added.
+- Version records are represented by dataclasses including:
+  - `DerivedSelection`
+  - `CurriculumVersionRecord`
+  - `MaterializedVersion`
+- Versioning errors are represented through explicit exception types including:
+  - `CurriculumVersionNotFound`
+  - `MasterCurriculumNotFound`
+  - `DuplicateCurriculumVersionName`
+  - `InvalidSelectionRule`
+- Repository operations are exposed through `CurriculumRepository` and cover:
+  - `assign_master_curriculum(...)`
+  - `get_master_version(...)`
+  - `get_version(...)`
+  - `list_versions(...)`
+  - `create_derived_version(...)`
+  - `include_in_version(...)`
+  - `exclude_from_version(...)`
+  - `materialize_version(...)`
+- Selection rules use JSON Pointer-style paths under `/curriculum` for sections
+  and entries.
+- Selection pointers intentionally reject metadata/root edits in issue `#63` so
+  derived versions cannot accidentally invalidate non-curriculum document
+  metadata.
+- Materialized versions are validated through `validate_open_cvn_json(...)` before
+  being returned.
+- Materialization records version metadata under
+  `extensions["x-open-cvn.versioning"]`.
+- `src/generated/` was not modified.
+
+## Implemented SQLite Shape
+
+```text
+curriculum_versions
+- id
+- name
+- kind
+- master_curriculum_id
+- source_version_id
+- selection_json
+- created_at
+- updated_at
+```
+
+Implemented constraints and indexes:
+
+- unique `name`
+- `kind` check constrained to `master` or `derived`
+- partial unique index `idx_curriculum_versions_single_master` for one master
+  version per store
+- `idx_curriculum_versions_name`
+- `idx_curriculum_versions_kind`
+- `idx_curriculum_versions_updated_at`
+- `idx_curriculum_versions_master_curriculum_id`
+
+## Implemented CLI Behavior
+
+Issue `#63` replaces the previous versioning placeholders with functional
+commands:
+
+```text
+open-cvn versions list [--store PATH]
+open-cvn versions master CURRICULUM_ID [--store PATH]
+open-cvn versions show NAME [--store PATH]
+open-cvn versions derive NAME [--from SOURCE] [--store PATH]
+open-cvn versions include NAME POINTER [--store PATH]
+open-cvn versions exclude NAME POINTER [--store PATH]
+```
+
+The JSON import/export, LaTeX, and PDF command groups remain scoped to later
+issues.
+
+## Tests Added Or Updated
+
+- Added `tests/test_open_cvn_app_versioning_unit.py`.
+- Updated `tests/test_open_cvn_app_cli_unit.py` so versioning commands expect real
+  behavior instead of issue `#63` placeholders.
+
+The versioning tests cover:
+
+- master assignment from an existing stored curriculum
+- single-master enforcement
+- derived version creation from master
+- derived version cloning from another derived version
+- duplicate version name rejection
+- missing master behavior
+- section exclusion materialization
+- entry exclusion materialization
+- master immutability after derived selection edits
+- trace metadata preservation
+- invalid selection pointer rejection
+- schema version `1` to schema version `2` migration
+
+## Verification Performed
+
+- `uv run pytest -n auto tests/test_open_cvn_app_versioning_unit.py -v`
+  - result: `11 passed in 34.52s`
+- `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `18 passed in 32.47s`
+- `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`
+  - result: `22 passed in 34.91s`
+- `uv run open-cvn store init --path /tmp/opencode/open-cvn-issue-63-smoke.sqlite && uv run open-cvn versions list --store /tmp/opencode/open-cvn-issue-63-smoke.sqlite`
+  - result: command initialized schema version `2` store and listed no versions
+    successfully
+- `uv run pytest -n auto tests`
+  - result: `399 passed in 431.30s (0:07:11)`
+
+## Deviations From Planned Scope
+
+- The issue implemented CLI include/exclude selection commands directly in issue
+  `#63` rather than deferring all selection editing to issue `#65`.
+- This was kept within the planned issue `#63` scope because the issue goal
+  explicitly included include/exclude behavior for derived versions.
+- Issue `#65` can now focus on richer editing and user-facing selection workflows
+  over the repository behavior implemented here.
+- When a full section is excluded, materialization removes the selected entries;
+  the Open CVN validator may normalize the section back to an empty list in the
+  returned document. This preserves selected-data semantics while keeping the
+  document valid.
+
+## New Limitations Found
+
+- No new durable limitations were found.
+
 ## Impact On Later Issues
 
-- issue `#65` adds editing or selection commands
+- issue `#64` can export materialized master or derived Open CVN JSON documents
+- issue `#65` can build richer editing and user-facing selection workflows on top
+  of the implemented repository selection behavior
 - issue `#66` exports selected derived versions to LaTeX
 
 ## Status
 
-- Status: planned
+- Status: completed

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-62-local-storage-sqlite-repository.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 62. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-63-master-and-derived-curriculum-versions.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 63. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-62-local-storage-sqlite-repository.md.
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-63-master-and-derived-curriculum-versions.md.
 
 
 

--- a/src/open_cvn_app/cli.py
+++ b/src/open_cvn_app/cli.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from open_cvn_app import __version__
 from open_cvn_app.config import OpenCvnAppConfig
 from open_cvn_app.results import AppResult
-from open_cvn_app.storage import SCHEMA_VERSION, StorageError, initialize_store
+from open_cvn_app.storage import SCHEMA_VERSION, CurriculumRepository, StorageError, initialize_store
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -49,6 +49,14 @@ def build_parser() -> argparse.ArgumentParser:
     versions_list_parser = versions_subparsers.add_parser("list", help="List curriculum versions.")
     _add_store_path_option(versions_list_parser)
     versions_list_parser.set_defaults(handler=_handle_versions_list)
+    versions_master_parser = versions_subparsers.add_parser("master", help="Assign master curriculum version.")
+    versions_master_parser.add_argument("curriculum_id", help="Stored curriculum ID to assign as master.")
+    _add_store_path_option(versions_master_parser)
+    versions_master_parser.set_defaults(handler=_handle_versions_master)
+    versions_show_parser = versions_subparsers.add_parser("show", help="Show curriculum version metadata.")
+    versions_show_parser.add_argument("name", help="Version name or ID.")
+    _add_store_path_option(versions_show_parser)
+    versions_show_parser.set_defaults(handler=_handle_versions_show)
     versions_derive_parser = versions_subparsers.add_parser(
         "derive",
         help="Create derived curriculum version.",
@@ -62,6 +70,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_store_path_option(versions_derive_parser)
     versions_derive_parser.set_defaults(handler=_handle_versions_derive)
+    versions_include_parser = versions_subparsers.add_parser("include", help="Include selection pointer in derived version.")
+    versions_include_parser.add_argument("name", help="Derived version name or ID.")
+    versions_include_parser.add_argument("pointer", help="JSON Pointer under /curriculum.")
+    _add_store_path_option(versions_include_parser)
+    versions_include_parser.set_defaults(handler=_handle_versions_include)
+    versions_exclude_parser = versions_subparsers.add_parser("exclude", help="Exclude selection pointer from derived version.")
+    versions_exclude_parser.add_argument("name", help="Derived version name or ID.")
+    versions_exclude_parser.add_argument("pointer", help="JSON Pointer under /curriculum.")
+    _add_store_path_option(versions_exclude_parser)
+    versions_exclude_parser.set_defaults(handler=_handle_versions_exclude)
 
     latex_parser = subparsers.add_parser("latex", help="Export curriculum to LaTeX.")
     latex_subparsers = latex_parser.add_subparsers(dest="latex_command")
@@ -148,11 +166,81 @@ def _handle_json_export(args: argparse.Namespace) -> AppResult:
 
 
 def _handle_versions_list(args: argparse.Namespace) -> AppResult:
-    return _planned_result("Version listing", "#63", args)
+    repository = _repository_from_args(args)
+    try:
+        versions = repository.list_versions()
+    except StorageError as exc:
+        return AppResult.failed("Version listing failed.", error=str(exc))
+    if not versions:
+        return AppResult.ok("No curriculum versions found.")
+    lines = ["Curriculum versions:"]
+    lines.extend(
+        f"- {version.name} ({version.kind}) id={version.id} "
+        f"master={version.master_curriculum_id} source={version.source_version_id or '-'} "
+        f"updated={version.updated_at}"
+        for version in versions
+    )
+    return AppResult.ok("\n".join(lines))
+
+
+def _handle_versions_master(args: argparse.Namespace) -> AppResult:
+    repository = _repository_from_args(args)
+    try:
+        version = repository.assign_master_curriculum(args.curriculum_id)
+    except StorageError as exc:
+        return AppResult.failed("Master version assignment failed.", error=str(exc))
+    return AppResult.ok(f"Assigned master curriculum version '{version.name}' with id {version.id}.")
+
+
+def _handle_versions_show(args: argparse.Namespace) -> AppResult:
+    repository = _repository_from_args(args)
+    try:
+        version = repository.get_version(args.name)
+    except StorageError as exc:
+        return AppResult.failed("Version lookup failed.", error=str(exc))
+    return AppResult.ok(
+        "\n".join(
+            (
+                f"Name: {version.name}",
+                f"ID: {version.id}",
+                f"Kind: {version.kind}",
+                f"Master curriculum ID: {version.master_curriculum_id}",
+                f"Source version ID: {version.source_version_id or '-'}",
+                f"Selection mode: {version.selection.mode}",
+                f"Included pointers: {', '.join(version.selection.included_pointers) or '-'}",
+                f"Excluded pointers: {', '.join(version.selection.excluded_pointers) or '-'}",
+                f"Created at: {version.created_at}",
+                f"Updated at: {version.updated_at}",
+            )
+        )
+    )
 
 
 def _handle_versions_derive(args: argparse.Namespace) -> AppResult:
-    return _planned_result("Derived version creation", "#63", args)
+    repository = _repository_from_args(args)
+    try:
+        version = repository.create_derived_version(args.name, source=args.source)
+    except StorageError as exc:
+        return AppResult.failed("Derived version creation failed.", error=str(exc))
+    return AppResult.ok(f"Created derived curriculum version '{version.name}' with id {version.id}.")
+
+
+def _handle_versions_include(args: argparse.Namespace) -> AppResult:
+    repository = _repository_from_args(args)
+    try:
+        version = repository.include_in_version(args.name, args.pointer)
+    except StorageError as exc:
+        return AppResult.failed("Version include failed.", error=str(exc))
+    return AppResult.ok(f"Included {args.pointer} in derived curriculum version '{version.name}'.")
+
+
+def _handle_versions_exclude(args: argparse.Namespace) -> AppResult:
+    repository = _repository_from_args(args)
+    try:
+        version = repository.exclude_from_version(args.name, args.pointer)
+    except StorageError as exc:
+        return AppResult.failed("Version exclude failed.", error=str(exc))
+    return AppResult.ok(f"Excluded {args.pointer} from derived curriculum version '{version.name}'.")
 
 
 def _handle_latex_export(args: argparse.Namespace) -> AppResult:
@@ -161,3 +249,8 @@ def _handle_latex_export(args: argparse.Namespace) -> AppResult:
 
 def _handle_pdf_generate(args: argparse.Namespace) -> AppResult:
     return _planned_result("PDF generation", "#67", args)
+
+
+def _repository_from_args(args: argparse.Namespace) -> CurriculumRepository:
+    config = _config_from_args(args)
+    return CurriculumRepository(config.store_path)

--- a/src/open_cvn_app/storage.py
+++ b/src/open_cvn_app/storage.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import sqlite3
 import uuid
+from collections.abc import MutableMapping
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -15,7 +17,7 @@ from open_cvn.parser_contract import (
 )
 
 
-SCHEMA_VERSION = "1"
+SCHEMA_VERSION = "2"
 
 
 class StorageError(RuntimeError):
@@ -36,6 +38,22 @@ class CurriculumNotFound(StorageError):
 
 class InvalidCurriculumDocument(StorageError):
     """Raised when an Open CVN document fails validation before storage."""
+
+
+class CurriculumVersionNotFound(StorageError):
+    """Raised when a curriculum version ID or name does not exist."""
+
+
+class MasterCurriculumNotFound(StorageError):
+    """Raised when a derived operation needs a master version that does not exist."""
+
+
+class DuplicateCurriculumVersionName(StorageError):
+    """Raised when a version name already exists in the local store."""
+
+
+class InvalidSelectionRule(StorageError):
+    """Raised when a derived-version selection rule is invalid."""
 
 
 @dataclass(frozen=True)
@@ -85,6 +103,32 @@ class CurriculumRecord:
     updated_at: str
 
 
+@dataclass(frozen=True)
+class DerivedSelection:
+    mode: str = "include_all"
+    included_pointers: tuple[str, ...] = ()
+    excluded_pointers: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CurriculumVersionRecord:
+    id: str
+    name: str
+    kind: str
+    master_curriculum_id: str
+    source_version_id: str | None
+    selection: DerivedSelection
+    created_at: str
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class MaterializedVersion:
+    version: CurriculumVersionRecord
+    document: Mapping[str, Any]
+    validation_status: str
+
+
 def initialize_store(path: str | Path) -> StoreInfo:
     store_path = _normalize_store_path(path)
     _ensure_parent_dir(store_path)
@@ -101,6 +145,8 @@ def initialize_store(path: str | Path) -> StoreInfo:
             raise IncompatibleStoreSchema(
                 f"Store schema version {current_version} is newer than supported {SCHEMA_VERSION}."
             )
+        elif _schema_version_number(current_version) < _schema_version_number(SCHEMA_VERSION):
+            _migrate_schema(connection, current_version)
         connection.commit()
     return StoreInfo(path=store_path, schema_version=SCHEMA_VERSION)
 
@@ -259,6 +305,182 @@ class CurriculumRepository:
             ).fetchall()
         return tuple(_row_to_diagnostic(row) for row in rows)
 
+    def assign_master_curriculum(self, curriculum_id: str, *, name: str = "master") -> CurriculumVersionRecord:
+        self.get_curriculum(curriculum_id)
+        selection = DerivedSelection()
+        version_id = str(uuid.uuid4())
+        now = _utc_now()
+        with self._connection() as connection:
+            existing_master = connection.execute(
+                "SELECT id FROM curriculum_versions WHERE kind = ?",
+                ("master",),
+            ).fetchone()
+            if existing_master is not None:
+                raise DuplicateCurriculumVersionName("A master curriculum version already exists.")
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO curriculum_versions(
+                        id,
+                        name,
+                        kind,
+                        master_curriculum_id,
+                        source_version_id,
+                        selection_json,
+                        created_at,
+                        updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        version_id,
+                        name,
+                        "master",
+                        curriculum_id,
+                        None,
+                        _selection_to_json(selection),
+                        now,
+                        now,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise DuplicateCurriculumVersionName(f"Curriculum version already exists: {name}") from exc
+            connection.commit()
+        return self.get_version(version_id)
+
+    def get_master_version(self) -> CurriculumVersionRecord:
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT * FROM curriculum_versions WHERE kind = ?",
+                ("master",),
+            ).fetchone()
+        if row is None:
+            raise MasterCurriculumNotFound("Master curriculum version has not been assigned.")
+        return _row_to_version(row)
+
+    def get_version(self, version: str) -> CurriculumVersionRecord:
+        with self._connection() as connection:
+            row = _fetch_version_row(connection, version)
+        if row is None:
+            raise CurriculumVersionNotFound(f"Curriculum version not found: {version}")
+        return _row_to_version(row)
+
+    def list_versions(self) -> tuple[CurriculumVersionRecord, ...]:
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM curriculum_versions
+                ORDER BY CASE kind WHEN 'master' THEN 0 ELSE 1 END,
+                         updated_at DESC,
+                         name ASC,
+                         id ASC
+                """
+            ).fetchall()
+        return tuple(_row_to_version(row) for row in rows)
+
+    def create_derived_version(self, name: str, *, source: str = "master") -> CurriculumVersionRecord:
+        with self._connection() as connection:
+            source_row = _fetch_version_row(connection, source)
+            if source_row is None:
+                if source == "master":
+                    raise MasterCurriculumNotFound("Master curriculum version has not been assigned.")
+                raise CurriculumVersionNotFound(f"Curriculum version not found: {source}")
+            source_version = _row_to_version(source_row)
+            version_id = str(uuid.uuid4())
+            now = _utc_now()
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO curriculum_versions(
+                        id,
+                        name,
+                        kind,
+                        master_curriculum_id,
+                        source_version_id,
+                        selection_json,
+                        created_at,
+                        updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        version_id,
+                        name,
+                        "derived",
+                        source_version.master_curriculum_id,
+                        source_version.id,
+                        _selection_to_json(source_version.selection),
+                        now,
+                        now,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise DuplicateCurriculumVersionName(f"Curriculum version already exists: {name}") from exc
+            connection.commit()
+        return self.get_version(version_id)
+
+    def include_in_version(self, version: str, pointer: str) -> CurriculumVersionRecord:
+        return self._update_selection(version, pointer, include=True)
+
+    def exclude_from_version(self, version: str, pointer: str) -> CurriculumVersionRecord:
+        return self._update_selection(version, pointer, include=False)
+
+    def materialize_version(self, version: str) -> MaterializedVersion:
+        version_record = self.get_version(version)
+        master = self.get_curriculum(version_record.master_curriculum_id)
+        document = deepcopy(master.document)
+
+        if version_record.kind == "derived":
+            _apply_selection(document, version_record.selection, master.document)
+
+        extensions = document.setdefault("extensions", {})
+        if not isinstance(extensions, MutableMapping):
+            raise InvalidSelectionRule("Open CVN extensions field must be an object for versioning metadata.")
+        extensions["x-open-cvn.versioning"] = {
+            "version_id": version_record.id,
+            "version_name": version_record.name,
+            "version_kind": version_record.kind,
+            "master_curriculum_id": version_record.master_curriculum_id,
+            "source_version_id": version_record.source_version_id,
+            "selection": _selection_to_data(version_record.selection),
+        }
+
+        validation_result = validate_open_cvn_json(document, source_identifier=f"version:{version_record.name}")
+        if validation_result.validation_status in {CvnValidationStatus.INVALID, CvnValidationStatus.FAILED}:
+            messages = "; ".join(issue.message for issue in validation_result.errors)
+            raise InvalidSelectionRule(messages or "Materialized Open CVN document is invalid.")
+        if validation_result.data is None:
+            raise InvalidSelectionRule("Materialized Open CVN validation did not return document data.")
+        return MaterializedVersion(
+            version=version_record,
+            document=validation_result.data,
+            validation_status=validation_result.validation_status.value,
+        )
+
+    def _update_selection(self, version: str, pointer: str, *, include: bool) -> CurriculumVersionRecord:
+        _validate_selection_pointer(pointer)
+        with self._connection() as connection:
+            row = _fetch_version_row(connection, version)
+            if row is None:
+                raise CurriculumVersionNotFound(f"Curriculum version not found: {version}")
+            version_record = _row_to_version(row)
+            if version_record.kind == "master":
+                raise InvalidSelectionRule("Master curriculum version selection cannot be edited.")
+            master_row = connection.execute(
+                "SELECT * FROM curricula WHERE id = ?",
+                (version_record.master_curriculum_id,),
+            ).fetchone()
+            if master_row is None:
+                raise CurriculumNotFound(f"Curriculum not found: {version_record.master_curriculum_id}")
+            master_document = _row_to_record(master_row).document
+            _resolve_json_pointer(master_document, pointer)
+            selection = _change_selection(version_record.selection, pointer, include=include)
+            now = _utc_now()
+            connection.execute(
+                "UPDATE curriculum_versions SET selection_json = ?, updated_at = ? WHERE id = ?",
+                (_selection_to_json(selection), now, version_record.id),
+            )
+            connection.commit()
+        return self.get_version(version_record.id)
+
     def _connection(self) -> sqlite3.Connection:
         connection = _connect(self.path)
         try:
@@ -381,6 +603,211 @@ def _row_to_diagnostic(row: sqlite3.Row) -> CurriculumDiagnostic:
     )
 
 
+def _row_to_version(row: sqlite3.Row) -> CurriculumVersionRecord:
+    return CurriculumVersionRecord(
+        id=row["id"],
+        name=row["name"],
+        kind=row["kind"],
+        master_curriculum_id=row["master_curriculum_id"],
+        source_version_id=row["source_version_id"],
+        selection=_selection_from_json(row["selection_json"]),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _fetch_version_row(connection: sqlite3.Connection, version: str) -> sqlite3.Row | None:
+    return connection.execute(
+        "SELECT * FROM curriculum_versions WHERE id = ? OR name = ?",
+        (version, version),
+    ).fetchone()
+
+
+def _selection_from_json(value: str) -> DerivedSelection:
+    data = json.loads(value)
+    selection = DerivedSelection(
+        mode=str(data.get("mode", "include_all")),
+        included_pointers=tuple(str(pointer) for pointer in data.get("included_pointers", ())),
+        excluded_pointers=tuple(str(pointer) for pointer in data.get("excluded_pointers", ())),
+    )
+    _validate_selection(selection)
+    return selection
+
+
+def _selection_to_json(selection: DerivedSelection) -> str:
+    _validate_selection(selection)
+    return json.dumps(_selection_to_data(selection), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _selection_to_data(selection: DerivedSelection) -> dict[str, Any]:
+    return {
+        "mode": selection.mode,
+        "included_pointers": list(selection.included_pointers),
+        "excluded_pointers": list(selection.excluded_pointers),
+    }
+
+
+def _validate_selection(selection: DerivedSelection) -> None:
+    if selection.mode not in {"include_all", "include_only"}:
+        raise InvalidSelectionRule(f"Unsupported selection mode: {selection.mode}")
+    for pointer in selection.included_pointers + selection.excluded_pointers:
+        _validate_selection_pointer(pointer)
+
+
+def _validate_selection_pointer(pointer: str) -> None:
+    if pointer == "/curriculum":
+        raise InvalidSelectionRule("Selection pointer must target a curriculum section or entry, not /curriculum.")
+    if not pointer.startswith("/curriculum/"):
+        raise InvalidSelectionRule(f"Selection pointer must target /curriculum: {pointer}")
+    for token in pointer.split("/")[1:]:
+        if "~" in token.replace("~0", "").replace("~1", ""):
+            raise InvalidSelectionRule(f"Invalid JSON Pointer escape sequence: {pointer}")
+
+
+def _change_selection(selection: DerivedSelection, pointer: str, *, include: bool) -> DerivedSelection:
+    included = list(selection.included_pointers)
+    excluded = list(selection.excluded_pointers)
+    if selection.mode == "include_all":
+        if include:
+            excluded = [item for item in excluded if item != pointer]
+        elif pointer not in excluded:
+            excluded.append(pointer)
+    else:
+        if include and pointer not in included:
+            included.append(pointer)
+        elif not include:
+            included = [item for item in included if item != pointer]
+    return DerivedSelection(
+        mode=selection.mode,
+        included_pointers=tuple(sorted(included)),
+        excluded_pointers=tuple(sorted(excluded)),
+    )
+
+
+def _apply_selection(document: MutableMapping[str, Any], selection: DerivedSelection, master_document: Mapping[str, Any]) -> None:
+    if selection.mode == "include_all":
+        for pointer in selection.excluded_pointers:
+            _remove_json_pointer(document, pointer)
+        return
+
+    empty_document = {
+        "schema_version": document["schema_version"],
+        "metadata": deepcopy(document["metadata"]),
+        "curriculum": {},
+    }
+    if "extensions" in document:
+        empty_document["extensions"] = deepcopy(document["extensions"])
+    for pointer in selection.included_pointers:
+        value = deepcopy(_resolve_json_pointer(master_document, pointer))
+        _set_json_pointer(empty_document, pointer, value)
+    document.clear()
+    document.update(empty_document)
+
+
+def _resolve_json_pointer(document: Mapping[str, Any] | list[Any], pointer: str) -> Any:
+    current: Any = document
+    for token in _json_pointer_tokens(pointer):
+        if isinstance(current, Mapping):
+            if token not in current:
+                raise InvalidSelectionRule(f"Selection pointer does not resolve: {pointer}")
+            current = current[token]
+        elif isinstance(current, list):
+            if not token.isdigit():
+                raise InvalidSelectionRule(f"Selection pointer list token is not an index: {pointer}")
+            index = int(token)
+            if index >= len(current):
+                raise InvalidSelectionRule(f"Selection pointer index is out of range: {pointer}")
+            current = current[index]
+        else:
+            raise InvalidSelectionRule(f"Selection pointer does not resolve: {pointer}")
+    return current
+
+
+def _remove_json_pointer(document: MutableMapping[str, Any] | list[Any], pointer: str) -> None:
+    tokens = _json_pointer_tokens(pointer)
+    if not tokens:
+        raise InvalidSelectionRule("Cannot remove the root document.")
+    parent = _resolve_json_pointer_tokens(document, tokens[:-1], pointer)
+    token = tokens[-1]
+    if isinstance(parent, MutableMapping):
+        if token not in parent:
+            raise InvalidSelectionRule(f"Selection pointer does not resolve: {pointer}")
+        del parent[token]
+        return
+    if isinstance(parent, list):
+        if not token.isdigit():
+            raise InvalidSelectionRule(f"Selection pointer list token is not an index: {pointer}")
+        index = int(token)
+        if index >= len(parent):
+            raise InvalidSelectionRule(f"Selection pointer index is out of range: {pointer}")
+        del parent[index]
+        return
+    raise InvalidSelectionRule(f"Selection pointer does not resolve: {pointer}")
+
+
+def _resolve_json_pointer_tokens(document: Mapping[str, Any] | list[Any], tokens: tuple[str, ...], pointer: str) -> Any:
+    current: Any = document
+    for token in tokens:
+        if isinstance(current, Mapping):
+            if token not in current:
+                raise InvalidSelectionRule(f"Selection pointer does not resolve: {pointer}")
+            current = current[token]
+        elif isinstance(current, list):
+            if not token.isdigit():
+                raise InvalidSelectionRule(f"Selection pointer list token is not an index: {pointer}")
+            index = int(token)
+            if index >= len(current):
+                raise InvalidSelectionRule(f"Selection pointer index is out of range: {pointer}")
+            current = current[index]
+        else:
+            raise InvalidSelectionRule(f"Selection pointer does not resolve: {pointer}")
+    return current
+
+
+def _set_json_pointer(document: MutableMapping[str, Any], pointer: str, value: Any) -> None:
+    tokens = _json_pointer_tokens(pointer)
+    if not tokens:
+        raise InvalidSelectionRule("Cannot replace the root document through selection.")
+    current: Any = document
+    for index, token in enumerate(tokens[:-1]):
+        next_token = tokens[index + 1]
+        if isinstance(current, MutableMapping):
+            if token not in current:
+                current[token] = [] if next_token.isdigit() else {}
+            current = current[token]
+        elif isinstance(current, list):
+            if not token.isdigit():
+                raise InvalidSelectionRule(f"Selection pointer list token is not an index: {pointer}")
+            item_index = int(token)
+            while len(current) <= item_index:
+                current.append([] if next_token.isdigit() else {})
+            current = current[item_index]
+        else:
+            raise InvalidSelectionRule(f"Selection pointer cannot be created: {pointer}")
+    final_token = tokens[-1]
+    if isinstance(current, MutableMapping):
+        current[final_token] = value
+        return
+    if isinstance(current, list):
+        if not final_token.isdigit():
+            raise InvalidSelectionRule(f"Selection pointer list token is not an index: {pointer}")
+        item_index = int(final_token)
+        while len(current) <= item_index:
+            current.append(None)
+        current[item_index] = value
+        return
+    raise InvalidSelectionRule(f"Selection pointer cannot be created: {pointer}")
+
+
+def _json_pointer_tokens(pointer: str) -> tuple[str, ...]:
+    _validate_selection_pointer(pointer)
+    return tuple(token.replace("~1", "/").replace("~0", "~") for token in pointer.split("/")[1:])
+
+
+def _escape_json_pointer_token(token: str) -> str:
+    return token.replace("~", "~0").replace("/", "~1")
+
+
 def _verify_initialized(connection: sqlite3.Connection) -> None:
     schema_version = _read_schema_version(connection)
     if schema_version is None:
@@ -389,6 +816,9 @@ def _verify_initialized(connection: sqlite3.Connection) -> None:
         raise IncompatibleStoreSchema(
             f"Store schema version {schema_version} is newer than supported {SCHEMA_VERSION}."
         )
+    if _schema_version_number(schema_version) < _schema_version_number(SCHEMA_VERSION):
+        _migrate_schema(connection, schema_version)
+        connection.commit()
 
 
 def _read_schema_version(connection: sqlite3.Connection) -> str | None:
@@ -411,6 +841,18 @@ def _schema_version_number(value: str) -> int:
         raise IncompatibleStoreSchema(f"Invalid store schema version: {value}") from exc
 
 
+def _migrate_schema(connection: sqlite3.Connection, current_version: str) -> None:
+    current_number = _schema_version_number(current_version)
+    if current_number == 1:
+        connection.executescript(_VERSIONING_SCHEMA_SQL)
+        connection.execute(
+            "UPDATE app_metadata SET value = ? WHERE key = ?",
+            (SCHEMA_VERSION, "schema_version"),
+        )
+        return
+    raise IncompatibleStoreSchema(f"Unsupported store schema migration from version {current_version}.")
+
+
 def _connect(path: Path) -> sqlite3.Connection:
     return sqlite3.connect(path)
 
@@ -430,6 +872,31 @@ def _ensure_parent_dir(path: Path) -> None:
 
 def _utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+_VERSIONING_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS curriculum_versions (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    kind TEXT NOT NULL CHECK (kind IN ('master', 'derived')),
+    master_curriculum_id TEXT NOT NULL,
+    source_version_id TEXT,
+    selection_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (master_curriculum_id) REFERENCES curricula(id) ON DELETE CASCADE,
+    FOREIGN KEY (source_version_id) REFERENCES curriculum_versions(id) ON DELETE SET NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_curriculum_versions_single_master
+    ON curriculum_versions(kind)
+    WHERE kind = 'master';
+CREATE INDEX IF NOT EXISTS idx_curriculum_versions_name ON curriculum_versions(name);
+CREATE INDEX IF NOT EXISTS idx_curriculum_versions_kind ON curriculum_versions(kind);
+CREATE INDEX IF NOT EXISTS idx_curriculum_versions_updated_at ON curriculum_versions(updated_at);
+CREATE INDEX IF NOT EXISTS idx_curriculum_versions_master_curriculum_id
+    ON curriculum_versions(master_curriculum_id);
+"""
 
 
 _SCHEMA_SQL = """
@@ -469,4 +936,4 @@ CREATE INDEX IF NOT EXISTS idx_curricula_display_name ON curricula(display_name)
 CREATE INDEX IF NOT EXISTS idx_curricula_updated_at ON curricula(updated_at);
 CREATE INDEX IF NOT EXISTS idx_curriculum_diagnostics_curriculum_id
     ON curriculum_diagnostics(curriculum_id);
-"""
+""" + _VERSIONING_SCHEMA_SQL

--- a/tests/test_open_cvn_app_cli_unit.py
+++ b/tests/test_open_cvn_app_cli_unit.py
@@ -1,9 +1,25 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from open_cvn_app import __version__
 from open_cvn_app.cli import build_parser, run
+from open_cvn_app.storage import CurriculumCreate, CurriculumRepository, initialize_store
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "open_cvn"
+
+
+def _create_store_with_curriculum(tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    document = json.loads((FIXTURES_DIR / "valid_minimal.json").read_text(encoding="utf-8"))
+    curriculum = repository.create_curriculum(CurriculumCreate(display_name="Master CV", document=document))
+    return store_path, curriculum
 
 
 def test_cli_help_contains_program_and_command_groups(capsys: pytest.CaptureFixture[str]):
@@ -54,20 +70,59 @@ def test_json_export_routes_to_issue_64_placeholder(capsys: pytest.CaptureFixtur
     assert "Open CVN JSON export is planned for issue #64" in output
 
 
-def test_versions_list_routes_to_issue_63_placeholder(capsys: pytest.CaptureFixture[str]):
-    exit_code = run(["versions", "list"])
+def test_versions_list_reads_initialized_store(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+
+    exit_code = run(["versions", "list", "--store", str(store_path)])
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert "Version listing is planned for issue #63" in output
+    assert "No curriculum versions found." in output
 
 
-def test_versions_derive_routes_to_issue_63_placeholder(capsys: pytest.CaptureFixture[str]):
-    exit_code = run(["versions", "derive", "public", "--from", "master"])
+def test_versions_master_and_derive_create_versions(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path, curriculum = _create_store_with_curriculum(tmp_path)
+
+    master_exit = run(["versions", "master", curriculum.id, "--store", str(store_path)])
+    derive_exit = run(["versions", "derive", "public", "--from", "master", "--store", str(store_path)])
+    list_exit = run(["versions", "list", "--store", str(store_path)])
 
     output = capsys.readouterr().out
-    assert exit_code == 0
-    assert "Derived version creation is planned for issue #63" in output
+    assert master_exit == 0
+    assert derive_exit == 0
+    assert list_exit == 0
+    assert "Assigned master curriculum version 'master'" in output
+    assert "Created derived curriculum version 'public'" in output
+    assert "master (master)" in output
+    assert "public (derived)" in output
+
+
+def test_versions_include_and_exclude_update_derived_selection(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path, curriculum = _create_store_with_curriculum(tmp_path)
+    run(["versions", "master", curriculum.id, "--store", str(store_path)])
+    run(["versions", "derive", "public", "--store", str(store_path)])
+
+    exclude_exit = run(["versions", "exclude", "public", "/curriculum/research", "--store", str(store_path)])
+    include_exit = run(["versions", "include", "public", "/curriculum/research", "--store", str(store_path)])
+
+    output = capsys.readouterr().out
+    assert exclude_exit == 0
+    assert include_exit == 0
+    assert "Excluded /curriculum/research" in output
+    assert "Included /curriculum/research" in output
+
+
+def test_versions_derive_reports_missing_master(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+
+    exit_code = run(["versions", "derive", "public", "--store", str(store_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Derived version creation failed." in captured.err
+    assert "Master curriculum version has not been assigned." in captured.err
 
 
 def test_latex_export_routes_to_issue_66_placeholder(capsys: pytest.CaptureFixture[str]):

--- a/tests/test_open_cvn_app_versioning_unit.py
+++ b/tests/test_open_cvn_app_versioning_unit.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from open_cvn_app.storage import (
+    SCHEMA_VERSION,
+    CurriculumCreate,
+    CurriculumRepository,
+    DuplicateCurriculumVersionName,
+    InvalidSelectionRule,
+    MasterCurriculumNotFound,
+    initialize_store,
+)
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "open_cvn"
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples" / "open_cvn"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+
+
+def _load_example(name: str) -> dict:
+    return json.loads((EXAMPLES_DIR / name).read_text(encoding="utf-8"))
+
+
+def _create_repository_with_curriculum(tmp_path: Path, document: dict | None = None):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    curriculum = repository.create_curriculum(
+        CurriculumCreate(display_name="Master CV", document=document or _load_fixture("valid_minimal.json"))
+    )
+    return repository, curriculum
+
+
+def _multi_entry_document() -> dict:
+    document = _load_example("research_entry.json")
+    document = deepcopy(document)
+    document["curriculum"]["research"].append(
+        {
+            "id": "research-002",
+            "type": "research.project",
+            "data": {"project_title": "Open CVN storage prototype"},
+            "trace": {"cvn_codes": ["050.020.010.000"], "confidence": "high"},
+        }
+    )
+    return document
+
+
+def test_assigns_master_curriculum_and_lists_versions(tmp_path: Path):
+    repository, curriculum = _create_repository_with_curriculum(tmp_path)
+
+    master = repository.assign_master_curriculum(curriculum.id)
+    versions = repository.list_versions()
+
+    assert master.name == "master"
+    assert master.kind == "master"
+    assert master.master_curriculum_id == curriculum.id
+    assert master.source_version_id is None
+    assert master.selection.mode == "include_all"
+    assert versions == (master,)
+
+
+def test_rejects_second_master_version(tmp_path: Path):
+    repository, curriculum = _create_repository_with_curriculum(tmp_path)
+    repository.assign_master_curriculum(curriculum.id)
+
+    with pytest.raises(DuplicateCurriculumVersionName):
+        repository.assign_master_curriculum(curriculum.id, name="another-master")
+
+
+def test_creates_derived_version_from_master(tmp_path: Path):
+    repository, curriculum = _create_repository_with_curriculum(tmp_path)
+    master = repository.assign_master_curriculum(curriculum.id)
+
+    derived = repository.create_derived_version("public")
+
+    assert derived.name == "public"
+    assert derived.kind == "derived"
+    assert derived.master_curriculum_id == curriculum.id
+    assert derived.source_version_id == master.id
+    assert derived.selection.mode == "include_all"
+
+
+def test_clones_derived_version_selection(tmp_path: Path):
+    repository, curriculum = _create_repository_with_curriculum(tmp_path, _multi_entry_document())
+    repository.assign_master_curriculum(curriculum.id)
+    public = repository.create_derived_version("public")
+    repository.exclude_from_version(public.name, "/curriculum/research/0")
+
+    cloned = repository.create_derived_version("short", source="public")
+
+
+    assert cloned.source_version_id == repository.get_version("public").id
+    assert cloned.selection.excluded_pointers == ("/curriculum/research/0",)
+
+
+def test_rejects_duplicate_version_name(tmp_path: Path):
+    repository, curriculum = _create_repository_with_curriculum(tmp_path)
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+
+    with pytest.raises(DuplicateCurriculumVersionName):
+        repository.create_derived_version("public")
+
+
+def test_rejects_derived_creation_without_master(tmp_path: Path):
+    repository, _curriculum = _create_repository_with_curriculum(tmp_path)
+
+    with pytest.raises(MasterCurriculumNotFound):
+        repository.create_derived_version("public")
+
+
+def test_excluding_section_materializes_selected_data_only(tmp_path: Path):
+    repository, curriculum = _create_repository_with_curriculum(tmp_path, _multi_entry_document())
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+    repository.exclude_from_version("public", "/curriculum/research")
+
+    materialized = repository.materialize_version("public")
+
+    assert materialized.document["curriculum"]["research"] == []
+    assert materialized.validation_status == "valid"
+    assert repository.get_curriculum(curriculum.id).document["curriculum"]["research"]
+
+
+def test_excluding_entry_materializes_without_mutating_master(tmp_path: Path):
+    repository, curriculum = _create_repository_with_curriculum(tmp_path, _multi_entry_document())
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+    repository.exclude_from_version("public", "/curriculum/research/0")
+
+    materialized = repository.materialize_version("public")
+    master_after_edit = repository.get_curriculum(curriculum.id)
+
+    assert [entry["id"] for entry in materialized.document["curriculum"]["research"]] == ["research-002"]
+    assert [entry["id"] for entry in master_after_edit.document["curriculum"]["research"]] == [
+        "research-001",
+        "research-002",
+    ]
+
+
+def test_materialization_preserves_trace_metadata(tmp_path: Path):
+    repository, curriculum = _create_repository_with_curriculum(tmp_path, _multi_entry_document())
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+    repository.exclude_from_version("public", "/curriculum/research/1")
+
+    materialized = repository.materialize_version("public")
+
+    assert materialized.document["curriculum"]["research"][0]["trace"]["cvn_codes"] == ["060.010.010.000"]
+    assert materialized.document["extensions"]["x-open-cvn.versioning"]["version_name"] == "public"
+
+
+def test_rejects_invalid_selection_edits(tmp_path: Path):
+    repository, curriculum = _create_repository_with_curriculum(tmp_path, _multi_entry_document())
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+
+    with pytest.raises(InvalidSelectionRule):
+        repository.exclude_from_version("master", "/curriculum/research/0")
+    with pytest.raises(InvalidSelectionRule):
+        repository.exclude_from_version("public", "/metadata/policy")
+    with pytest.raises(InvalidSelectionRule):
+        repository.exclude_from_version("public", "/curriculum/research/99")
+
+
+def test_initialize_store_migrates_schema_version_1_store(tmp_path: Path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    with sqlite3.connect(store_path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE app_metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            INSERT INTO app_metadata(key, value) VALUES ('schema_version', '1');
+            CREATE TABLE curricula (
+                id TEXT PRIMARY KEY,
+                display_name TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                schema_version TEXT NOT NULL,
+                policy_name TEXT NOT NULL,
+                policy_version TEXT NOT NULL,
+                source_format TEXT NOT NULL,
+                source_identifier TEXT,
+                validation_status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE TABLE curriculum_diagnostics (
+                id TEXT PRIMARY KEY,
+                curriculum_id TEXT NOT NULL,
+                severity TEXT NOT NULL,
+                code TEXT NOT NULL,
+                message TEXT NOT NULL,
+                source_location TEXT,
+                path_json TEXT NOT NULL,
+                details_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY (curriculum_id) REFERENCES curricula(id) ON DELETE CASCADE
+            );
+            """
+        )
+
+    store_info = initialize_store(store_path)
+
+    assert store_info.schema_version == SCHEMA_VERSION
+    with sqlite3.connect(store_path) as connection:
+        schema_version = connection.execute(
+            "SELECT value FROM app_metadata WHERE key = 'schema_version'"
+        ).fetchone()[0]
+        version_table = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'curriculum_versions'"
+        ).fetchone()[0]
+    assert schema_version == SCHEMA_VERSION
+    assert version_table == "curriculum_versions"


### PR DESCRIPTION

## Summary
- Add SQLite schema v2 with master/derived curriculum version records
- Add selection-based derived materialization and versioning CLI commands
- Add tests and update persistent roadmap/status docs
## Verification
- `uv run pytest -n auto tests`
- Result: `399 passed in 431.30s (0:07:11)`
Closes #63