### PR TITLE
feat: implement Open CVN JSON import/export workflow

### DIFF
--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -135,7 +135,7 @@ files in order:
 - `docs/roadmap/issues/issue-63-master-and-derived-curriculum-versions.md`:
   planned master and derived curriculum versioning issue
 - `docs/roadmap/issues/issue-64-open-cvn-json-import-export-workflow.md`:
-  planned Open CVN JSON application import/export issue
+  authoritative record of the Open CVN JSON application import/export issue
 - `docs/roadmap/issues/issue-65-curriculum-editing-and-selection-mvp.md`:
   planned MVP editing and selection issue
 - `docs/roadmap/issues/issue-66-latex-export-from-open-cvn.md`: planned LaTeX

--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -2,7 +2,7 @@
 
 ## Status Date
 
-- Last updated: 2026-07-07
+- Last updated: 2026-07-08
 
 ## Completed Or Stabilized Work
 
@@ -854,6 +854,48 @@
   - result: `399 passed in 431.30s (0:07:11)`
 - no new durable limitations were found
 
+### Issue `#64`
+
+- the Open CVN JSON import/export workflow issue is implemented under:
+  - `src/open_cvn_app/cli.py`
+- the JSON CLI placeholders from issue `#61` are now functional:
+  - `open-cvn json import INPUT [--store PATH] [--name NAME] [--as-master]`
+  - `open-cvn json export OUTPUT [--store PATH] [--version NAME]`
+- import uses `parse_open_cvn_json(...)` from the public `open_cvn` parser package
+  and does not introduce an app-specific JSON validator or alternate JSON shape
+- valid imports are stored through `CurriculumRepository.create_curriculum(...)`
+  with parser warnings preserved as repository diagnostics when present
+- `--name` sets the stored curriculum display name; otherwise the input path stem
+  is used
+- `--as-master` assigns the imported curriculum as the master version when no
+  master already exists
+- duplicate `--as-master` imports fail before creating a new curriculum so a
+  one-step import/master command does not leave an orphan curriculum record
+- export uses `CurriculumRepository.materialize_version(...)`, so master and
+  derived exports share the issue `#63` version materialization behavior
+- exported JSON is deterministic with `ensure_ascii=False`, sorted object keys,
+  two-space indentation, and a final newline
+- export creates parent directories for explicit nested output paths
+- CLI output reports structured parser failures with issue code, severity, path,
+  source location, and message
+- CLI import/export coverage was added to:
+  - `tests/test_open_cvn_app_cli_unit.py`
+- targeted CLI verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `18 passed in 17.84s`
+- targeted storage and versioning regression verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py -v`
+  - result: `18 passed in 16.82s`
+- targeted parser contract regression verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`
+  - result: `22 passed in 16.91s`
+- console-script smoke verification passed for store init, JSON import with
+  `--as-master`, and JSON export of the master version
+- full-suite verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `406 passed in 719.75s (0:11:59)`
+- no new durable limitations were found
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -865,8 +907,8 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#63`: issue `#64` Open CVN JSON import/export
-  workflow
+- Next work item after issue `#64`: issue `#65` curriculum editing and selection
+  MVP
 - Epic `#60` has been expanded into issues `#61` through `#69`
 - MVP direction:
   - CLI-first local prototype
@@ -878,7 +920,7 @@
   - optional PDF generation and preview handoff
   - application MVP tests and user documentation
   - post-MVP LLM-assisted import spike
-- Next implementation issue: `#64` Open CVN JSON import/export workflow
+- Next implementation issue: `#65` curriculum editing and selection MVP
 
 ## Blocking Or Relevant Limitations
 

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -30,13 +30,13 @@ Agents should also read `AGENTS.md` before this file.
 - Project: open CVN schema and tooling for Spanish academic CV processing
 - Current pipeline stage: structural generation, metadata normalization,
   semantic policy, domain generation, conceptual schema, Open CVN JSON format,
-  parser/validator contract, CLI shell, local SQLite storage, and master/derived
-  curriculum versioning completed
+  parser/validator contract, CLI shell, local SQLite storage, master/derived
+  curriculum versioning, and Open CVN JSON application import/export completed
 - Last documented issues: `#11`, `#12`, `#13`, `#14`, `#15`, `#16`, `#17`,
   `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, `#47`, `#48`, `#49`, `#50`,
-  `#61`, `#62`, and `#63`
+  `#61`, `#62`, `#63`, and `#64`
 - Latest documented hotfix records: `#3`, `#4`, `#5`, `#6`, `#7`, `#8`
