### PR TITLE
feat: implement curriculum editing selection MVP

### DIFF
--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -2,7 +2,7 @@
 
 ## Status Date
 
-- Last updated: 2026-07-08
+- Last updated: 2026-07-09
 
 ## Completed Or Stabilized Work
 
@@ -896,6 +896,56 @@
   - result: `406 passed in 719.75s (0:11:59)`
 - no new durable limitations were found
 
+### Issue `#65`
+
+- the curriculum editing and selection MVP issue is implemented under:
+  - `src/open_cvn_app/editing.py`
+  - `src/open_cvn_app/cli.py`
+  - `src/open_cvn_app/storage.py`
+- user-facing selection discovery commands are now functional:
+  - `open-cvn versions sections NAME [--store PATH]`
+  - `open-cvn versions entries NAME SECTION [--store PATH]`
+- section listing reports materialized curriculum section names, JSON Pointer
+  selectors, value kinds, and entry counts where applicable
+- entry listing reports zero-based index, JSON Pointer selector, optional entry
+  `id`, optional entry `type`, compact summary, and trace CVN codes when present
+- existing selection mutation commands now validate the materialized version after
+  mutation:
+  - `open-cvn versions include NAME POINTER [--store PATH]`
+  - `open-cvn versions exclude NAME POINTER [--store PATH]`
+- derived-version metadata editing is now functional:
+  - `open-cvn versions metadata NAME [--store PATH] [--display-name TEXT] [--purpose TEXT]`
+- derived metadata is stored additively inside deterministic `selection_json` and
+  exposed during materialization under
+  `extensions["x-open-cvn.versioning"]["metadata"]`
+- unsupported fine-grained field edits now fail explicitly through:
+  - `open-cvn versions field-edit NAME POINTER VALUE [--store PATH]`
+- field-level edits do not mutate stored data and instruct users to use
+  include/exclude section or entry selection instead
+- editing tests are implemented in:
+  - `tests/test_open_cvn_app_editing_unit.py`
+- CLI coverage for issue `#65` was added to:
+  - `tests/test_open_cvn_app_cli_unit.py`
+- targeted editing verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_editing_unit.py -v`
+  - result: `7 passed in 24.78s`
+- targeted CLI verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `23 passed in 26.12s`
+- targeted storage and versioning regression verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py -v`
+  - result: `18 passed in 26.31s`
+- targeted parser regression verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`
+  - result: `22 passed in 25.91s`
+- console-script smoke verification passed for store init, JSON import as master,
+  derived creation, section listing, entry listing, entry exclusion, derived JSON
+  export, and exported empty `research` entries after exclusion
+- full-suite verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `418 passed in 801.95s (0:13:21)`
+- no new durable limitations were found
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -907,8 +957,7 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#64`: issue `#65` curriculum editing and selection
-  MVP
+- Next work item after issue `#65`: issue `#66` LaTeX export from Open CVN
 - Epic `#60` has been expanded into issues `#61` through `#69`
 - MVP direction:
   - CLI-first local prototype
@@ -920,7 +969,7 @@
   - optional PDF generation and preview handoff
   - application MVP tests and user documentation
   - post-MVP LLM-assisted import spike
-- Next implementation issue: `#65` curriculum editing and selection MVP
+- Next implementation issue: `#66` LaTeX export from Open CVN
 
 ## Blocking Or Relevant Limitations
 

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -31,12 +31,13 @@ Agents should also read `AGENTS.md` before this file.
 - Current pipeline stage: structural generation, metadata normalization,
   semantic policy, domain generation, conceptual schema, Open CVN JSON format,
   parser/validator contract, CLI shell, local SQLite storage, master/derived
-  curriculum versioning, and Open CVN JSON application import/export completed
+  curriculum versioning, Open CVN JSON application import/export, and curriculum
+  editing/selection MVP completed
 - Last documented issues: `#11`, `#12`, `#13`, `#14`, `#15`, `#16`, `#17`,
   `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, `#47`, `#48`, `#49`, `#50`,
-  `#61`, `#62`, `#63`, and `#64`
+  `#61`, `#62`, `#63`, `#64`, and `#65`
 - Latest documented hotfix records: `#3`, `#4`, `#5`, `#6`, `#7`, `#8`
-- Next planned issue: `#65`
+- Next planned issue: `#66`
 - Canonical source package: `docs/CvnXML_v1.4.3_2.1_17012025/`
 
 ## Documentation Map

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -50,7 +50,7 @@ Goal:
 | `#62` | Local storage with SQLite | Completed | SQLite store initialization, schema metadata, curriculum repository, diagnostics, CLI store init, and tests implemented |
 | `#63` | Master and derived curriculum versions | Completed | Schema v2 migration, master/derived repository operations, selection materialization, CLI commands, and tests implemented |
 | `#64` | Open CVN JSON import/export workflow | Completed | CLI JSON import/export implemented using the public parser/validator, SQLite storage, master/derived materialization, deterministic export formatting, and tests |
-| `#65` | Curriculum editing and selection MVP | Planned | Basic include/exclude customization for derived versions |
+| `#65` | Curriculum editing and selection MVP | Completed | Section/entry listing, derived metadata, immediate selection validation, unsupported field-edit messaging, and tests implemented |
 | `#66` | LaTeX export from Open CVN | Planned | Jinja-style LaTeX rendering from stored Open CVN data |
 | `#67` | PDF generation and preview handoff | Planned | Optional local TeX compilation and generated-PDF path handoff |
 | `#68` | Application MVP tests and documentation | Planned | End-to-end MVP tests, user docs, and epic `#60` closure |

--- a/docs/roadmap/issues/issue-65-curriculum-editing-and-selection-mvp.md
+++ b/docs/roadmap/issues/issue-65-curriculum-editing-and-selection-mvp.md
@@ -43,6 +43,345 @@ The MVP should prioritize coarse operations over a full nested JSON editor:
 7. add tests for selection behavior and invalid selectors
 8. document editing limitations
 
