### PR TITLE
feat: implement LaTeX export workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ Every new session should read these files in order before making changes:
 - setup and commands: `docs/development/setup.md`
 - complete regeneration workflow: `docs/development/regeneration_workflow.md`
 - parser workflow: `docs/development/parser_workflow.md`
+- LaTeX export workflow: `docs/development/latex_export_workflow.md`
 - code style and conventions: `docs/development/code_style.md`
 - documentation conventions: `docs/documentation/documentation_conventions.md`
 - old AGENTS content migration map:

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -138,8 +138,8 @@ files in order:
   authoritative record of the Open CVN JSON application import/export issue
 - `docs/roadmap/issues/issue-65-curriculum-editing-and-selection-mvp.md`:
   planned MVP editing and selection issue
-- `docs/roadmap/issues/issue-66-latex-export-from-open-cvn.md`: planned LaTeX
-  export issue
+- `docs/roadmap/issues/issue-66-latex-export-from-open-cvn.md`: authoritative
+  record of the LaTeX export issue
 - `docs/roadmap/issues/issue-67-pdf-generation-and-preview-handoff.md`: planned
   optional PDF generation issue
 - `docs/roadmap/issues/issue-68-application-mvp-tests-and-documentation.md`:
@@ -176,6 +176,8 @@ files in order:
   verification workflow
 - `docs/development/parser_workflow.md`: contributor guide for using and testing
   the public PDF/XML/JSON parser workflow
+- `docs/development/latex_export_workflow.md`: issue `#66` user workflow for
+  exporting stored Open CVN master or derived versions to LaTeX
 - `docs/development/code_style.md`: code style, typing, and conventions
 - `docs/documentation/documentation_conventions.md`: documentation taxonomy,
   cross-linking rules, and update protocol

--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -946,6 +946,43 @@
   - result: `418 passed in 801.95s (0:13:21)`
 - no new durable limitations were found
 
+### Issue `#66`
+
+- the LaTeX export from Open CVN issue is implemented under:
+  - `src/open_cvn_app/latex.py`
+  - `src/open_cvn_app/templates/latex/basic_cv.tex.jinja`
+  - `src/open_cvn_app/cli.py`
+- the existing LaTeX CLI placeholder is now functional:
+  - `open-cvn latex export OUTPUT [--store PATH] [--version NAME]`
+- LaTeX export uses `CurriculumRepository.materialize_version(...)`, so master
+  and derived versions share the existing versioning and selection behavior
+- Jinja is now a runtime dependency because LaTeX rendering is an application CLI
+  workflow
+- the initial MVP template renders version metadata, identity fields when present,
+  and non-empty education, research, professional experience, achievements, and
+  other sections
+- empty repeated sections are omitted by the MVP template
+- text values are escaped for common LaTeX-sensitive characters through the
+  `latex` Jinja filter implemented in `src/open_cvn_app/latex.py`
+- exported `.tex` files are deterministic, UTF-8 encoded, and end with one final
+  newline
+- PDF compilation remains deferred to issue `#67`
+- LaTeX export workflow documentation now exists at:
+  - `docs/development/latex_export_workflow.md`
+- targeted LaTeX and CLI verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_latex_unit.py tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `29 passed in 40.59s`
+- targeted storage, versioning, and editing regression verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py tests/test_open_cvn_app_editing_unit.py -v`
+  - result: `25 passed in 49.19s`
+- console-script smoke verification passed for store initialization, JSON import
+  as master, derived creation, derived selection exclusion, and derived LaTeX
+  export
+- full-suite verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `424 passed in 357.81s (0:05:57)`
+- no new durable limitations were found
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -957,7 +994,7 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#65`: issue `#66` LaTeX export from Open CVN
+- Next work item after issue `#66`: issue `#67` PDF generation and preview handoff
 - Epic `#60` has been expanded into issues `#61` through `#69`
 - MVP direction:
   - CLI-first local prototype
@@ -969,7 +1006,7 @@
   - optional PDF generation and preview handoff
   - application MVP tests and user documentation
   - post-MVP LLM-assisted import spike
-- Next implementation issue: `#66` LaTeX export from Open CVN
+- Next implementation issue: `#67` PDF generation and preview handoff
 
 ## Blocking Or Relevant Limitations
 

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -31,13 +31,13 @@ Agents should also read `AGENTS.md` before this file.
 - Current pipeline stage: structural generation, metadata normalization,
   semantic policy, domain generation, conceptual schema, Open CVN JSON format,
   parser/validator contract, CLI shell, local SQLite storage, master/derived
-  curriculum versioning, Open CVN JSON application import/export, and curriculum
-  editing/selection MVP completed
+  curriculum versioning, Open CVN JSON application import/export, curriculum
+  editing/selection MVP, and LaTeX export completed
 - Last documented issues: `#11`, `#12`, `#13`, `#14`, `#15`, `#16`, `#17`,
   `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, `#47`, `#48`, `#49`, `#50`,