-- Next planned issue: `#64`
+- Next planned issue: `#65`
 - Canonical source package: `docs/CvnXML_v1.4.3_2.1_17012025/`
 
 ## Documentation Map

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -49,7 +49,7 @@ Goal:
 | `#61` | Application MVP scope and CLI shell | Completed | CLI-first prototype shell, command surface, console script, placeholders, and smoke tests implemented |
 | `#62` | Local storage with SQLite | Completed | SQLite store initialization, schema metadata, curriculum repository, diagnostics, CLI store init, and tests implemented |
 | `#63` | Master and derived curriculum versions | Completed | Schema v2 migration, master/derived repository operations, selection materialization, CLI commands, and tests implemented |
-| `#64` | Open CVN JSON import/export workflow | Planned | Application import/export using epic `#41` parser and validator |
+| `#64` | Open CVN JSON import/export workflow | Completed | CLI JSON import/export implemented using the public parser/validator, SQLite storage, master/derived materialization, deterministic export formatting, and tests |
 | `#65` | Curriculum editing and selection MVP | Planned | Basic include/exclude customization for derived versions |
 | `#66` | LaTeX export from Open CVN | Planned | Jinja-style LaTeX rendering from stored Open CVN data |
 | `#67` | PDF generation and preview handoff | Planned | Optional local TeX compilation and generated-PDF path handoff |

--- a/docs/roadmap/issues/issue-64-open-cvn-json-import-export-workflow.md
+++ b/docs/roadmap/issues/issue-64-open-cvn-json-import-export-workflow.md
@@ -39,6 +39,328 @@ Import must call `parse_open_cvn_json(...)` or `validate_open_cvn_json(...)` fro
 7. add CLI and repository integration tests
 8. document import/export commands
 