+## Detailed Execution Plan
+
+This plan is the accepted execution plan for implementing issue `#65`.
+During execution, each work update must identify the active task and, when
+applicable, the active subtask. Each task or subtask update should include:
+
+- initial summary of the task or subtask goal
+- current task and subtask identifier
+- whether the user must modify any file manually
+- next step to follow
+
+Unless explicitly requested otherwise, code edits are expected to be performed by
+the user. Documentation edits may be applied when the user asks to establish or
+update the issue plan.
+
+### Task 1 - Confirm Scope And Constraints
+
+- Subtask 1.1: confirm issue `#65` builds user-facing editing and selection UX on
+  top of the issue `#63` versioning repository behavior instead of rewriting the
+  storage or materialization core.
+- Subtask 1.2: confirm existing `versions include NAME POINTER` and
+  `versions exclude NAME POINTER` commands remain the canonical include/exclude
+  mutation commands.
+- Subtask 1.3: confirm selectors continue to use JSON Pointer syntax and remain
+  restricted to `/curriculum` section or entry paths.
+- Subtask 1.4: confirm field-level edits are unsupported in the MVP and must fail
+  with a clear message.
+- Subtask 1.5: confirm materialized Open CVN JSON is validated through
+  `validate_open_cvn_json(...)` after selection or metadata changes where
+  applicable.
+- Subtask 1.6: confirm `src/generated/` remains untouched.
+
+Expected output: final implementation boundary for issue `#65` before code work.
+
+### Task 2 - Define Selection Command Grammar
+
+- Subtask 2.1: keep JSON Pointer as the canonical selector representation.
+- Subtask 2.2: document section selectors such as `/curriculum/research`.
+- Subtask 2.3: document entry selectors such as `/curriculum/research/0`.
+- Subtask 2.4: follow RFC 6901 pointer rules for `/`, `~0`, `~1`, object tokens,
+  and zero-based array indexes.
+- Subtask 2.5: reject root, metadata, extensions, and bare `/curriculum` selectors
+  for issue `#65` selection edits.
+- Subtask 2.6: display entry `id` values where present but keep the JSON Pointer
+  as the selector that commands consume.
+- Subtask 2.7: use entry indexes as the stable MVP fallback when an entry lacks an
+  explicit `id`.
+
+Expected output: deterministic command grammar and selector rules for CLI help,
+tests, and documentation.
+
+### Task 3 - Implement Curriculum Inspection Support
+
+- Subtask 3.1: add a small inspection layer in `src/open_cvn_app/storage.py` or a
+  focused helper module under `src/open_cvn_app/`.
+- Subtask 3.2: expose an operation to list curriculum sections for a materialized
+  version.
+- Subtask 3.3: expose an operation to list entries inside a repeated curriculum
+  section for a materialized version.
+- Subtask 3.4: derive inspection results from `CurriculumRepository.materialize_version(...)`
+  so derived selections are reflected in user-facing output.
+- Subtask 3.5: preserve deterministic ordering from the Open CVN JSON
+  `curriculum` object.
+- Subtask 3.6: return section metadata including name, pointer, value kind, and
+  entry count when applicable.
+- Subtask 3.7: return entry metadata including index, pointer, optional `id`,
+  optional `type`, compact summary, and trace CVN codes when present.
+
+Expected output: reusable inspection behavior for CLI listing commands without a
+GUI editor.
+
+### Task 4 - Define Entry Summary Rules
+
+- Subtask 4.1: show `entry["id"]` when present and `-` when absent.
+- Subtask 4.2: show `entry["type"]` when present and `-` when absent.
+- Subtask 4.3: build a compact summary from the first simple scalar fields under
+  `entry["data"]`.
+- Subtask 4.4: use `-` when no simple scalar summary is available.
+- Subtask 4.5: show CVN codes from `entry["trace"]["cvn_codes"]` when present.
+- Subtask 4.6: avoid adding heavy heuristics or new runtime dependencies for
+  summary generation.
+
+Expected output: stable, human-readable entry listing suitable for choosing
+include/exclude pointers.
+
+### Task 5 - Implement Section Listing CLI
+
+- Subtask 5.1: add `open-cvn versions sections NAME [--store PATH]` to
+  `src/open_cvn_app/cli.py`.
+- Subtask 5.2: resolve the local store path through `OpenCvnAppConfig`.
+- Subtask 5.3: load the requested version through the inspection behavior.
+- Subtask 5.4: print a deterministic section listing with names, pointers, and
+  entry counts or value kinds.
+- Subtask 5.5: return `No curriculum sections found.` for empty curriculum
+  objects.
+- Subtask 5.6: convert storage and selection failures into
+  `AppResult.failed("Section listing failed.", error=str(exc))`.
+
+Expected output: users can discover section-level selectors before applying
+include/exclude commands.
+
+### Task 6 - Implement Entry Listing CLI
+
+- Subtask 6.1: add `open-cvn versions entries NAME SECTION [--store PATH]` to
+  `src/open_cvn_app/cli.py`.
+- Subtask 6.2: accept both `research` and `/curriculum/research` as the `SECTION`
+  argument.
+- Subtask 6.3: normalize section arguments to a canonical `/curriculum/<section>`
+  pointer.
+- Subtask 6.4: reject missing sections with a clear error.
+- Subtask 6.5: reject non-list curriculum sections such as `identity` with a clear
+  unsupported message.
+- Subtask 6.6: print deterministic entry lines with index, pointer, id, type,
+  summary, and CVN codes.
+- Subtask 6.7: return `No entries found in section '<section>'.` for empty
+  repeated sections.
+
+Expected output: users can discover entry-level selectors without manually
+opening Open CVN JSON files.
+
+### Task 7 - Implement Derived Version Metadata Editing
+
+- Subtask 7.1: store optional derived-version metadata without adding a new table
+  when possible by extending deterministic selection JSON.
+- Subtask 7.2: preserve compatibility with existing selection JSON that lacks
+  metadata.
+- Subtask 7.3: support metadata keys for MVP display name and purpose.
+- Subtask 7.4: add repository behavior to update derived-version metadata.
+- Subtask 7.5: reject metadata updates against the master version unless a later
+  decision deliberately expands the scope.
+- Subtask 7.6: include derived metadata in
+  `extensions["x-open-cvn.versioning"]` during materialization.
+- Subtask 7.7: validate materialized Open CVN JSON after metadata changes.
+
+Expected output: derived versions can carry auditable human-facing purpose or name
+metadata without implementing a full editor.
+
+### Task 8 - Implement Metadata CLI
+
+- Subtask 8.1: add `open-cvn versions metadata NAME [--store PATH]
+  [--display-name TEXT] [--purpose TEXT]` to `src/open_cvn_app/cli.py`.
+- Subtask 8.2: when no metadata options are passed, show current derived metadata.
+- Subtask 8.3: when metadata options are passed, update the derived metadata.
+- Subtask 8.4: print deterministic output with version name, display name, and
+  purpose.
+- Subtask 8.5: convert storage and validation failures into
+  `AppResult.failed("Version metadata update failed.", error=str(exc))` or a
+  similarly specific message.
+
+Expected output: users can set and inspect simple derived-version metadata from
+the CLI.
+
+### Task 9 - Implement Unsupported Field-Edit Command
+
+- Subtask 9.1: add an explicit CLI command such as
+  `open-cvn versions field-edit NAME POINTER VALUE [--store PATH]`.
+- Subtask 9.2: return exit code `1` for this command in issue `#65`.
+- Subtask 9.3: print a clear message that field-level edits are not supported in
+  the MVP and users should use section or entry include/exclude selection instead.
+- Subtask 9.4: ensure the command does not mutate storage.
+
+Expected output: unsupported fine-grained editing fails clearly instead of being
+absent or ambiguous.
+
+### Task 10 - Validate Selection Changes Immediately
+
+- Subtask 10.1: after `versions include`, materialize the edited version to verify
+  the selected document remains valid.
+- Subtask 10.2: after `versions exclude`, materialize the edited version to verify
+  the selected document remains valid.
+- Subtask 10.3: preserve existing successful command messages where possible.
+- Subtask 10.4: fail clearly if materialization validation fails after a selection
+  change.
+- Subtask 10.5: keep master curriculum payload immutable after derived selection
+  edits.
+
+Expected output: users get immediate validation feedback after selection edits,
+not only during later export.
+
+### Task 11 - Add Editing And Inspection Unit Tests
+
+- Subtask 11.1: add a focused test module such as
+  `tests/test_open_cvn_app_editing_unit.py`.
+- Subtask 11.2: test section listing against representative Open CVN examples.
+- Subtask 11.3: test entry listing for entries with `id`, `type`, summary, pointer,
+  and CVN codes.
+- Subtask 11.4: test entry listing fallback when an entry lacks `id`.
+- Subtask 11.5: test empty repeated-section listing.
+- Subtask 11.6: test non-list sections are rejected for entry listing.
+- Subtask 11.7: test derived metadata update and materialized extension output.
+- Subtask 11.8: test unsupported field-edit behavior does not mutate data if the
+  implementation exposes a repository-level guard.
+- Subtask 11.9: test invalid selectors fail clearly.
+
+Expected output: unit tests cover inspection, metadata, unsupported edits, and
+invalid selector behavior.
+
+### Task 12 - Update CLI Tests
+
+- Subtask 12.1: extend `tests/test_open_cvn_app_cli_unit.py` for
+  `versions sections`.
+- Subtask 12.2: extend CLI tests for `versions entries` with a plain section name.
+- Subtask 12.3: extend CLI tests for `versions entries` with a full section
+  pointer.
+- Subtask 12.4: test empty entry listing after excluding a section or when a
+  section has no entries.
+- Subtask 12.5: test metadata show and update behavior.
+- Subtask 12.6: test unsupported `versions field-edit` returns exit code `1` and a
+  clear message.
+- Subtask 12.7: test missing version, missing section, and non-list section error
+  paths.
+- Subtask 12.8: keep existing JSON import/export, versioning, LaTeX placeholder,
+  and PDF placeholder tests passing.
+
+Expected output: CLI tests prove user-facing issue `#65` behavior.
+
+### Task 13 - Prepare Or Extend Fixtures
+
+- Subtask 13.1: reuse `examples/open_cvn/research_entry.json` where possible.
+- Subtask 13.2: reuse `examples/open_cvn/education_entry.json` where possible.
+- Subtask 13.3: add a small deterministic fixture only if multi-entry or missing
+  `id` behavior cannot be tested clearly with existing examples.
+- Subtask 13.4: place any new Open CVN JSON test fixture under
+  `tests/fixtures/open_cvn/`.
+- Subtask 13.5: keep any new fixture valid against the Open CVN JSON validator.
+
+Expected output: representative test data for section and entry listing without
+overbuilding fixtures.
+
+### Task 14 - Run Targeted Verification
+
+- Subtask 14.1: run editing tests:
+  `uv run pytest -n auto tests/test_open_cvn_app_editing_unit.py -v`.
+- Subtask 14.2: run CLI tests:
+  `uv run pytest -n auto tests/test_open_cvn_app_cli_unit.py -v`.
+- Subtask 14.3: run storage and versioning regressions:
+  `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py -v`.
+- Subtask 14.4: run parser contract regressions:
+  `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`.
+- Subtask 14.5: record exact results in this issue document.
+
+Expected output: targeted issue behavior and dependencies pass.
+
+### Task 15 - Run Console Script Smoke Verification
+
+- Subtask 15.1: initialize a temporary smoke store under `/tmp/opencode`.
+- Subtask 15.2: import `examples/open_cvn/research_entry.json` as master.
+- Subtask 15.3: create a derived version named `public`.
+- Subtask 15.4: list sections for the derived version.
+- Subtask 15.5: list entries for the `research` section.
+- Subtask 15.6: exclude `/curriculum/research/0` from the derived version.
+- Subtask 15.7: export the derived version as Open CVN JSON.
+- Subtask 15.8: confirm the exported derived JSON validates and omits the excluded
+  entry.
+
+Expected output: installed CLI proves the editing and selection workflow outside
+direct unit tests.
+
+### Task 16 - Run Full Repository Verification
+
+- Subtask 16.1: run `uv run pytest -n auto tests`.
+- Subtask 16.2: record the exact pass/fail result in this issue document.
+- Subtask 16.3: if full verification cannot be completed, record the skipped
+  command and reason.
+
+Expected output: full repository verification passes or a documented reason is
+available.
+
+### Task 17 - Update Persistent Documentation
+
+- Subtask 17.1: update this issue document with actual implementation artifacts,
+  deviations, verification, and status.
+- Subtask 17.2: update `docs/context/current_status.md` so issue `#65` is recorded
+  accurately and issue `#66` becomes the next implementation issue if `#65` is
+  completed.
+- Subtask 17.3: update `docs/roadmap/cvn_generation_roadmap.md` if it tracks issue
+  `#65` status.
+- Subtask 17.4: update `docs/pipeline/known_limitations.md` only if a new durable
+  limitation is found.
+- Subtask 17.5: update `PROJECT_GUIDE.md` only if repository orientation,
+  contributor reading order, or the documentation map changes.
+
+Expected output: repository context remains resumable after issue completion.
+
+## Planned Issue 65 CLI Shape
+
+```text
+open-cvn versions sections NAME [--store PATH]
+open-cvn versions entries NAME SECTION [--store PATH]
+open-cvn versions metadata NAME [--store PATH] [--display-name TEXT] [--purpose TEXT]
+open-cvn versions field-edit NAME POINTER VALUE [--store PATH]
+```
+
+Existing selection mutation commands from issue `#63` remain part of the editing
+workflow:
+
+```text
+open-cvn versions include NAME POINTER [--store PATH]
+open-cvn versions exclude NAME POINTER [--store PATH]
+```
+
+## Planned Selector Rules
+
+- Selectors use JSON Pointer syntax from RFC 6901.
+- Section selectors target `/curriculum/<section>`.
+- Entry selectors target `/curriculum/<section>/<index>`.
+- Entry indexes are zero-based JSON array indexes.
+- Entry `id` values are displayed when present, but pointers remain the canonical
+  command selectors for the MVP.
+- Field-level selectors below an entry may be displayed in future work but are not
+  editable in issue `#65`.
+
+## Planned Unsupported Field Edit Message
+
+Fine-grained field editing should fail clearly in issue `#65`, with wording close
+to:
+
+```text
+Field-level edits are not supported in issue #65 MVP.
+Use include/exclude section or entry selection instead.
+```
+
+## Definition Of Done
+
+- Users can list curriculum sections for a master or derived version.
+- Users can list repeated entries in a curriculum section and see stable selection
+  pointers.
+- Users can include or exclude discovered section and entry pointers using the
+  existing selection commands.
+- Selection changes are validated through materialized Open CVN JSON.
+- Users can inspect and update simple derived-version metadata such as display name
+  or purpose.
+- Unsupported field-level edits fail with a clear message.
+- Tests cover section listing, entry listing, include/exclude validation, metadata,
+  unsupported field edits, and invalid selectors.
+- Console-script smoke verification covers the user-facing selection workflow.
+- Full repository verification passes or a documented reason is recorded.
+- Persistent documentation is updated in the same session as the implementation.
+
 ## Expected Output
 
 - selection/editing CLI commands