-  `#61`, `#62`, `#63`, `#64`, and `#65`
+  `#61`, `#62`, `#63`, `#64`, `#65`, and `#66`
 - Latest documented hotfix records: `#3`, `#4`, `#5`, `#6`, `#7`, `#8`
-- Next planned issue: `#66`
+- Next planned issue: `#67`
 - Canonical source package: `docs/CvnXML_v1.4.3_2.1_17012025/`
 
 ## Documentation Map
@@ -118,8 +118,8 @@ Agents should also read `AGENTS.md` before this file.
   planned Open CVN JSON application import/export issue
 - `docs/roadmap/issues/issue-65-curriculum-editing-and-selection-mvp.md`:
   planned MVP editing and selection issue
-- `docs/roadmap/issues/issue-66-latex-export-from-open-cvn.md`: planned LaTeX
-  export issue
+- `docs/roadmap/issues/issue-66-latex-export-from-open-cvn.md`: authoritative
+  record of the LaTeX export issue
 - `docs/roadmap/issues/issue-67-pdf-generation-and-preview-handoff.md`: planned
   optional PDF generation issue
 - `docs/roadmap/issues/issue-68-application-mvp-tests-and-documentation.md`:
@@ -155,6 +155,8 @@ Agents should also read `AGENTS.md` before this file.
   verification workflow
 - `docs/development/parser_workflow.md`: contributor guide for using and testing
   the public PDF/XML/JSON parser workflow
+- `docs/development/latex_export_workflow.md`: issue `#66` workflow for exporting
+  stored Open CVN master or derived versions to LaTeX
 - `docs/development/code_style.md`: code style, typing, and documentation rules
 - `docs/documentation/documentation_conventions.md`: documentation taxonomy and
   update protocol

--- a/docs/development/latex_export_workflow.md
+++ b/docs/development/latex_export_workflow.md
@@ -1,0 +1,87 @@
+# LaTeX Export Workflow
+
+## Purpose
+
+This document describes the issue `#66` MVP workflow for exporting stored Open CVN
+curriculum versions to LaTeX.
+
+The export path is intentionally simple. It proves that a validated Open CVN JSON
+document can be stored, materialized as a master or derived version, and rendered
+to a deterministic `.tex` file.
+
+## Command
+
+Export the master version:
+
+```bash
+uv run open-cvn latex export cv.tex --store open-cvn.sqlite --version master
+```
+
+Export a derived version:
+
+```bash
+uv run open-cvn latex export public-cv.tex --store open-cvn.sqlite --version public
+```
+
+The command writes UTF-8 LaTeX text and creates parent directories for the output
+path when needed.
+
+## Input Source
+
+LaTeX export reads stored curriculum versions through
+`CurriculumRepository.materialize_version(...)`.
+
+This means:
+
+- master export renders the stored master curriculum
+- derived export renders the materialized selection state
+- include/exclude edits made through `open-cvn versions include` and
+  `open-cvn versions exclude` are reflected in the `.tex` output
+- Open CVN validation still runs during version materialization
+
+## Template
+
+The initial template lives at:
+
+```text
+src/open_cvn_app/templates/latex/basic_cv.tex.jinja
+```
+
+It renders:
+
+- version metadata
+- identity fields when present
+- non-empty education entries
+- non-empty research entries
+- non-empty professional experience entries
+- non-empty achievement entries
+- non-empty other entries
+
+Empty repeated sections are omitted in the MVP template.
+
+## Escaping
+
+Text values are escaped before insertion into LaTeX through the `latex` Jinja
+filter implemented in `src/open_cvn_app/latex.py`.
+
+The MVP escaping covers common LaTeX-sensitive characters:
+
+```text
+\ { } $ & # % _ ~ ^
+```
+
+## Determinism
+
+The renderer avoids timestamps, random identifiers, and local absolute paths in
+the generated `.tex` content.
+
+Nested Open CVN values rendered as JSON use sorted keys. Exported files end with
+one final newline.
+
+## Limitations
+
+The issue `#66` template is not a final CV design. It is a deterministic technical
+proof for the export workflow.
+
+PDF compilation, TeX engine discovery, and preview handoff are deferred to issue
+`#67`.

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -51,7 +51,7 @@ Goal:
 | `#63` | Master and derived curriculum versions | Completed | Schema v2 migration, master/derived repository operations, selection materialization, CLI commands, and tests implemented |
 | `#64` | Open CVN JSON import/export workflow | Completed | CLI JSON import/export implemented using the public parser/validator, SQLite storage, master/derived materialization, deterministic export formatting, and tests |
 | `#65` | Curriculum editing and selection MVP | Completed | Section/entry listing, derived metadata, immediate selection validation, unsupported field-edit messaging, and tests implemented |
-| `#66` | LaTeX export from Open CVN | Planned | Jinja-style LaTeX rendering from stored Open CVN data |
+| `#66` | LaTeX export from Open CVN | Completed | Jinja-based deterministic `.tex` export from stored master or derived Open CVN versions implemented |
 | `#67` | PDF generation and preview handoff | Planned | Optional local TeX compilation and generated-PDF path handoff |
 | `#68` | Application MVP tests and documentation | Planned | End-to-end MVP tests, user docs, and epic `#60` closure |
 | `#69` | LLM-assisted import spike | Planned | Post-MVP exploration for PDFs without deterministic XML extraction |