+## Detailed Execution Plan
+
+This plan is the accepted execution plan for implementing issue `#64`.
+During execution, each work update must identify the active task and, when
+applicable, the active subtask. Each task or subtask update should include:
+
+- initial summary of the task or subtask goal
+- current task and subtask identifier
+- whether the user must modify any file manually
+- next step to follow
+
+Unless explicitly requested otherwise, code edits are expected to be performed by
+the user. Documentation edits may be applied when the user asks to establish or
+update the issue plan.
+
+### Task 1 - Confirm Scope And Constraints
+
+- Subtask 1.1: confirm issue `#64` is limited to Open CVN JSON application import
+  and export.
+- Subtask 1.2: confirm import must use `parse_open_cvn_json(...)` or
+  `validate_open_cvn_json(...)` from the public `open_cvn` package.
+- Subtask 1.3: confirm no app-specific JSON validator or alternate JSON shape is
+  introduced.
+- Subtask 1.4: confirm storage must use the issue `#62` and issue `#63`
+  repository APIs in `src/open_cvn_app/storage.py`.
+- Subtask 1.5: confirm export must support materialized master and derived
+  versions through `CurriculumRepository.materialize_version(...)`.
+- Subtask 1.6: confirm issue `#64` does not implement curriculum editing,
+  LaTeX export, PDF generation, or LLM import behavior.
+- Subtask 1.7: confirm `src/generated/` remains untouched.
+
+Expected output: final implementation boundary for issue `#64` before code work.
+
+### Task 2 - Define Stable CLI Behavior
+
+- Subtask 2.1: keep the existing command family names from issue `#61`:
+  `open-cvn json import` and `open-cvn json export`.
+- Subtask 2.2: extend `open-cvn json import INPUT [--store PATH]` with optional
+  `--name NAME` for the stored curriculum display name.
+- Subtask 2.3: extend `open-cvn json import INPUT [--store PATH]` with optional
+  `--as-master` for assigning the imported curriculum as the master version.
+- Subtask 2.4: keep `open-cvn json export OUTPUT [--store PATH] [--version NAME]`
+  and use `master` as the default version name.
+- Subtask 2.5: define successful import output including display name,
+  curriculum ID, validation status, and source path.
+- Subtask 2.6: define successful import-with-master output including the assigned
+  master version ID.
+- Subtask 2.7: define failed import output including validation status and one
+  line per structured parser issue with code, severity, path, location, and
+  message.
+- Subtask 2.8: define successful export output including version name, output
+  path, and validation status.
+
+Expected output: deterministic CLI output contract that tests can assert.
+
+### Task 3 - Extend CLI Argument Parsing
+
+- Subtask 3.1: modify `src/open_cvn_app/cli.py` so `json import` accepts
+  `--name NAME`.
+- Subtask 3.2: modify `src/open_cvn_app/cli.py` so `json import` accepts
+  `--as-master`.
+- Subtask 3.3: keep `json export` positional `OUTPUT`, `--store`, and `--version`
+  behavior unchanged.
+- Subtask 3.4: verify `open-cvn --help` still lists the same command groups.
+
+Expected output: parser accepts the issue `#64` import/export surface without
+breaking existing commands.
+
+### Task 4 - Add CLI Formatting And JSON Writing Helpers
+
+- Subtask 4.1: add a private helper in `src/open_cvn_app/cli.py` for formatting
+  parser issues into deterministic CLI lines.
+- Subtask 4.2: include parser issue `code`, `severity`, `path`,
+  `source_location`, and `message` in formatted output.
+- Subtask 4.3: add a private helper in `src/open_cvn_app/cli.py` for canonical
+  JSON export writing.
+- Subtask 4.4: write exported JSON with `ensure_ascii=False`, `sort_keys=True`,
+  `indent=2`, and a final newline.
+- Subtask 4.5: create parent directories for explicit nested export paths.
+
+Expected output: small local helpers keep import/export handlers readable and make
+output deterministic.
+
+### Task 5 - Implement JSON Import Command
+
+- Subtask 5.1: replace the issue `#64` placeholder in `_handle_json_import(...)`.
+- Subtask 5.2: resolve the local store path through `OpenCvnAppConfig`.
+- Subtask 5.3: call `parse_open_cvn_json(...)` with the input path and source
+  identifier.
+- Subtask 5.4: reject `invalid` and `failed` parse results before storage.
+- Subtask 5.5: reject parse results with missing `data` before storage.
+- Subtask 5.6: derive the display name from `--name` or the input path stem.
+- Subtask 5.7: persist the validated document through
+  `CurriculumRepository.create_curriculum(...)`.
+- Subtask 5.8: preserve parser warnings as repository diagnostics.
+- Subtask 5.9: when `--as-master` is passed, call
+  `CurriculumRepository.assign_master_curriculum(...)` for the imported
+  curriculum.
+- Subtask 5.10: convert `StorageError` failures into `AppResult.failed(...)`.
+
+Expected output: valid Open CVN JSON files import into local SQLite storage.
+
+### Task 6 - Implement JSON Export Command
+
+- Subtask 6.1: replace the issue `#64` placeholder in `_handle_json_export(...)`.
+- Subtask 6.2: resolve the local store path through `OpenCvnAppConfig`.
+- Subtask 6.3: materialize the requested version through
+  `CurriculumRepository.materialize_version(...)`.
+- Subtask 6.4: write the materialized Open CVN JSON document to the output path
+  with deterministic formatting.
+- Subtask 6.5: preserve materialized version metadata under
+  `extensions["x-open-cvn.versioning"]` as produced by issue `#63`.
+- Subtask 6.6: convert `StorageError` and `OSError` failures into
+  `AppResult.failed(...)`.
+
+Expected output: stored master and derived versions export as canonical Open CVN
+JSON files.
+
+### Task 7 - Add CLI Import Tests For Valid Documents
+
+- Subtask 7.1: update `tests/test_open_cvn_app_cli_unit.py` so the previous JSON
+  import placeholder test expects real import behavior.
+- Subtask 7.2: use `tests/fixtures/open_cvn/valid_minimal.json` as the import
+  fixture.
+- Subtask 7.3: run `json import <fixture> --store <tmp> --name "Imported CV"`.
+- Subtask 7.4: assert the command exits with code `0`.
+- Subtask 7.5: assert output includes the import success message, curriculum ID,
+  and `Validation status: valid`.
+- Subtask 7.6: load the temporary store through `CurriculumRepository` and assert
+  one curriculum was created.
+- Subtask 7.7: assert the stored display name and source identifier match the CLI
+  input.
+
+Expected output: CLI test proves a valid Open CVN JSON file is stored.
+
+### Task 8 - Add CLI Import Tests For Master Assignment
+
+- Subtask 8.1: run `json import <fixture> --store <tmp> --as-master`.
+- Subtask 8.2: assert the command exits with code `0`.
+- Subtask 8.3: assert output includes the master assignment message.
+- Subtask 8.4: assert `CurriculumRepository.list_versions()` returns a master
+  version linked to the imported curriculum.
+- Subtask 8.5: test duplicate master handling by importing another document with
+  `--as-master` into a store that already has a master.
+- Subtask 8.6: assert duplicate master handling exits with code `1` and reports a
+  clear storage error.
+
+Expected output: import can optionally create the master version, and duplicate
+master failures are visible.
+
+### Task 9 - Add CLI Import Tests For Invalid Documents
+
+- Subtask 9.1: run `json import tests/fixtures/open_cvn/wrong_shape.json --store
+  <tmp>`.
+- Subtask 9.2: assert the command exits with code `1`.
+- Subtask 9.3: assert stderr includes `Open CVN JSON import failed` and
+  `json_schema_validation_failure`.
+- Subtask 9.4: assert no curriculum records were stored.
+- Subtask 9.5: run `json import tests/fixtures/open_cvn/malformed.json --store
+  <tmp>`.
+- Subtask 9.6: assert stderr includes `invalid_json`.
+- Subtask 9.7: assert no curriculum records were stored for malformed input.
+
+Expected output: invalid and malformed JSON fail with structured error output and
+do not pollute storage.
+
+### Task 10 - Add CLI Export Tests For Master Versions
+
+- Subtask 10.1: create a temporary store and store a valid Open CVN JSON document.
+- Subtask 10.2: assign the stored curriculum as the master version.
+- Subtask 10.3: run `json export <output> --store <tmp> --version master`.
+- Subtask 10.4: assert the command exits with code `0`.
+- Subtask 10.5: assert the output file exists.
+- Subtask 10.6: parse the exported file as JSON and validate it with
+  `validate_open_cvn_json(...)`.
+- Subtask 10.7: assert validation status is `valid`.
+- Subtask 10.8: assert the file uses deterministic pretty JSON and ends with a
+  newline.
+
+Expected output: master version export writes a revalidable canonical JSON file.
+
+### Task 11 - Add CLI Export Tests For Derived Versions
+
+- Subtask 11.1: create a temporary store using `examples/open_cvn/research_entry.json`
+  or an equivalent multi-entry fixture.
+- Subtask 11.2: assign the stored curriculum as master.
+- Subtask 11.3: create a derived version named `public`.
+- Subtask 11.4: exclude a curriculum pointer such as `/curriculum/research` or a
+  repeated entry pointer.
+- Subtask 11.5: run `json export <output> --store <tmp> --version public`.
+- Subtask 11.6: assert the exported document contains selected data only.
+- Subtask 11.7: assert `extensions["x-open-cvn.versioning"]["version_name"]` is
+  `public`.
+- Subtask 11.8: validate the exported document with `validate_open_cvn_json(...)`.
+
+Expected output: derived version export uses issue `#63` materialization behavior.
+
+### Task 12 - Add CLI Export Failure Tests
+
+- Subtask 12.1: run export against an uninitialized store.
+- Subtask 12.2: assert the command exits with code `1` and reports export failure.
+- Subtask 12.3: run export for a missing version name in an initialized store.
+- Subtask 12.4: assert the command exits with code `1` and reports the missing
+  version error.
+- Subtask 12.5: run export to a nested output path and assert parent directories
+  are created.
+
+Expected output: export failures are deterministic and nested output paths work.
+
+### Task 13 - Run Targeted Verification
+
+- Subtask 13.1: run CLI tests:
+  `uv run pytest -n auto tests/test_open_cvn_app_cli_unit.py -v`.
+- Subtask 13.2: run storage and versioning regressions:
+  `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py -v`.
+- Subtask 13.3: run parser contract regressions:
+  `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`.
+- Subtask 13.4: record exact results in this issue document.
+
+Expected output: targeted issue `#64` behavior and dependencies pass.
+
+### Task 14 - Run Console Script Smoke Verification
+
+- Subtask 14.1: initialize a temporary smoke store with
+  `uv run open-cvn store init --path /tmp/opencode/open-cvn-issue-64-smoke.sqlite`.
+- Subtask 14.2: import a representative example with
+  `uv run open-cvn json import examples/open_cvn/minimal.json --store /tmp/opencode/open-cvn-issue-64-smoke.sqlite --as-master`.
+- Subtask 14.3: export the master version with
+  `uv run open-cvn json export /tmp/opencode/open-cvn-issue-64-export.json --store /tmp/opencode/open-cvn-issue-64-smoke.sqlite --version master`.
+- Subtask 14.4: record whether the smoke workflow completed successfully.
+
+Expected output: installed console command proves the import/export workflow
+outside direct unit tests.
+
+### Task 15 - Run Full Repository Verification
+
+- Subtask 15.1: run `uv run pytest -n auto tests`.
+- Subtask 15.2: record the exact pass/fail result in this issue document.
+- Subtask 15.3: if full verification cannot be completed, record the skipped
+  command and reason.
+
+Expected output: full repository verification passes or a documented reason is
+available.
+
+### Task 16 - Update Persistent Documentation
+
+- Subtask 16.1: update this issue document with actual implementation artifacts,
+  deviations, verification, and status.
+- Subtask 16.2: update `docs/context/current_status.md` so issue `#64` is recorded
+  accurately and issue `#65` becomes the next implementation issue if `#64` is
+  completed.
+- Subtask 16.3: update `docs/roadmap/cvn_generation_roadmap.md` if it tracks issue
+  `#64` status.
+- Subtask 16.4: update `docs/pipeline/known_limitations.md` only if a new durable
+  limitation is found.
+- Subtask 16.5: update `PROJECT_GUIDE.md` only if repository orientation,
+  contributor reading order, or the documentation map changes.
+
+Expected output: repository context remains resumable after issue completion.
+
+## Planned CLI Shape
+
+```text
+open-cvn json import INPUT [--store PATH] [--name NAME] [--as-master]
+open-cvn json export OUTPUT [--store PATH] [--version NAME]
+```
+
+## Planned Import Output Shape
+
+Successful import without master assignment should report:
+
+```text
+Imported Open CVN JSON as curriculum '<display_name>'.
+Curriculum ID: <curriculum_id>
+Validation status: <validation_status>
+Source: <input_path>
+```
+
+Successful import with `--as-master` should additionally report:
+
+```text
+Assigned master curriculum version 'master' with id <version_id>.
+```
+
+Invalid import should report structured parser issues in a user-readable form,
+including at least issue code, severity, path, source location, and message.
+
+## Planned Export Output Shape
+
+Successful export should report:
+
+```text
+Exported Open CVN JSON version '<version_name>' to <output_path>.
+Validation status: <validation_status>
+```
+
+Exported JSON should be deterministic:
+
+```text
+ensure_ascii=False
+sort_keys=True
+indent=2
+final newline
+```
+
+## Definition Of Done
+
+- `open-cvn json import` imports valid Open CVN JSON into local SQLite storage.
+- Import uses `parse_open_cvn_json(...)` or `validate_open_cvn_json(...)` from the
+  public `open_cvn` package.
+- Import does not introduce an app-specific JSON shape or validator.
+- Invalid and malformed input fail with structured user-readable CLI output.
+- Import can optionally assign the imported curriculum as the master version.
+- `open-cvn json export` exports materialized master and derived versions.
+- Exported JSON revalidates with `validate_open_cvn_json(...)`.
+- Exported JSON uses deterministic formatting.
+- Tests cover valid import, invalid import, malformed import, master export,
+  derived export, and export failures.
+- Console-script smoke verification covers store init, import, and export.
+- Full repository verification passes or a documented reason is recorded.
+- Persistent documentation is updated in the same session as the implementation.
+
 ## Expected Output
 
 - working JSON import command