@@ -61,6 +400,115 @@ The MVP should prioritize coarse operations over a full nested JSON editor:
 - issue `#66` exports customized derived versions to LaTeX
 - later GUI work can reuse the same selection service
 
+## Implementation Notes
+
+- User-facing curriculum editing and selection support is implemented in:
+  - `src/open_cvn_app/editing.py`
+  - `src/open_cvn_app/cli.py`
+  - `src/open_cvn_app/storage.py`
+- The implementation builds on the issue `#63` selection repository behavior
+  instead of replacing the storage or materialization core.
+- The new inspection layer lists materialized curriculum sections and repeated
+  entries for a requested master or derived version.
+- Section listing exposes section names, JSON Pointer selectors, value kinds, and
+  entry counts when a section is list-backed.
+- Entry listing exposes zero-based index, JSON Pointer selector, optional entry
+  `id`, optional entry `type`, compact summary, and trace CVN codes when present.
+- Entry summaries prioritize title/name-like fields and then fall back to the next
+  simple scalar data fields.
+- Derived-version metadata is stored additively in deterministic selection JSON
+  through optional `display_name` and `purpose` metadata keys.
+- Materialized versions expose derived metadata under
+  `extensions["x-open-cvn.versioning"]["metadata"]` when metadata is present.
+- Existing include/exclude selection edits now materialize the edited version after
+  mutation so users get immediate validation feedback.
+- Fine-grained field edits are intentionally unsupported and fail through an
+  explicit `versions field-edit` command without mutating stored data.
+- `src/generated/` was not modified.
+
+## Implemented CLI Behavior
+
+Issue `#65` adds these user-facing editing and selection discovery commands:
+
+```text
+open-cvn versions sections NAME [--store PATH]
+open-cvn versions entries NAME SECTION [--store PATH]
+open-cvn versions metadata NAME [--store PATH] [--display-name TEXT] [--purpose TEXT]
+open-cvn versions field-edit NAME POINTER VALUE [--store PATH]
+```
+
+The existing issue `#63` selection mutation commands remain functional and now
+validate the materialized derived document immediately after mutation:
+
+```text
+open-cvn versions include NAME POINTER [--store PATH]
+open-cvn versions exclude NAME POINTER [--store PATH]
+```
+
+## Tests Added Or Updated
+
+- Added `tests/test_open_cvn_app_editing_unit.py`.
+- Updated `tests/test_open_cvn_app_cli_unit.py`.
+
+The new and updated tests cover:
+
+- materialized section listing
+- repeated-entry listing by section name and section pointer
+- entry display identifiers, summaries, and trace CVN code output
+- missing-entry-ID fallback to pointer/index display
+- empty repeated sections and non-list section errors
+- derived metadata update and materialized extension output
+- metadata preservation across later selection edits
+- unsupported field-edit behavior without storage mutation
+- invalid selector and master-metadata error paths
+- existing import/export, storage, versioning, LaTeX placeholder, and PDF
+  placeholder regressions
+
+## Verification Performed
+
+- `uv run pytest -n auto tests/test_open_cvn_app_editing_unit.py -v`
+  - result: `7 passed in 24.78s`
+- `uv run pytest -n auto tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `23 passed in 26.12s`
+- `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py -v`
+  - result: `18 passed in 26.31s`
+- `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`
+  - result: `22 passed in 25.91s`
+- Console-script smoke workflow:
+  - `uv run open-cvn store init --path /tmp/opencode/open-cvn-issue-65-smoke.sqlite`
+  - `uv run open-cvn json import examples/open_cvn/research_entry.json --store /tmp/opencode/open-cvn-issue-65-smoke.sqlite --as-master`
+  - `uv run open-cvn versions derive public --store /tmp/opencode/open-cvn-issue-65-smoke.sqlite`
+  - `uv run open-cvn versions sections public --store /tmp/opencode/open-cvn-issue-65-smoke.sqlite`
+  - `uv run open-cvn versions entries public research --store /tmp/opencode/open-cvn-issue-65-smoke.sqlite`
+  - `uv run open-cvn versions exclude public /curriculum/research/0 --store /tmp/opencode/open-cvn-issue-65-smoke.sqlite`
+  - `uv run open-cvn json export /tmp/opencode/open-cvn-issue-65-public.json --store /tmp/opencode/open-cvn-issue-65-smoke.sqlite --version public`
+  - result: workflow initialized schema version `2`, imported a master document,
+    created a derived version, listed sections, listed entries, excluded an entry,
+    exported a valid derived JSON document, and confirmed the exported `research`
+    entries were empty
+- `uv run pytest -n auto tests`
+  - result: `418 passed in 801.95s (0:13:21)`
+
+## Deviations From Planned Scope
+
+- No functional deviations.
+- Derived metadata is stored in the existing `selection_json` document instead of
+  adding a new SQLite table or schema version. This keeps the metadata auditable
+  and avoids unnecessary migration for MVP-only fields.
+- Entry summaries use a tiny title/name priority list before falling back to the
+  next scalar data fields so canonical JSON key sorting does not make summaries
+  less useful.
+
+## New Limitations Found
+
+- No new durable limitations were found.
+
+## Impact On Later Issues After Implementation
+
+- issue `#66` can export selected and metadata-tagged derived versions to LaTeX
+- later GUI work can reuse the section/entry inspection service and repository
+  selection behavior
+
 ## Status
 