--- a/docs/roadmap/issues/issue-66-latex-export-from-open-cvn.md
+++ b/docs/roadmap/issues/issue-66-latex-export-from-open-cvn.md
@@ -39,6 +39,258 @@ first template should prioritize correctness and stable output over visual polis
 6. add deterministic rendering tests using example Open CVN JSON
 7. document template limitations and customization points
 
+## Detailed Execution Plan
+
+This plan is the accepted execution plan for implementing issue `#66`.
+During execution, each work update must identify the active task and, when
+applicable, the active subtask. Each task or subtask update should include:
+
+- initial summary of the task or subtask goal
+- current task and subtask identifier
+- whether the user must modify any file manually
+- next step to follow
+
+Unless explicitly requested otherwise, code edits are expected to be performed by
+the user. Documentation edits may be applied when the user asks to establish or
+update the issue plan.
+
+### Task 1 - Confirm Scope And Constraints
+
+- Subtask 1.1: confirm issue `#66` only exports LaTeX from stored Open CVN
+  curriculum versions.
+- Subtask 1.2: confirm the exported source document must come from
+  `CurriculumRepository.materialize_version(...)`.
+- Subtask 1.3: confirm master and derived versions are both supported through the
+  existing `--version` CLI option.
+- Subtask 1.4: confirm issue `#66` writes `.tex` only and does not compile PDFs.
+- Subtask 1.5: confirm PDF generation and preview behavior remain deferred to
+  issue `#67`.
+- Subtask 1.6: confirm the MVP template prioritizes correctness, deterministic
+  output, and testability over visual polish.
+- Subtask 1.7: confirm trace metadata is omitted by default unless a later
+  explicit option is added.
+- Subtask 1.8: confirm `src/generated/` remains untouched.
+
+Expected output: final implementation boundary for issue `#66` before code work.
+
+### Task 2 - Add Template Dependency
+
+- Subtask 2.1: add `jinja2>=3.1` to runtime project dependencies in
+  `pyproject.toml`.
+- Subtask 2.2: keep Jinja as a runtime dependency because LaTeX export is a user
+  application command, not a test-only or code-generation workflow.
+- Subtask 2.3: synchronize the environment with
+  `uv sync --group codegen --group testing`.
+- Subtask 2.4: verify the dependency can be imported from the project
+  environment.
+
+Expected output: Jinja is available to the application CLI and tests.
+
+### Task 3 - Define LaTeX Export Module Contract
+
+- Subtask 3.1: create `src/open_cvn_app/latex.py` for hand-maintained LaTeX export
+  logic.
+- Subtask 3.2: define a small render API such as
+  `render_latex_document(document, version_name: str) -> str`.
+- Subtask 3.3: define an export helper such as
+  `export_latex_document(repository, version, output_path)` if it keeps CLI code
+  simpler.
+- Subtask 3.4: define small dataclasses only when they make template context or
+  CLI results clearer.
+- Subtask 3.5: avoid adding a broad export framework until multiple template
+  families or formats require it.
+
+Expected output: focused module boundary for rendering and writing LaTeX without
+duplicating storage behavior.
+
+### Task 4 - Implement LaTeX Escaping
+
+- Subtask 4.1: implement `escape_latex(value: object) -> str`.
+- Subtask 4.2: convert `None` to an empty string.
+- Subtask 4.3: convert scalar non-string values with `str(...)`.
+- Subtask 4.4: escape LaTeX-sensitive characters including backslash, braces,
+  dollar, ampersand, hash, percent, underscore, tilde, and caret.
+- Subtask 4.5: register `escape_latex(...)` as a Jinja filter, for example
+  `latex`.
+- Subtask 4.6: add direct unit tests for escaping representative special
+  characters.
+
+Expected output: template variables can be safely rendered into basic LaTeX text
+without obvious syntax breakage from user data.
+
+### Task 5 - Build Deterministic Template Context
+
+- Subtask 5.1: convert the Open CVN JSON root into a stable template context.
+- Subtask 5.2: include `schema_version`, document language, `version_name`, and
+  version metadata when present.
+- Subtask 5.3: convert `curriculum.identity` object values into deterministic
+  label/value rows.
+- Subtask 5.4: convert repeated curriculum sections into section records with
+  section name, display title, and entry rows.
+- Subtask 5.5: cover MVP sections `education`, `research`,
+  `professional_experience`, `achievements`, and `other`.
+- Subtask 5.6: preserve source order from the Open CVN JSON document where
+  possible.
+- Subtask 5.7: for entry `data`, render simple scalar fields directly and use
+  deterministic JSON serialization for nested values.
+- Subtask 5.8: avoid heavy semantic relabeling heuristics in this issue.
+
+Expected output: templates receive simple, deterministic structures and do not
+need to understand raw Open CVN JSON deeply.
+
+### Task 6 - Add MVP LaTeX Template
+
+- Subtask 6.1: create template directory under
+  `src/open_cvn_app/templates/latex/`.
+- Subtask 6.2: add `basic_cv.tex.jinja` as the initial package template.
+- Subtask 6.3: use common LaTeX packages only, avoiding rare dependencies that
+  would complicate issue `#67` PDF compilation.
+- Subtask 6.4: render a document title from identity data when available and use a
+  deterministic fallback otherwise.
+- Subtask 6.5: render version metadata near the top of the document.
+- Subtask 6.6: render identity fields when present.
+- Subtask 6.7: render non-empty repeated sections with stable headings and entry
+  lists.
+- Subtask 6.8: decide and test a stable empty-section behavior, either omission or
+  a fixed placeholder.
+
+Expected output: a simple `.tex` document template proves the export path without
+committing to final visual design.
+
+### Task 7 - Configure Jinja Environment
+
+- Subtask 7.1: load templates with `PackageLoader("open_cvn_app",
+  "templates/latex")` or an equivalent package-safe loader.
+- Subtask 7.2: set `autoescape=False` because HTML autoescaping is not suitable
+  for LaTeX output.
+- Subtask 7.3: set `trim_blocks=True`, `lstrip_blocks=True`, and
+  `keep_trailing_newline=True` for deterministic whitespace.
+- Subtask 7.4: use `StrictUndefined` so missing template fields fail during tests
+  instead of silently producing incomplete output.
+- Subtask 7.5: register the LaTeX escaping filter before loading templates.
+
+Expected output: rendering environment is deterministic and fails clearly on
+template/context mismatches.
+
+### Task 8 - Write Deterministic `.tex` Output
+
+- Subtask 8.1: implement a text writing helper that creates parent directories.
+- Subtask 8.2: write UTF-8 output.
+- Subtask 8.3: normalize the rendered document to exactly one final newline.
+- Subtask 8.4: avoid timestamps, random identifiers, local absolute paths, or
+  other nondeterministic data inside rendered LaTeX.
+- Subtask 8.5: convert `OSError` failures into user-readable CLI errors.
+
+Expected output: repeated exports from the same stored version produce identical
+`.tex` files.
+
+### Task 9 - Implement CLI LaTeX Export Command
+
+- Subtask 9.1: replace the issue `#66` placeholder in `_handle_latex_export(...)`.
+- Subtask 9.2: keep existing CLI shape:
+  `open-cvn latex export OUTPUT [--store PATH] [--version NAME]`.
+- Subtask 9.3: resolve the local store path through `OpenCvnAppConfig`.
+- Subtask 9.4: materialize the requested version through
+  `CurriculumRepository.materialize_version(...)`.
+- Subtask 9.5: render the materialized document through the LaTeX module.
+- Subtask 9.6: write the output file with deterministic formatting.
+- Subtask 9.7: report successful output path, version name, and validation
+  status.
+- Subtask 9.8: report storage, render, and write failures as
+  `AppResult.failed("LaTeX export failed.", error=str(exc))` or an equally
+  specific message.
+
+Expected output: users can export master or derived stored versions to `.tex`
+from the existing CLI command group.
+
+### Task 10 - Add LaTeX Rendering Unit Tests
+
+- Subtask 10.1: create `tests/test_open_cvn_app_latex_unit.py`.
+- Subtask 10.2: test `escape_latex(...)` with representative LaTeX-sensitive
+  characters.
+- Subtask 10.3: test rendering of `tests/fixtures/open_cvn/valid_minimal.json`.
+- Subtask 10.4: test rendering of at least one richer example under
+  `examples/open_cvn/`, such as `research_entry.json`.
+- Subtask 10.5: assert deterministic rendering by comparing exact text or stable
+  key slices where full snapshots would be too brittle.
+- Subtask 10.6: assert rendered text ends with one final newline.
+
+Expected output: rendering behavior is covered independently from CLI and storage
+plumbing.
+
+### Task 11 - Add CLI LaTeX Export Tests
+
+- Subtask 11.1: update the previous LaTeX placeholder CLI test so it expects real
+  export behavior.
+- Subtask 11.2: test exporting the master version from a temporary initialized
+  store.
+- Subtask 11.3: assert the command exits with code `0`.
+- Subtask 11.4: assert the output `.tex` file exists and contains expected stable
+  LaTeX markers.
+- Subtask 11.5: assert successful CLI output includes version name, output path,
+  and validation status.
+- Subtask 11.6: test exporting a derived version after a selection change and
+  verify the rendered content reflects materialized derived data.
+- Subtask 11.7: test missing version failure.
+- Subtask 11.8: test nested output parent directory creation.
+
+Expected output: CLI tests prove the full storage-to-materialized-version-to-tex
+workflow.
+
+### Task 12 - Run Console Smoke Workflow
+
+- Subtask 12.1: initialize a temporary store under `/tmp/opencode/`.
+- Subtask 12.2: import an Open CVN JSON example as the master version.
+- Subtask 12.3: create a derived version.
+- Subtask 12.4: apply at least one include/exclude selection to the derived
+  version.
+- Subtask 12.5: export the derived version to `.tex` through the console script.
+- Subtask 12.6: inspect command output and generated file existence.
+
+Expected output: console-script smoke proves the installed `open-cvn` entry point
+works outside pytest helpers.
+
+### Task 13 - Verify Test Suite
+
+- Subtask 13.1: run targeted LaTeX and CLI tests while developing.
+- Subtask 13.2: run storage, versioning, and editing regression tests after CLI
+  integration.
+- Subtask 13.3: run full repository verification with
+  `uv run pytest -n auto tests`.
+- Subtask 13.4: document any failure that cannot be fixed in the same session with
+  cause, affected command, and follow-up.
+
+Expected output: issue `#66` changes are verified against targeted behavior and
+repository regression coverage.
+
+### Task 14 - Update Persistent Documentation
+
+- Subtask 14.1: update this issue document with implementation notes,
+  verification results, deviations, and final status.
+- Subtask 14.2: update `docs/context/current_status.md` with issue `#66` outcome.
+- Subtask 14.3: update user-facing workflow documentation for the LaTeX export
+  command, creating a focused document only if no suitable app workflow document
+  exists.
+- Subtask 14.4: update `docs/pipeline/known_limitations.md` only if LaTeX export
+  uncovers a durable limitation.
+- Subtask 14.5: update `docs/roadmap/cvn_generation_roadmap.md` if issue status
+  changes there.
+
+Expected output: repository documentation remains aligned with the implemented
+LaTeX export workflow.
+
+### Acceptance Criteria
+
+- Stored master curriculum version renders to `.tex`.
+- Stored derived curriculum version renders materialized selection state to
+  `.tex`.
+- LaTeX-sensitive text values are escaped.
+- Output is deterministic and ends with a final newline.
+- Existing CLI command shape remains stable.
+- Missing store, missing version, render, and write failures report clear errors.
+- Tests cover escaping, rendering, CLI export, and derived-version behavior.
+- Full repository verification passes or any failure is documented with cause.
+
 ## Expected Output
 
 - LaTeX template file or files