@@ -53,6 +375,80 @@ Import must call `parse_open_cvn_json(...)` or `validate_open_cvn_json(...)` fro
 - exported JSON revalidates with `validate_open_cvn_json(...)`
 - full repository verification passes or a reason is documented
 
+## Implementation Notes
+
+- The Open CVN JSON import/export workflow is implemented in:
+  - `src/open_cvn_app/cli.py`
+- The implementation keeps the existing issue `#61` command family and replaces
+  the issue `#64` placeholders with functional behavior:
+  - `open-cvn json import INPUT [--store PATH] [--name NAME] [--as-master]`
+  - `open-cvn json export OUTPUT [--store PATH] [--version NAME]`
+- Import uses `parse_open_cvn_json(...)` from the public `open_cvn` package.
+- Import rejects `invalid` and `failed` parser results before storage.
+- Import persists valid documents through `CurriculumRepository.create_curriculum(...)`.
+- Parser warnings are preserved as repository diagnostics when present.
+- `--name` controls the stored curriculum display name; otherwise the input file
+  stem is used.
+- `--as-master` assigns the imported curriculum as the master version when no
+  master exists.
+- `--as-master` fails before creating a new curriculum when the store already has
+  a master version.
+- Export uses `CurriculumRepository.materialize_version(...)`, so both master and
+  derived versions use the issue `#63` versioning behavior.
+- Export writes deterministic Open CVN JSON using `ensure_ascii=False`,
+  `sort_keys=True`, `indent=2`, and a final newline.
+- Export creates parent directories for explicit nested output paths.
+- Structured parser errors are rendered in CLI output with code, severity, path,
+  source location, and message.
+- `src/generated/` was not modified.
+
+## Tests Added Or Updated
+
+- Updated `tests/test_open_cvn_app_cli_unit.py`.
+
+The CLI tests now cover:
+
+- valid Open CVN JSON import into SQLite storage
+- import display-name selection through `--name`
+- optional master assignment through `--as-master`
+- duplicate master rejection without creating an extra curriculum
+- invalid Open CVN JSON schema failure output
+- malformed JSON failure output
+- master version export to deterministic JSON
+- derived version export through materialized selection behavior
+- missing-version export failure
+- uninitialized-store export failure
+- existing version, LaTeX, PDF, help, and version command regressions
+
+## Verification Performed
+
+- `uv run pytest -n auto tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `18 passed in 17.84s`
+- `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py -v`
+  - result: `18 passed in 16.82s`
+- `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`
+  - result: `22 passed in 16.91s`
+- Console-script smoke workflow:
+  - `uv run open-cvn store init --path /tmp/opencode/open-cvn-issue-64-smoke-1783526641.sqlite`
+  - `uv run open-cvn json import examples/open_cvn/minimal.json --store /tmp/opencode/open-cvn-issue-64-smoke-1783526641.sqlite --as-master`
+  - `uv run open-cvn json export /tmp/opencode/open-cvn-issue-64-export-1783526641.json --store /tmp/opencode/open-cvn-issue-64-smoke-1783526641.sqlite --version master`
+  - result: workflow initialized schema version `2`, imported `minimal`, assigned
+    master, exported valid JSON, and parsed the exported JSON successfully
+- `uv run pytest -n auto tests`
+  - result: `406 passed in 719.75s (0:11:59)`
+
+## Deviations From Planned Scope
+
+- The accepted plan added `--name` and `--as-master` to make import storage and
+  master assignment explicit from the CLI.
+- Duplicate `--as-master` imports fail before creating a new curriculum. This is a
+  stricter behavior than creating the curriculum first and then failing master
+  assignment, and avoids orphan imports from a failed one-step command.
+
+## New Limitations Found
+
+- No new durable limitations were found.
+
 ## Impact On Later Issues
 
 - issue `#66` can use exported or stored Open CVN JSON for LaTeX rendering