-- Status: planned
+- Status: completed

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-64-open-cvn-json-import-export-workflow.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 64. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-65-curriculum-editing-and-selection-mvp.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 65. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-64-open-cvn-json-import-export-workflow.md
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-65-curriculum-editing-and-selection-mvp.md
 
 
 

--- a/src/open_cvn_app/cli.py
+++ b/src/open_cvn_app/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from open_cvn import CvnParseIssue, CvnValidationStatus, parse_open_cvn_json
 from open_cvn_app import __version__
 from open_cvn_app.config import OpenCvnAppConfig
+from open_cvn_app.editing import list_curriculum_entries, list_curriculum_sections
 from open_cvn_app.results import AppResult
 from open_cvn_app.storage import (
     SCHEMA_VERSION,
@@ -73,6 +74,30 @@ def build_parser() -> argparse.ArgumentParser:
     versions_show_parser.add_argument("name", help="Version name or ID.")
     _add_store_path_option(versions_show_parser)
     versions_show_parser.set_defaults(handler=_handle_versions_show)
+    versions_sections_parser = versions_subparsers.add_parser(
+        "sections",
+        help="List curriculum sections in a version.",
+    )
+    versions_sections_parser.add_argument("name", help="Version name or ID.")
+    _add_store_path_option(versions_sections_parser)
+    versions_sections_parser.set_defaults(handler=_handle_versions_sections)
+    versions_entries_parser = versions_subparsers.add_parser(
+        "entries",
+        help="List entries in a curriculum section.",
+    )
+    versions_entries_parser.add_argument("name", help="Version name or ID.")
+    versions_entries_parser.add_argument("section", help="Curriculum section name or /curriculum section pointer.")
+    _add_store_path_option(versions_entries_parser)
+    versions_entries_parser.set_defaults(handler=_handle_versions_entries)
+    versions_metadata_parser = versions_subparsers.add_parser(
+        "metadata",
+        help="Show or update derived version metadata.",
+    )
+    versions_metadata_parser.add_argument("name", help="Derived version name or ID.")
+    versions_metadata_parser.add_argument("--display-name", help="Human display name for the derived version.")
+    versions_metadata_parser.add_argument("--purpose", help="Human purpose for the derived version.")
+    _add_store_path_option(versions_metadata_parser)
+    versions_metadata_parser.set_defaults(handler=_handle_versions_metadata)
     versions_derive_parser = versions_subparsers.add_parser(
         "derive",
         help="Create derived curriculum version.",
@@ -96,6 +121,15 @@ def build_parser() -> argparse.ArgumentParser:
     versions_exclude_parser.add_argument("pointer", help="JSON Pointer under /curriculum.")
     _add_store_path_option(versions_exclude_parser)
     versions_exclude_parser.set_defaults(handler=_handle_versions_exclude)
+    versions_field_edit_parser = versions_subparsers.add_parser(
+        "field-edit",
+        help="Report unsupported field-level edit behavior for the MVP.",
+    )
+    versions_field_edit_parser.add_argument("name", help="Version name or ID.")
+    versions_field_edit_parser.add_argument("pointer", help="Field JSON Pointer.")
+    versions_field_edit_parser.add_argument("value", help="Replacement value.")
+    _add_store_path_option(versions_field_edit_parser)
+    versions_field_edit_parser.set_defaults(handler=_handle_versions_field_edit)
 
     latex_parser = subparsers.add_parser("latex", help="Export curriculum to LaTeX.")
     latex_subparsers = latex_parser.add_subparsers(dest="latex_command")
@@ -303,6 +337,67 @@ def _handle_versions_show(args: argparse.Namespace) -> AppResult:
     )
 
 
+def _handle_versions_sections(args: argparse.Namespace) -> AppResult:
+    repository = _repository_from_args(args)
+    try:
+        sections = list_curriculum_sections(repository, args.name)
+    except StorageError as exc:
+        return AppResult.failed("Section listing failed.", error=str(exc))
+    if not sections:
+        return AppResult.ok("No curriculum sections found.")
+    lines = [f"Curriculum sections for version '{args.name}':"]
+    for section in sections:
+        entries = section.entry_count if section.entry_count is not None else section.value_kind
+        lines.append(f"- {section.name} pointer={section.pointer} entries={entries}")
+    return AppResult.ok("\n".join(lines))
+
+
+def _handle_versions_entries(args: argparse.Namespace) -> AppResult:
+    repository = _repository_from_args(args)
+    try:
+        entries = list_curriculum_entries(repository, args.name, args.section)
+    except StorageError as exc:
+        return AppResult.failed("Entry listing failed.", error=str(exc))
+    section_name = _display_section_name(args.section)
+    if not entries:
+        return AppResult.ok(f"No entries found in section '{section_name}'.")
+    lines = [f"Entries for version '{args.name}' section '{section_name}':"]
+    for entry in entries:
+        lines.append(
+            f"- [{entry.index}] pointer={entry.pointer} "
+            f"id={entry.entry_id or '-'} type={entry.entry_type or '-'} "
+            f"summary={entry.summary or '-'} cvn_codes={', '.join(entry.cvn_codes) or '-'}"
+        )
+    return AppResult.ok("\n".join(lines))
+
+
+def _handle_versions_metadata(args: argparse.Namespace) -> AppResult:
+    repository = _repository_from_args(args)
+    try:
+        if args.display_name is not None or args.purpose is not None:
+            version = repository.update_version_metadata(
+                args.name,
+                display_name=args.display_name,
+                purpose=args.purpose,
+            )
+            prefix = f"Updated metadata for derived curriculum version '{version.name}'."
+        else:
+            version = repository.get_version(args.name)
+            prefix = f"Metadata for curriculum version '{version.name}':"
+    except StorageError as exc:
+        return AppResult.failed("Version metadata update failed.", error=str(exc))
+    metadata = version.selection.metadata or {}
+    return AppResult.ok(
+        "\n".join(
+            (
+                prefix,
+                f"Display name: {metadata.get('display_name', '-')}",
+                f"Purpose: {metadata.get('purpose', '-')}",
+            )
+        )
+    )
+
+
 def _handle_versions_derive(args: argparse.Namespace) -> AppResult:
     repository = _repository_from_args(args)
     try:
@@ -316,6 +411,7 @@ def _handle_versions_include(args: argparse.Namespace) -> AppResult:
     repository = _repository_from_args(args)
     try:
         version = repository.include_in_version(args.name, args.pointer)
+        repository.materialize_version(version.id)
     except StorageError as exc:
         return AppResult.failed("Version include failed.", error=str(exc))
     return AppResult.ok(f"Included {args.pointer} in derived curriculum version '{version.name}'.")
@@ -325,9 +421,17 @@ def _handle_versions_exclude(args: argparse.Namespace) -> AppResult:
     repository = _repository_from_args(args)
     try:
         version = repository.exclude_from_version(args.name, args.pointer)
+        repository.materialize_version(version.id)
     except StorageError as exc:
         return AppResult.failed("Version exclude failed.", error=str(exc))
     return AppResult.ok(f"Excluded {args.pointer} from derived curriculum version '{version.name}'.")
+
+
+def _handle_versions_field_edit(args: argparse.Namespace) -> AppResult:
+    return AppResult.failed(
+        "Field-level edits are not supported in issue #65 MVP.",
+        error="Use include/exclude section or entry selection instead.",
+    )
 
 
 def _handle_latex_export(args: argparse.Namespace) -> AppResult:
@@ -361,6 +465,14 @@ def _format_issue_path(path: tuple[str, ...]) -> str:
     if not path:
         return "-"
     return "/".join(path)
+
+
+def _display_section_name(section: str) -> str:
+    if section.startswith("/curriculum/"):
+        parts = section.split("/")
+        if len(parts) == 3:
+            return parts[2].replace("~1", "/").replace("~0", "~")
+    return section
 
 
 def _write_canonical_json(path: Path, document: object) -> None:

--- a/src/open_cvn_app/editing.py
+++ b/src/open_cvn_app/editing.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from open_cvn_app.storage import CurriculumRepository, InvalidSelectionRule
+
+
+@dataclass(frozen=True)
+class CurriculumSectionView:
+    name: str
+    pointer: str
+    value_kind: str
+    entry_count: int | None
+
+
+@dataclass(frozen=True)
+class CurriculumEntryView:
+    index: int
+    pointer: str
+    entry_id: str | None
+    entry_type: str | None
+    summary: str | None
+    cvn_codes: tuple[str, ...]
+
+
+def list_curriculum_sections(
+    repository: CurriculumRepository,
+    version: str,
+) -> tuple[CurriculumSectionView, ...]:
+    document = repository.materialize_version(version).document
+    curriculum = _curriculum_mapping(document)
+    sections: list[CurriculumSectionView] = []
+    for name, value in curriculum.items():
+        if isinstance(value, list):
+            value_kind = "list"
+            entry_count = len(value)
+        elif isinstance(value, Mapping):
+            value_kind = "object"
+            entry_count = None
+        else:
+            value_kind = type(value).__name__
+            entry_count = None
+        sections.append(
+            CurriculumSectionView(
+                name=str(name),
+                pointer=f"/curriculum/{_escape_json_pointer_token(str(name))}",
+                value_kind=value_kind,
+                entry_count=entry_count,
+            )
+        )
+    return tuple(sections)
+
+
+def list_curriculum_entries(
+    repository: CurriculumRepository,
+    version: str,
+    section: str,
+) -> tuple[CurriculumEntryView, ...]:
+    section_name = _section_name_from_argument(section)
+    document = repository.materialize_version(version).document
+    curriculum = _curriculum_mapping(document)
+    if section_name not in curriculum:
+        raise InvalidSelectionRule(f"Curriculum section not found: {section_name}")
+    entries = curriculum[section_name]
+    if not isinstance(entries, list):
+        raise InvalidSelectionRule(
+            f"Curriculum section is not a repeated entry list: {section_name}"
+        )
+    escaped_section = _escape_json_pointer_token(section_name)
+    return tuple(
+        CurriculumEntryView(
+            index=index,
+            pointer=f"/curriculum/{escaped_section}/{index}",
+            entry_id=_optional_string(entry, "id"),
+            entry_type=_optional_string(entry, "type"),
+            summary=_entry_summary(entry),
+            cvn_codes=_cvn_codes(entry),
+        )
+        for index, entry in enumerate(entries)
+    )
+
+
+def _curriculum_mapping(document: Mapping[str, Any]) -> Mapping[str, Any]:
+    curriculum = document.get("curriculum")
+    if not isinstance(curriculum, Mapping):
+        raise InvalidSelectionRule("Open CVN curriculum field must be an object.")
+    return curriculum
+
+
+def _section_name_from_argument(section: str) -> str:
+    if section.startswith("/curriculum/"):
+        parts = section.split("/")
+        if len(parts) != 3:
+            raise InvalidSelectionRule(
+                f"Section selector must target one curriculum section: {section}"
+            )
+        return parts[2].replace("~1", "/").replace("~0", "~")
+    if section.startswith("/"):
+        raise InvalidSelectionRule(f"Section selector must target /curriculum: {section}")
+    return section
+
+
+def _optional_string(value: object, key: str) -> str | None:
+    if not isinstance(value, Mapping):
+        return None
+    item = value.get(key)
+    if item is None:
+        return None
+    return str(item)
+
+
+def _entry_summary(value: object) -> str | None:
+    if not isinstance(value, Mapping):
+        return None
+    data = value.get("data")
+    if not isinstance(data, Mapping):
+        return None
+    parts: list[str] = []
+    for key, item in _summary_items(data):
+        if isinstance(item, str | int | float | bool):
+            parts.append(f"{key}={item}")
+        if len(parts) == 2:
+            break
+    return "; ".join(parts) if parts else None
+
+
+def _summary_items(data: Mapping[str, Any]) -> tuple[tuple[str, Any], ...]:
+    priority = ("title", "degree_name", "project_title", "name")
+    items: list[tuple[str, Any]] = []
+    seen: set[str] = set()
+    for key in priority:
+        if key in data:
+            items.append((key, data[key]))
+            seen.add(key)
+    items.extend((str(key), value) for key, value in data.items() if key not in seen)
+    return tuple(items)
+
+
+def _cvn_codes(value: object) -> tuple[str, ...]:
+    if not isinstance(value, Mapping):
+        return ()
+    trace = value.get("trace")
+    if not isinstance(trace, Mapping):
+        return ()
+    codes = trace.get("cvn_codes")
+    if not isinstance(codes, list):
+        return ()
+    return tuple(str(code) for code in codes)
+
+
+def _escape_json_pointer_token(token: str) -> str:
+    return token.replace("~", "~0").replace("/", "~1")

--- a/src/open_cvn_app/storage.py
+++ b/src/open_cvn_app/storage.py
@@ -108,6 +108,7 @@ class DerivedSelection:
     mode: str = "include_all"
     included_pointers: tuple[str, ...] = ()
     excluded_pointers: tuple[str, ...] = ()
+    metadata: Mapping[str, str] | None = None
 
 
 @dataclass(frozen=True)
@@ -423,6 +424,41 @@ class CurriculumRepository:
     def exclude_from_version(self, version: str, pointer: str) -> CurriculumVersionRecord:
         return self._update_selection(version, pointer, include=False)
 
+    def update_version_metadata(
+        self,
+        version: str,
+        *,
+        display_name: str | None = None,
+        purpose: str | None = None,
+    ) -> CurriculumVersionRecord:
+        with self._connection() as connection:
+            row = _fetch_version_row(connection, version)
+            if row is None:
+                raise CurriculumVersionNotFound(f"Curriculum version not found: {version}")
+            version_record = _row_to_version(row)
+            if version_record.kind == "master":
+                raise InvalidSelectionRule("Master curriculum version metadata cannot be edited.")
+            metadata = dict(version_record.selection.metadata or {})
+            if display_name is not None:
+                _set_or_remove_metadata(metadata, "display_name", display_name)
+            if purpose is not None:
+                _set_or_remove_metadata(metadata, "purpose", purpose)
+            selection = DerivedSelection(
+                mode=version_record.selection.mode,
+                included_pointers=version_record.selection.included_pointers,
+                excluded_pointers=version_record.selection.excluded_pointers,
+                metadata=metadata,
+            )
+            now = _utc_now()
+            connection.execute(
+                "UPDATE curriculum_versions SET selection_json = ?, updated_at = ? WHERE id = ?",
+                (_selection_to_json(selection), now, version_record.id),
+            )
+            connection.commit()
+        updated = self.get_version(version_record.id)
+        self.materialize_version(updated.id)
+        return updated
+
     def materialize_version(self, version: str) -> MaterializedVersion:
         version_record = self.get_version(version)
         master = self.get_curriculum(version_record.master_curriculum_id)
@@ -442,6 +478,8 @@ class CurriculumRepository:
             "source_version_id": version_record.source_version_id,
             "selection": _selection_to_data(version_record.selection),
         }