@@ -54,10 +306,60 @@ first template should prioritize correctness and stable output over visual polis
 - LaTeX escaping prevents obvious broken output for special characters
 - full repository verification passes or a reason is documented
 
+## Implementation Notes
+
+- Added runtime `jinja2>=3.1` dependency for application LaTeX rendering.
+- Added package data configuration so LaTeX templates are included with
+  `open_cvn_app`.
+- Implemented LaTeX rendering in `src/open_cvn_app/latex.py`.
+- Added initial template at
+  `src/open_cvn_app/templates/latex/basic_cv.tex.jinja`.
+- Replaced the issue `#66` CLI placeholder with functional
+  `open-cvn latex export OUTPUT [--store PATH] [--version NAME]` behavior.
+- The CLI uses `CurriculumRepository.materialize_version(...)`, so master and
+  derived exports share the existing versioning and selection behavior.
+- Empty repeated sections are omitted by the MVP template.
+- Trace metadata remains omitted by default.
+- PDF compilation remains deferred to issue `#67`.
+
+## Implemented Artifacts
+
+- `src/open_cvn_app/latex.py`
+- `src/open_cvn_app/templates/latex/basic_cv.tex.jinja`
+- `src/open_cvn_app/cli.py`
+- `tests/test_open_cvn_app_latex_unit.py`
+- `tests/test_open_cvn_app_cli_unit.py`
+- `docs/development/latex_export_workflow.md`
+- `pyproject.toml`
+
+## Implemented Verification
+
+- Dependency synchronization and targeted LaTeX/CLI verification passed with:
+  - `uv sync --group codegen --group testing`
+  - `uv run pytest -n auto tests/test_open_cvn_app_latex_unit.py tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `29 passed in 40.59s`
+- Storage, versioning, and editing regression verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py tests/test_open_cvn_app_editing_unit.py -v`
+  - result: `25 passed in 49.19s`
+- Console-script smoke verification passed for store initialization, JSON import
+  as master, derived creation, derived selection exclusion, and derived LaTeX
+  export.
+- Full-suite verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `424 passed in 357.81s (0:05:57)`
+
+## Implementation Deviations
+
+- The accepted plan allowed adding a focused workflow document if no suitable app
+  workflow document existed; `docs/development/latex_export_workflow.md` was added
+  for that purpose.
+- No new durable pipeline limitation was found, so
+  `docs/pipeline/known_limitations.md` was not changed.
+
 ## Impact On Later Issues
 
 - issue `#67` compiles `.tex` output into PDF when a local TeX engine exists
 
 ## Status
 