@@ -60,4 +456,4 @@ Import must call `parse_open_cvn_json(...)` or `validate_open_cvn_json(...)` fro
 
 ## Status
 
-- Status: planned
+- Status: completed

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-63-master-and-derived-curriculum-versions.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 63. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-64-open-cvn-json-import-export-workflow.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 64. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-63-master-and-derived-curriculum-versions.md.
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-64-open-cvn-json-import-export-workflow.md
 
 
 

--- a/src/open_cvn_app/cli.py
+++ b/src/open_cvn_app/cli.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Sequence
+from pathlib import Path
 
+from open_cvn import CvnParseIssue, CvnValidationStatus, parse_open_cvn_json
 from open_cvn_app import __version__
 from open_cvn_app.config import OpenCvnAppConfig
 from open_cvn_app.results import AppResult
-from open_cvn_app.storage import SCHEMA_VERSION, CurriculumRepository, StorageError, initialize_store
+from open_cvn_app.storage import (
+    SCHEMA_VERSION,
+    CurriculumCreate,
+    CurriculumRepository,
+    MasterCurriculumNotFound,
+    StorageError,
+    initialize_store,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -36,6 +46,12 @@ def build_parser() -> argparse.ArgumentParser:
     json_subparsers = json_parser.add_subparsers(dest="json_command")
     json_import_parser = json_subparsers.add_parser("import", help="Import Open CVN JSON.")
     json_import_parser.add_argument("input", help="Input Open CVN JSON file.")
+    json_import_parser.add_argument("--name", help="Stored curriculum display name.")
+    json_import_parser.add_argument(
+        "--as-master",
+        action="store_true",
+        help="Assign imported curriculum as the master version.",
+    )
     _add_store_path_option(json_import_parser)
     json_import_parser.set_defaults(handler=_handle_json_import)
     json_export_parser = json_subparsers.add_parser("export", help="Export Open CVN JSON.")
@@ -158,11 +174,82 @@ def _handle_store_init(args: argparse.Namespace) -> AppResult:
 
 
 def _handle_json_import(args: argparse.Namespace) -> AppResult:
-    return _planned_result("Open CVN JSON import", "#64", args)
+    input_path = Path(args.input)
+    repository = _repository_from_args(args)
+    parse_result = parse_open_cvn_json(input_path, source_identifier=str(input_path))
+    if parse_result.validation_status in {CvnValidationStatus.INVALID, CvnValidationStatus.FAILED}:
+        return AppResult.failed(
+            "Open CVN JSON import failed.",
+            error="\n".join(
+                (
+                    f"Validation status: {parse_result.validation_status.value}",
+                    "Errors:",
+                    _format_parse_issues(parse_result.errors),
+                )
+            ),
+        )
+    if parse_result.data is None:
+        return AppResult.failed(
+            "Open CVN JSON import failed.",
+            error="Parser accepted input but did not return Open CVN JSON data.",
+        )
+
+    display_name = args.name or input_path.stem
+    try:
+        if args.as_master:
+            try:
+                repository.get_master_version()
+            except MasterCurriculumNotFound:
+                pass
+            else:
+                return AppResult.failed(
+                    "Open CVN JSON import failed.",
+                    error="A master curriculum version already exists.",
+                )
+        record = repository.create_curriculum(
+            CurriculumCreate(
+                display_name=display_name,
+                document=parse_result.data,
+                source_identifier=str(input_path),
+                diagnostics=parse_result.warnings,
+            )
+        )
+        master_line = None
+        if args.as_master:
+            master = repository.assign_master_curriculum(record.id)
+            master_line = f"Assigned master curriculum version '{master.name}' with id {master.id}."
+    except StorageError as exc:
+        return AppResult.failed("Open CVN JSON import failed.", error=str(exc))
+
+    lines = [
+        f"Imported Open CVN JSON as curriculum '{record.display_name}'.",
+        f"Curriculum ID: {record.id}",
+        f"Validation status: {record.validation_status}",
+        f"Source: {input_path}",
+    ]
+    if master_line is not None:
+        lines.append(master_line)
+    return AppResult.ok("\n".join(lines))
 
 
 def _handle_json_export(args: argparse.Namespace) -> AppResult:
-    return _planned_result("Open CVN JSON export", "#64", args)
+    repository = _repository_from_args(args)
+    output_path = Path(args.output)
+    try:
+        materialized = repository.materialize_version(args.version_name)
+        _write_canonical_json(output_path, materialized.document)
+    except StorageError as exc:
+        return AppResult.failed("Open CVN JSON export failed.", error=str(exc))
+    except OSError as exc:
+        return AppResult.failed("Open CVN JSON export failed.", error=str(exc))
+    return AppResult.ok(
+        "\n".join(
+            (
+                f"Exported Open CVN JSON version '{materialized.version.name}' to {output_path}.",
+                f"Validation status: {materialized.validation_status}",
+            )
+        )
+    )
 
 
 def _handle_versions_list(args: argparse.Namespace) -> AppResult:
@@ -254,3 +341,29 @@ def _handle_pdf_generate(args: argparse.Namespace) -> AppResult:
 def _repository_from_args(args: argparse.Namespace) -> CurriculumRepository:
     config = _config_from_args(args)
     return CurriculumRepository(config.store_path)
+
+
+def _format_parse_issues(issues: tuple[CvnParseIssue, ...]) -> str:
+    if not issues:
+        return "-"
+    return "\n".join(_format_parse_issue(issue) for issue in issues)
+
+
+def _format_parse_issue(issue: CvnParseIssue) -> str:
+    location = issue.source_location or "-"
+    return (
+        f"- code={issue.code.value} severity={issue.severity.value} "
+        f"path={_format_issue_path(issue.path)} location={location} message={issue.message}"
+    )
+
+
+def _format_issue_path(path: tuple[str, ...]) -> str:
+    if not path:
+        return "-"
+    return "/".join(path)
+
+
+def _write_canonical_json(path: Path, document: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(document, ensure_ascii=False, sort_keys=True, indent=2)
+    path.write_text(f"{payload}\n", encoding="utf-8")

--- a/tests/test_open_cvn_app_cli_unit.py
+++ b/tests/test_open_cvn_app_cli_unit.py
@@ -5,12 +5,14 @@ from pathlib import Path
 
 import pytest
 
+from open_cvn import CvnValidationStatus, validate_open_cvn_json
 from open_cvn_app import __version__
 from open_cvn_app.cli import build_parser, run
 from open_cvn_app.storage import CurriculumCreate, CurriculumRepository, initialize_store
 
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "open_cvn"
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples" / "open_cvn"
 
 
 def _create_store_with_curriculum(tmp_path):
@@ -54,20 +56,162 @@ def test_store_init_creates_local_store(capsys: pytest.CaptureFixture[str], tmp_
     assert store_path.exists()
 
 
-def test_json_import_routes_to_issue_64_placeholder(capsys: pytest.CaptureFixture[str]):
-    exit_code = run(["json", "import", "input.json"])
+def test_json_import_stores_valid_open_cvn_document(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    input_path = FIXTURES_DIR / "valid_minimal.json"
+
+    exit_code = run([
+        "json",
+        "import",
+        str(input_path),
+        "--store",
+        str(store_path),
+        "--name",
+        "Imported CV",
+    ])
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert "Open CVN JSON import is planned for issue #64" in output
+    assert "Imported Open CVN JSON as curriculum 'Imported CV'." in output
+    assert "Curriculum ID:" in output
+    assert "Validation status: valid" in output
+    repository = CurriculumRepository(store_path)
+    curricula = repository.list_curricula()
+    assert len(curricula) == 1
+    assert curricula[0].display_name == "Imported CV"
+    assert curricula[0].source_identifier == str(input_path)
 
 
-def test_json_export_routes_to_issue_64_placeholder(capsys: pytest.CaptureFixture[str]):
-    exit_code = run(["json", "export", "output.json", "--version", "public"])
+def test_json_import_can_assign_master_version(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    input_path = FIXTURES_DIR / "valid_minimal.json"
+
+    exit_code = run(["json", "import", str(input_path), "--store", str(store_path), "--as-master"])
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert "Open CVN JSON export is planned for issue #64" in output
+    assert "Assigned master curriculum version 'master'" in output
+    repository = CurriculumRepository(store_path)
+    curricula = repository.list_curricula()
+    versions = repository.list_versions()
+    assert len(curricula) == 1
+    assert len(versions) == 1
+    assert versions[0].kind == "master"
+    assert versions[0].master_curriculum_id == curricula[0].id
+
+
+def test_json_import_reports_duplicate_master(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path, curriculum = _create_store_with_curriculum(tmp_path)
+    repository = CurriculumRepository(store_path)
+    repository.assign_master_curriculum(curriculum.id)
+    input_path = FIXTURES_DIR / "valid_minimal.json"
+
+    exit_code = run(["json", "import", str(input_path), "--store", str(store_path), "--as-master"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Open CVN JSON import failed." in captured.err
+    assert "A master curriculum version already exists." in captured.err
+
+
+def test_json_import_reports_schema_validation_errors(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    input_path = FIXTURES_DIR / "wrong_shape.json"
+
+    exit_code = run(["json", "import", str(input_path), "--store", str(store_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Open CVN JSON import failed." in captured.err
+    assert "Validation status: invalid" in captured.err
+    assert "json_schema_validation_failure" in captured.err
+    assert CurriculumRepository(store_path).list_curricula() == ()
+
+
+def test_json_import_reports_malformed_json(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    input_path = FIXTURES_DIR / "malformed.json"
+
+    exit_code = run(["json", "import", str(input_path), "--store", str(store_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Open CVN JSON import failed." in captured.err
+    assert "Validation status: failed" in captured.err
+    assert "invalid_json" in captured.err
+    assert CurriculumRepository(store_path).list_curricula() == ()
+
+
+def test_json_export_writes_revalidatable_master_document(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path, curriculum = _create_store_with_curriculum(tmp_path)
+    repository = CurriculumRepository(store_path)
+    repository.assign_master_curriculum(curriculum.id)
+    output_path = tmp_path / "exports" / "master.json"
+
+    exit_code = run(["json", "export", str(output_path), "--store", str(store_path), "--version", "master"])
+
+    output = capsys.readouterr().out
+    exported_text = output_path.read_text(encoding="utf-8")
+    exported_document = json.loads(exported_text)
+    validation_result = validate_open_cvn_json(exported_document, source_identifier="exported-master")
+    assert exit_code == 0
+    assert "Exported Open CVN JSON version 'master'" in output
+    assert "Validation status: valid" in output
+    assert validation_result.validation_status == CvnValidationStatus.VALID
+    assert exported_text.endswith("\n")
+    assert exported_text == f"{json.dumps(exported_document, ensure_ascii=False, sort_keys=True, indent=2)}\n"
+
+
+def test_json_export_writes_materialized_derived_document(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    document = json.loads((EXAMPLES_DIR / "research_entry.json").read_text(encoding="utf-8"))
+    curriculum = repository.create_curriculum(CurriculumCreate(display_name="Master CV", document=document))
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+    repository.exclude_from_version("public", "/curriculum/research")
+    output_path = tmp_path / "public.json"
+
+    exit_code = run(["json", "export", str(output_path), "--store", str(store_path), "--version", "public"])
+
+    output = capsys.readouterr().out
+    exported_document = json.loads(output_path.read_text(encoding="utf-8"))
+    validation_result = validate_open_cvn_json(exported_document, source_identifier="exported-public")
+    assert exit_code == 0
+    assert "Exported Open CVN JSON version 'public'" in output
+    assert exported_document["curriculum"]["research"] == []
+    assert exported_document["extensions"]["x-open-cvn.versioning"]["version_name"] == "public"
+    assert validation_result.validation_status == CvnValidationStatus.VALID
+
+
+def test_json_export_reports_missing_version(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    output_path = tmp_path / "missing.json"
+
+    exit_code = run(["json", "export", str(output_path), "--store", str(store_path), "--version", "missing"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Open CVN JSON export failed." in captured.err
+    assert "Curriculum version not found: missing" in captured.err
+
+
+def test_json_export_reports_uninitialized_store(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    output_path = tmp_path / "missing.json"
+
+    exit_code = run(["json", "export", str(output_path), "--store", str(store_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Open CVN JSON export failed." in captured.err
+    assert "SQLite file is not an initialized Open CVN store." in captured.err
 
 
 def test_versions_list_reads_initialized_store(capsys: pytest.CaptureFixture[str], tmp_path):


### PR DESCRIPTION
## Summary
- implement `open-cvn json import` using the public Open CVN parser
- implement `open-cvn json export` for materialized master and derived versions
- add CLI coverage for valid/invalid import, master assignment, and exports
- update issue #64 and project status documentation

## Verification
- `uv run pytest -n auto tests/test_open_cvn_app_cli_unit.py -v`
- `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py -v`
- `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`
- `uv run pytest -n auto tests`