+        if version_record.selection.metadata:
+            extensions["x-open-cvn.versioning"]["metadata"] = dict(version_record.selection.metadata)
 
         validation_result = validate_open_cvn_json(document, source_identifier=f"version:{version_record.name}")
         if validation_result.validation_status in {CvnValidationStatus.INVALID, CvnValidationStatus.FAILED}:
@@ -625,10 +663,14 @@ def _fetch_version_row(connection: sqlite3.Connection, version: str) -> sqlite3.
 
 def _selection_from_json(value: str) -> DerivedSelection:
     data = json.loads(value)
+    raw_metadata = data.get("metadata") or {}
+    if not isinstance(raw_metadata, Mapping):
+        raise InvalidSelectionRule("Selection metadata must be an object.")
     selection = DerivedSelection(
         mode=str(data.get("mode", "include_all")),
         included_pointers=tuple(str(pointer) for pointer in data.get("included_pointers", ())),
         excluded_pointers=tuple(str(pointer) for pointer in data.get("excluded_pointers", ())),
+        metadata={str(key): str(value) for key, value in raw_metadata.items()},
     )
     _validate_selection(selection)
     return selection
@@ -640,11 +682,14 @@ def _selection_to_json(selection: DerivedSelection) -> str:
 
 
 def _selection_to_data(selection: DerivedSelection) -> dict[str, Any]:
-    return {
+    data = {
         "mode": selection.mode,
         "included_pointers": list(selection.included_pointers),
         "excluded_pointers": list(selection.excluded_pointers),
     }
+    if selection.metadata:
+        data["metadata"] = dict(sorted(selection.metadata.items()))
+    return data
 
 
 def _validate_selection(selection: DerivedSelection) -> None:
@@ -652,6 +697,20 @@ def _validate_selection(selection: DerivedSelection) -> None:
         raise InvalidSelectionRule(f"Unsupported selection mode: {selection.mode}")
     for pointer in selection.included_pointers + selection.excluded_pointers:
         _validate_selection_pointer(pointer)
+    if selection.metadata is not None:
+        for key, value in selection.metadata.items():
+            if key not in {"display_name", "purpose"}:
+                raise InvalidSelectionRule(f"Unsupported version metadata key: {key}")
+            if not isinstance(value, str):
+                raise InvalidSelectionRule(f"Version metadata value must be a string: {key}")
+
+
+def _set_or_remove_metadata(metadata: dict[str, str], key: str, value: str) -> None:
+    clean_value = value.strip()
+    if clean_value:
+        metadata[key] = clean_value
+    else:
+        metadata.pop(key, None)
 
 
 def _validate_selection_pointer(pointer: str) -> None:
@@ -681,6 +740,7 @@ def _change_selection(selection: DerivedSelection, pointer: str, *, include: boo
         mode=selection.mode,
         included_pointers=tuple(sorted(included)),
         excluded_pointers=tuple(sorted(excluded)),
+        metadata=selection.metadata,
     )
 
 

--- a/tests/test_open_cvn_app_cli_unit.py
+++ b/tests/test_open_cvn_app_cli_unit.py
@@ -257,6 +257,124 @@ def test_versions_include_and_exclude_update_derived_selection(capsys: pytest.Ca
     assert "Included /curriculum/research" in output
 
 
+def test_versions_sections_lists_materialized_sections(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    document = json.loads((EXAMPLES_DIR / "research_entry.json").read_text(encoding="utf-8"))
+    curriculum = repository.create_curriculum(CurriculumCreate(display_name="Master CV", document=document))
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+
+    exit_code = run(["versions", "sections", "public", "--store", str(store_path)])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Curriculum sections for version 'public':" in output
+    assert "- research pointer=/curriculum/research entries=1" in output
+    assert "- identity pointer=/curriculum/identity entries=object" in output
+
+
+def test_versions_entries_lists_plain_and_pointer_sections(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    document = json.loads((EXAMPLES_DIR / "research_entry.json").read_text(encoding="utf-8"))
+    curriculum = repository.create_curriculum(CurriculumCreate(display_name="Master CV", document=document))
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+
+    plain_exit = run(["versions", "entries", "public", "research", "--store", str(store_path)])
+    pointer_exit = run([
+        "versions",
+        "entries",
+        "public",
+        "/curriculum/research",
+        "--store",
+        str(store_path),
+    ])
+
+    output = capsys.readouterr().out
+    assert plain_exit == 0
+    assert pointer_exit == 0
+    assert "Entries for version 'public' section 'research':" in output
+    assert "pointer=/curriculum/research/0" in output
+    assert "id=research-001" in output
+    assert "type=research.publication" in output
+
+
+def test_versions_entries_reports_empty_and_non_list_sections(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    document = json.loads((EXAMPLES_DIR / "education_entry.json").read_text(encoding="utf-8"))
+    curriculum = repository.create_curriculum(CurriculumCreate(display_name="Master CV", document=document))
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+
+    empty_exit = run(["versions", "entries", "public", "research", "--store", str(store_path)])
+    non_list_exit = run(["versions", "entries", "public", "identity", "--store", str(store_path)])
+
+    captured = capsys.readouterr()
+    assert empty_exit == 0
+    assert "No entries found in section 'research'." in captured.out
+    assert non_list_exit == 1
+    assert "Entry listing failed." in captured.err
+    assert "Curriculum section is not a repeated entry list: identity" in captured.err
+
+
+def test_versions_metadata_show_and_update(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path, curriculum = _create_store_with_curriculum(tmp_path)
+    repository = CurriculumRepository(store_path)
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+
+    update_exit = run([
+        "versions",
+        "metadata",
+        "public",
+        "--display-name",
+        "Public CV",
+        "--purpose",
+        "grant application",
+        "--store",
+        str(store_path),
+    ])
+    show_exit = run(["versions", "metadata", "public", "--store", str(store_path)])
+
+    output = capsys.readouterr().out
+    assert update_exit == 0
+    assert show_exit == 0
+    assert "Updated metadata for derived curriculum version 'public'." in output
+    assert "Display name: Public CV" in output
+    assert "Purpose: grant application" in output
+
+
+def test_versions_field_edit_reports_unsupported_without_mutating(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path, curriculum = _create_store_with_curriculum(tmp_path)
+    repository = CurriculumRepository(store_path)
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+    before = repository.materialize_version("public").document
+
+    exit_code = run([
+        "versions",
+        "field-edit",
+        "public",
+        "/curriculum/research/0/data/title",
+        "New title",
+        "--store",
+        str(store_path),
+    ])
+
+    captured = capsys.readouterr()
+    after = repository.materialize_version("public").document
+    assert exit_code == 1
+    assert "Field-level edits are not supported in issue #65 MVP." in captured.err
+    assert "Use include/exclude section or entry selection instead." in captured.err
+    assert after == before
+
+
 def test_versions_derive_reports_missing_master(capsys: pytest.CaptureFixture[str], tmp_path):
     store_path = tmp_path / "open-cvn.sqlite"
     initialize_store(store_path)

--- a/tests/test_open_cvn_app_editing_unit.py
+++ b/tests/test_open_cvn_app_editing_unit.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from open_cvn_app.editing import list_curriculum_entries, list_curriculum_sections
+from open_cvn_app.storage import (
+    CurriculumCreate,
+    CurriculumRepository,
+    InvalidSelectionRule,
+    initialize_store,
+)
+
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples" / "open_cvn"
+
+
+def _load_example(name: str) -> dict:
+    return json.loads((EXAMPLES_DIR / name).read_text(encoding="utf-8"))
+
+
+def _repository_with_document(tmp_path: Path, document: dict):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    curriculum = repository.create_curriculum(CurriculumCreate(display_name="Master CV", document=document))
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+    return repository
+
+
+def test_lists_curriculum_sections_for_materialized_version(tmp_path: Path):
+    repository = _repository_with_document(tmp_path, _load_example("research_entry.json"))
+
+    sections = list_curriculum_sections(repository, "public")
+
+    research = next(section for section in sections if section.name == "research")
+    identity = next(section for section in sections if section.name == "identity")
+    assert research.pointer == "/curriculum/research"
+    assert research.entry_count == 1
+    assert identity.value_kind == "object"
+    assert identity.entry_count is None
+
+
+def test_lists_entries_with_stable_display_identifiers(tmp_path: Path):
+    repository = _repository_with_document(tmp_path, _load_example("research_entry.json"))
+
+    entries = list_curriculum_entries(repository, "public", "research")
+
+    assert len(entries) == 1
+    assert entries[0].index == 0
+    assert entries[0].pointer == "/curriculum/research/0"
+    assert entries[0].entry_id == "research-001"
+    assert entries[0].entry_type == "research.publication"
+    assert entries[0].summary == "title=Open CVN data representation; publication_year=2026"
+    assert entries[0].cvn_codes == ("060.010.010.000",)
+
+
+def test_lists_entries_with_missing_id_fallback(tmp_path: Path):
+    document = _load_example("research_entry.json")
+    document = deepcopy(document)
+    del document["curriculum"]["research"][0]["id"]
+    repository = _repository_with_document(tmp_path, document)
+
+    entries = list_curriculum_entries(repository, "public", "/curriculum/research")
+
+    assert entries[0].entry_id is None
+    assert entries[0].pointer == "/curriculum/research/0"
+
+
+def test_entry_listing_reports_empty_and_non_list_sections(tmp_path: Path):
+    repository = _repository_with_document(tmp_path, _load_example("education_entry.json"))
+
+    assert list_curriculum_entries(repository, "public", "research") == ()
+    with pytest.raises(InvalidSelectionRule, match="not a repeated entry list"):
+        list_curriculum_entries(repository, "public", "identity")
+
+
+def test_updates_derived_metadata_and_materializes_extension(tmp_path: Path):
+    repository = _repository_with_document(tmp_path, _load_example("research_entry.json"))
+
+    version = repository.update_version_metadata(
+        "public",
+        display_name="Public CV",
+        purpose="grant application",
+    )
+    materialized = repository.materialize_version("public")
+
+    assert version.selection.metadata == {
+        "display_name": "Public CV",
+        "purpose": "grant application",
+    }
+    assert materialized.document["extensions"]["x-open-cvn.versioning"]["metadata"] == {
+        "display_name": "Public CV",
+        "purpose": "grant application",
+    }
+    assert materialized.validation_status == "valid"
+
+
+def test_selection_edits_preserve_derived_metadata(tmp_path: Path):
+    repository = _repository_with_document(tmp_path, _load_example("research_entry.json"))
+    repository.update_version_metadata("public", display_name="Public CV", purpose="grant application")
+
+    repository.exclude_from_version("public", "/curriculum/research/0")
+    materialized = repository.materialize_version("public")
+
+    assert repository.get_version("public").selection.metadata == {
+        "display_name": "Public CV",
+        "purpose": "grant application",
+    }
+    assert materialized.document["extensions"]["x-open-cvn.versioning"]["metadata"] == {
+        "display_name": "Public CV",
+        "purpose": "grant application",
+    }
+
+
+def test_rejects_master_metadata_updates_and_invalid_sections(tmp_path: Path):
+    repository = _repository_with_document(tmp_path, _load_example("research_entry.json"))
+
+    with pytest.raises(InvalidSelectionRule, match="Master curriculum version metadata cannot be edited"):
+        repository.update_version_metadata("master", purpose="base")
+    with pytest.raises(InvalidSelectionRule, match="Curriculum section not found"):
+        list_curriculum_entries(repository, "public", "missing")


### PR DESCRIPTION
## Summary

- add section and entry listing commands for materialized curriculum versions
- add derived-version metadata editing for display name and purpose
- validate materialized derived JSON after include/exclude selection changes
- add explicit unsupported field-edit command with clear failure message
- update issue #65 documentation, roadmap, and current status

## Verification

- `uv run pytest -n auto tests/test_open_cvn_app_editing_unit.py -v`
- `uv run pytest -n auto tests/test_open_cvn_app_cli_unit.py -v`
- `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py -v`
- `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`
- `uv run pytest -n auto tests`
Short PR description:
Completes issue #65 by adding CLI-first curriculum section/entry discovery, derived metadata editing, immediate selection validation, unsupported field-edit messaging, tests, and persistent documentation updates.