-- Status: planned
+- Status: completed

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-65-curriculum-editing-and-selection-mvp.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 65. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-66-latex-export-from-open-cvn.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 66. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-65-curriculum-editing-and-selection-mvp.md
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-66-latex-export-from-open-cvn.md
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
+    "jinja2>=3.1",
     "jsonschema>=4.26",
     "pydantic>=2.12.5",
     "pymupdf>=1.26",
@@ -32,3 +33,6 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+open_cvn_app = ["templates/latex/*.jinja"]

--- a/src/open_cvn_app/cli.py
+++ b/src/open_cvn_app/cli.py
@@ -10,6 +10,7 @@ from open_cvn import CvnParseIssue, CvnValidationStatus, parse_open_cvn_json
 from open_cvn_app import __version__
 from open_cvn_app.config import OpenCvnAppConfig
 from open_cvn_app.editing import list_curriculum_entries, list_curriculum_sections
+from open_cvn_app.latex import export_latex_document
 from open_cvn_app.results import AppResult
 from open_cvn_app.storage import (
     SCHEMA_VERSION,
@@ -435,7 +436,25 @@ def _handle_versions_field_edit(args: argparse.Namespace) -> AppResult:
 
 
 def _handle_latex_export(args: argparse.Namespace) -> AppResult:
-    return _planned_result("LaTeX export", "#66", args)
+    repository = _repository_from_args(args)
+    try:
+        result = export_latex_document(
+            repository,
+            version=args.version_name,
+            output_path=args.output,
+        )
+    except StorageError as exc:
+        return AppResult.failed("LaTeX export failed.", error=str(exc))
+    except OSError as exc:
+        return AppResult.failed("LaTeX export failed.", error=str(exc))
+    return AppResult.ok(
+        "\n".join(
+            (
+                f"Exported LaTeX version '{result.version_name}' to {result.output_path}.",
+                f"Validation status: {result.validation_status}",
+            )
+        )
+    )
 
 
 def _handle_pdf_generate(args: argparse.Namespace) -> AppResult:

--- a/src/open_cvn_app/latex.py
+++ b/src/open_cvn_app/latex.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, PackageLoader, StrictUndefined
+
+from open_cvn_app.storage import CurriculumRepository
+
+
+SECTION_TITLES = {
+    "education": "Education",
+    "research": "Research",
+    "professional_experience": "Professional Experience",
+    "achievements": "Achievements",
+    "other": "Other",
+}
+
+SUMMARY_KEYS = ("title", "degree_name", "project_title", "name")
+
+
+@dataclass(frozen=True)
+class LatexField:
+    label: str
+    value: str
+
+
+@dataclass(frozen=True)
+class LatexEntry:
+    entry_id: str | None
+    entry_type: str | None
+    summary: str | None
+    fields: tuple[LatexField, ...]
+
+
+@dataclass(frozen=True)
+class LatexSection:
+    name: str
+    title: str
+    entries: tuple[LatexEntry, ...]
+
+
+@dataclass(frozen=True)
+class LatexExportResult:
+    output_path: Path
+    version_name: str
+    validation_status: str
+
+
+def escape_latex(value: object) -> str:
+    if value is None:
+        return ""
+    replacements = {
+        "\\": r"\textbackslash{}",
+        "{": r"\{",
+        "}": r"\}",
+        "$": r"\$",
+        "&": r"\&",
+        "#": r"\#",
+        "%": r"\%",
+        "_": r"\_",
+        "~": r"\textasciitilde{}",
+        "^": r"\textasciicircum{}",
+    }
+    return "".join(replacements.get(char, char) for char in str(value))
+
+
+def render_latex_document(document: Mapping[str, Any], *, version_name: str) -> str:
+    template = _environment().get_template("basic_cv.tex.jinja")
+    rendered = template.render(_template_context(document, version_name=version_name))
+    return _normalize_final_newline(rendered)
+
+
+def export_latex_document(
+    repository: CurriculumRepository,
+    *,
+    version: str,
+    output_path: str | Path,
+) -> LatexExportResult:
+    materialized = repository.materialize_version(version)
+    path = Path(output_path)
+    rendered = render_latex_document(
+        materialized.document,
+        version_name=materialized.version.name,
+    )
+    _write_text(path, rendered)
+    return LatexExportResult(
+        output_path=path,
+        version_name=materialized.version.name,
+        validation_status=materialized.validation_status,
+    )
+
+
+def _environment() -> Environment:
+    environment = Environment(
+        loader=PackageLoader("open_cvn_app", "templates/latex"),
+        autoescape=False,
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+        undefined=StrictUndefined,
+    )
+    environment.filters["latex"] = escape_latex
+    return environment
+
+
+def _template_context(document: Mapping[str, Any], *, version_name: str) -> dict[str, Any]:
+    metadata = _mapping(document.get("metadata"))
+    curriculum = _mapping(document.get("curriculum"))
+    versioning = _versioning_metadata(document)
+    identity = _mapping(curriculum.get("identity"))
+    display_name = _display_name(identity)
+    return {
+        "title": display_name or "Open CVN Curriculum",
+        "schema_version": str(document.get("schema_version", "")),
+        "language": str(metadata.get("language", "")),
+        "version_name": str(versioning.get("version_name", version_name)),
+        "version_kind": str(versioning.get("version_kind", "unknown")),
+        "identity_fields": _identity_fields(identity),
+        "sections": _sections(curriculum),
+    }
+
+
+def _versioning_metadata(document: Mapping[str, Any]) -> Mapping[str, Any]:
+    extensions = _mapping(document.get("extensions"))
+    return _mapping(extensions.get("x-open-cvn.versioning"))
+
+
+def _display_name(identity: Mapping[str, Any]) -> str | None:
+    given_name = identity.get("given_name")
+    family_name = identity.get("family_name")
+    parts = [str(part) for part in (given_name, family_name) if part]
+    if parts:
+        return " ".join(parts)
+    name = identity.get("name")
+    return str(name) if name else None
+
+
+def _identity_fields(identity: Mapping[str, Any]) -> tuple[LatexField, ...]:
+    return tuple(
+        LatexField(label=_label(key), value=_format_value(value))
+        for key, value in identity.items()
+        if key != "trace" and _format_value(value)
+    )
+
+
+def _sections(curriculum: Mapping[str, Any]) -> tuple[LatexSection, ...]:
+    sections: list[LatexSection] = []
+    for name in ("education", "research", "professional_experience", "achievements", "other"):
+        value = curriculum.get(name)
+        if not isinstance(value, list) or not value:
+            continue
+        entries = tuple(_entry(entry) for entry in value)
+        sections.append(
+            LatexSection(
+                name=name,
+                title=SECTION_TITLES[name],
+                entries=entries,
+            )
+        )
+    return tuple(sections)
+
+
+def _entry(value: object) -> LatexEntry:
+    if not isinstance(value, Mapping):
+        return LatexEntry(entry_id=None, entry_type=None, summary=_format_value(value), fields=())
+    data = _mapping(value.get("data"))
+    return LatexEntry(
+        entry_id=_optional_string(value.get("id")),
+        entry_type=_optional_string(value.get("type")),
+        summary=_entry_summary(data),
+        fields=tuple(
+            LatexField(label=_label(key), value=_format_value(item))
+            for key, item in data.items()
+            if _format_value(item)
+        ),
+    )
+
+
+def _entry_summary(data: Mapping[str, Any]) -> str | None:
+    for key in SUMMARY_KEYS:
+        value = data.get(key)
+        if isinstance(value, str | int | float | bool):
+            return str(value)
+    for value in data.values():
+        if isinstance(value, str | int | float | bool):
+            return str(value)
+    return None
+
+
+def _format_value(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str | int | float | bool):
+        return str(value)
+    if isinstance(value, Mapping | Sequence) and not isinstance(value, str | bytes | bytearray):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(", ", ": "))
+    return str(value)
+
+
+def _label(value: object) -> str:
+    return str(value).replace("_", " ").title()
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _optional_string(value: object) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_normalize_final_newline(content), encoding="utf-8")
+
+
+def _normalize_final_newline(content: str) -> str:
+    return f"{content.rstrip(chr(10))}\n"

--- a/src/open_cvn_app/templates/latex/basic_cv.tex.jinja
+++ b/src/open_cvn_app/templates/latex/basic_cv.tex.jinja
@@ -1,0 +1,47 @@
+\documentclass[11pt,a4paper]{article}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage[margin=2.5cm]{geometry}
+\usepackage{hyperref}
+
+\title{ {{ title|latex }} }
+\author{}
+\date{}
+
+\begin{document}
+\maketitle
+
+\section*{Version Metadata}
+\begin{description}
+\item[Schema version] {{ schema_version|latex }}
+\item[Language] {{ language|latex }}
+\item[Version] {{ version_name|latex }}
+\item[Version kind] {{ version_kind|latex }}
+\end{description}
+
+{% if identity_fields %}
+\section*{Identity}
+\begin{description}
+{% for field in identity_fields %}
+\item[{{ field.label|latex }}] {{ field.value|latex }}
+{% endfor %}
+\end{description}
+{% endif %}
+
+{% for section in sections %}
+\section*{ {{ section.title|latex }} }
+{% for entry in section.entries %}
+\subsection*{ {{ entry.summary|default(entry.entry_type or entry.entry_id or "Entry", true)|latex }} }
+\begin{description}
+{% if entry.entry_id %}\item[ID] {{ entry.entry_id|latex }}
+{% endif %}
+{% if entry.entry_type %}\item[Type] {{ entry.entry_type|latex }}
+{% endif %}
+{% for field in entry.fields %}
+\item[{{ field.label|latex }}] {{ field.value|latex }}
+{% endfor %}
+\end{description}
+{% endfor %}
+{% endfor %}
+
+\end{document}

--- a/tests/test_open_cvn_app_cli_unit.py
+++ b/tests/test_open_cvn_app_cli_unit.py
@@ -387,12 +387,56 @@ def test_versions_derive_reports_missing_master(capsys: pytest.CaptureFixture[st
     assert "Master curriculum version has not been assigned." in captured.err
 
 
-def test_latex_export_routes_to_issue_66_placeholder(capsys: pytest.CaptureFixture[str]):
-    exit_code = run(["latex", "export", "cv.tex"])
+def test_latex_export_writes_master_tex(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path, curriculum = _create_store_with_curriculum(tmp_path)
+    repository = CurriculumRepository(store_path)
+    repository.assign_master_curriculum(curriculum.id)
+    output_path = tmp_path / "exports" / "cv.tex"
+
+    exit_code = run(["latex", "export", str(output_path), "--store", str(store_path), "--version", "master"])
 
     output = capsys.readouterr().out
+    exported_text = output_path.read_text(encoding="utf-8")
     assert exit_code == 0
-    assert "LaTeX export is planned for issue #66" in output
+    assert "Exported LaTeX version 'master'" in output
+    assert "Validation status: valid" in output
+    assert "\\documentclass[11pt,a4paper]{article}" in exported_text
+    assert "\\section*{Version Metadata}" in exported_text
+    assert exported_text.endswith("\n")
+
+
+def test_latex_export_writes_materialized_derived_tex(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    document = json.loads((EXAMPLES_DIR / "research_entry.json").read_text(encoding="utf-8"))
+    curriculum = repository.create_curriculum(CurriculumCreate(display_name="Master CV", document=document))
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+    repository.exclude_from_version("public", "/curriculum/research")
+    output_path = tmp_path / "public.tex"
+
+    exit_code = run(["latex", "export", str(output_path), "--store", str(store_path), "--version", "public"])
+
+    output = capsys.readouterr().out
+    exported_text = output_path.read_text(encoding="utf-8")
+    assert exit_code == 0
+    assert "Exported LaTeX version 'public'" in output
+    assert "\\item[Version] public" in exported_text
+    assert "Open CVN data representation" not in exported_text
+
+
+def test_latex_export_reports_missing_version(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    output_path = tmp_path / "missing.tex"
+
+    exit_code = run(["latex", "export", str(output_path), "--store", str(store_path), "--version", "missing"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "LaTeX export failed." in captured.err
+    assert "Curriculum version not found: missing" in captured.err
 
 
 def test_pdf_generate_routes_to_issue_67_placeholder(capsys: pytest.CaptureFixture[str]):

--- a/tests/test_open_cvn_app_latex_unit.py
+++ b/tests/test_open_cvn_app_latex_unit.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from open_cvn_app.latex import escape_latex, render_latex_document
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "open_cvn"
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples" / "open_cvn"
+
+
+def test_escape_latex_escapes_special_characters():
+    assert escape_latex("A&B_#%$ {x} ~ ^ \\") == (
+        r"A\&B\_\#\%\$ \{x\} \textasciitilde{} "
+        r"\textasciicircum{} \textbackslash{}"
+    )
+
+
+def test_render_latex_document_renders_minimal_document():
+    document = json.loads((FIXTURES_DIR / "valid_minimal.json").read_text(encoding="utf-8"))
+
+    rendered = render_latex_document(document, version_name="master")
+
+    assert rendered.startswith("\\documentclass[11pt,a4paper]{article}\n")
+    assert "\\section*{Version Metadata}" in rendered
+    assert "\\item[Schema version] 0.1.0" in rendered
+    assert "\\item[Version] master" in rendered
+    assert "\\section*{Research}" not in rendered
+    assert rendered.endswith("\n")
+    assert not rendered.endswith("\n\n")
+
+
+def test_render_latex_document_renders_research_entry():
+    document = json.loads((EXAMPLES_DIR / "research_entry.json").read_text(encoding="utf-8"))
+
+    rendered = render_latex_document(document, version_name="public")
+
+    assert "\\section*{ Research }" in rendered
+    assert "Open CVN data representation" in rendered
+    assert "\\item[ID] research-001" in rendered
+    assert "\\item[Type] research.publication" in rendered
+    assert "\\item[Publication Year] 2026" in rendered
+    assert r"UNESCO\_CODES" in rendered
+
+
+def test_render_latex_document_escapes_identity_values():
+    document = json.loads((EXAMPLES_DIR / "identity.json").read_text(encoding="utf-8"))
+    document["curriculum"]["identity"]["given_name"] = "Ana & Co_"
+
+    rendered = render_latex_document(document, version_name="master")
+
+    assert "Ana \\& Co\\_" in rendered

--- a/uv.lock
+++ b/uv.lock
@@ -408,6 +408,7 @@ name = "tfg-open-cvn-schema"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "jinja2" },
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pymupdf" },
@@ -425,6 +426,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
+    { name = "jinja2", specifier = ">=3.1" },
     { name = "jsonschema", specifier = ">=4.26" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pymupdf", specifier = ">=1.26" },


### PR DESCRIPTION
## Summary
- Add Jinja-based `.tex` export for stored Open CVN master and derived versions.
- Add deterministic LaTeX rendering, escaping, CLI integration, tests, and docs.
- Keep PDF compilation deferred to issue #67.
## Verification
- `uv run pytest -n auto tests/test_open_cvn_app_latex_unit.py tests/test_open_cvn_app_cli_unit.py -v`
- `uv run pytest -n auto tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py tests/test_open_cvn_app_editing_unit.py -v`
- `uv run pytest -n auto tests`
Closes #66