### PR TITLE
feat(app): add optional PDF generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ Every new session should read these files in order before making changes:
 - complete regeneration workflow: `docs/development/regeneration_workflow.md`
 - parser workflow: `docs/development/parser_workflow.md`
 - LaTeX export workflow: `docs/development/latex_export_workflow.md`
+- PDF generation workflow: `docs/development/pdf_generation_workflow.md`
 - code style and conventions: `docs/development/code_style.md`
 - documentation conventions: `docs/documentation/documentation_conventions.md`
 - old AGENTS content migration map:

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -178,6 +178,8 @@ files in order:
   the public PDF/XML/JSON parser workflow
 - `docs/development/latex_export_workflow.md`: issue `#66` user workflow for
   exporting stored Open CVN master or derived versions to LaTeX
+- `docs/development/pdf_generation_workflow.md`: issue `#67` user workflow for
+  optional PDF generation and preview handoff from stored curriculum versions
 - `docs/development/code_style.md`: code style, typing, and conventions
 - `docs/documentation/documentation_conventions.md`: documentation taxonomy,
   cross-linking rules, and update protocol

--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -2,7 +2,7 @@
 
 ## Status Date
 
-- Last updated: 2026-07-09
+- Last updated: 2026-07-10
 
 ## Completed Or Stabilized Work
 
@@ -983,6 +983,46 @@
   - result: `424 passed in 357.81s (0:05:57)`
 - no new durable limitations were found
 
+### Issue `#67`
+
+- the PDF generation and preview handoff issue is implemented under:
+  - `src/open_cvn_app/pdf.py`
+  - `src/open_cvn_app/cli.py`
+- the existing PDF CLI placeholder is now functional:
+  - `open-cvn pdf generate OUTPUT [--store PATH] [--version NAME] [--open]`
+- PDF generation uses `CurriculumRepository.materialize_version(...)`, so master
+  and derived versions share existing versioning and selection behavior
+- PDF generation reuses the issue `#66` LaTeX renderer and compiles the rendered
+  `.tex` document in an isolated temporary build directory
+- supported compiler discovery order is:
+  - `latexmk`
+  - `pdflatex`
+- `latexmk` is preferred for multi-pass compilation; `pdflatex` fallback runs two
+  passes
+- missing compiler behavior is structured and reports that one of `latexmk` or
+  `pdflatex` must be installed
+- compiler failures preserve command, return code, timeout status, stdout, and
+  stderr diagnostics
+- `--open` performs an explicit best-effort preview handoff through the platform
+  default viewer; automated tests mock this behavior
+- PDF generation workflow documentation now exists at:
+  - `docs/development/pdf_generation_workflow.md`
+- targeted PDF and CLI verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_pdf_unit.py tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `40 passed in 52.02s`
+- targeted storage, versioning, editing, and LaTeX regression verification passed
+  with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_latex_unit.py tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py tests/test_open_cvn_app_editing_unit.py -v`
+  - result: `29 passed in 45.92s`
+- console-script smoke verification passed through store initialization, JSON
+  import as master, derived creation, derived selection exclusion, and expected
+  missing-compiler PDF generation behavior because no `latexmk` or `pdflatex`
+  executable is installed in the local environment
+- full-suite verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `439 passed in 355.05s (0:05:55)`
+- no new durable limitations were found
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -994,7 +1034,8 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#66`: issue `#67` PDF generation and preview handoff
+- Next work item after issue `#67`: issue `#68` application MVP tests and
+  documentation
 - Epic `#60` has been expanded into issues `#61` through `#69`
 - MVP direction:
   - CLI-first local prototype
@@ -1006,7 +1047,7 @@
   - optional PDF generation and preview handoff
   - application MVP tests and user documentation
   - post-MVP LLM-assisted import spike
-- Next implementation issue: `#67` PDF generation and preview handoff
+- Next implementation issue: `#68` application MVP tests and documentation
 
 ## Blocking Or Relevant Limitations
 

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -157,6 +157,8 @@ Agents should also read `AGENTS.md` before this file.
   the public PDF/XML/JSON parser workflow
 - `docs/development/latex_export_workflow.md`: issue `#66` workflow for exporting
   stored Open CVN master or derived versions to LaTeX
+- `docs/development/pdf_generation_workflow.md`: issue `#67` workflow for optional
+  PDF generation and preview handoff from stored curriculum versions
 - `docs/development/code_style.md`: code style, typing, and documentation rules
 - `docs/documentation/documentation_conventions.md`: documentation taxonomy and
   update protocol

--- a/docs/development/latex_export_workflow.md
+++ b/docs/development/latex_export_workflow.md
@@ -78,10 +78,22 @@ the generated `.tex` content.
 Nested Open CVN values rendered as JSON use sorted keys. Exported files end with
 one final newline.
 
+## PDF Generation
+
+PDF compilation from generated LaTeX is implemented by issue `#67` and documented
+in:
+
+```text
+docs/development/pdf_generation_workflow.md
+```
+
+The PDF workflow remains optional because it depends on a local TeX distribution
+outside Python dependencies.
+
 ## Limitations
 
 The issue `#66` template is not a final CV design. It is a deterministic technical
 proof for the export workflow.
 
-PDF compilation, TeX engine discovery, and preview handoff are deferred to issue
-`#67`.
+The issue `#66` template is still not a final CV design. Issue `#67` compiles the
+generated source into PDF when `latexmk` or `pdflatex` is available.

--- a/docs/development/pdf_generation_workflow.md
+++ b/docs/development/pdf_generation_workflow.md
@@ -1,0 +1,112 @@
+# PDF Generation Workflow
+
+## Purpose
+
+This document describes the issue `#67` MVP workflow for compiling stored Open CVN
+curriculum versions from LaTeX into PDF.
+
+PDF generation is optional. The application can still import, store, edit, export
+JSON, and render LaTeX when no local TeX distribution is installed.
+
+## Command
+
+Generate a PDF for the master version:
+
+```bash
+uv run open-cvn pdf generate cv.pdf --store open-cvn.sqlite --version master
+```
+
+Generate a PDF for a derived version:
+
+```bash
+uv run open-cvn pdf generate public-cv.pdf --store open-cvn.sqlite --version public
+```
+
+Open the generated PDF with the platform default viewer after compilation:
+
+```bash
+uv run open-cvn pdf generate public-cv.pdf --store open-cvn.sqlite --version public --open
+```
+
+The `--open` handoff is explicit. Without it, the command reports the generated
+PDF path and does not launch a viewer.
+
+## Input Source
+
+PDF generation reads stored curriculum versions through
+`CurriculumRepository.materialize_version(...)`.
+
+This means:
+
+- master PDF generation renders the stored master curriculum
+- derived PDF generation renders the materialized selection state
+- include/exclude edits made through `open-cvn versions include` and
+  `open-cvn versions exclude` affect the PDF
+- Open CVN validation still runs during version materialization
+
+## Compilation Pipeline
+
+The PDF command reuses the issue `#66` LaTeX renderer. It writes a temporary
+`.tex` file in an isolated build directory, runs the selected TeX compiler, and
+copies the resulting PDF to the requested output path.
+
+Only the final PDF is intended to remain as a durable artifact. Auxiliary files
+such as `.aux`, `.log`, `.fls`, and `.fdb_latexmk` stay in the temporary build
+directory.
+
+## Compiler Discovery
+
+The discovery order is:
+
+1. `latexmk`
+2. `pdflatex`
+
+`latexmk` is preferred because it automates multi-pass LaTeX compilation.
+`pdflatex` is used as a fallback and runs two passes for basic references.
+
+The project does not install TeX as a Python dependency. Install a TeX
+distribution separately, for example TeX Live, MiKTeX, or MacTeX, and ensure
+`latexmk` or `pdflatex` is on `PATH`.
+
+## Missing Compiler Behavior
+
+When no supported compiler is installed, the command fails with structured output
+similar to:
+
+```text
+PDF generation unavailable.
+No supported TeX compiler found. Install one of: latexmk, pdflatex.
+```
+
+This is expected behavior for environments without TeX. It should not break the
+rest of the application workflow or automated tests.
+
+## Compiler Failure Diagnostics
+
+Compilation failures report:
+
+- command
+- return code
+- timeout status
+- captured stdout
+- captured stderr
+
+The CLI keeps these diagnostics user-readable while tests assert the structured
+diagnostic behavior.
+
+## Preview Handoff
+
+Preview handoff uses the platform default viewer through Python's `webbrowser`
+module and a local file URI.
+
+Limitations:
+
+- preview is best-effort and platform-dependent
+- automated tests mock preview behavior instead of opening real viewers
+- `--open` should not be used in unattended CI workflows
+
+## Verification
+
+Issue `#67` tests mock compiler discovery, compiler success, compiler failure,
+timeouts, missing compiler behavior, and preview handoff. A local TeX installation
+is not required for automated verification.

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -52,7 +52,7 @@ Goal:
 | `#64` | Open CVN JSON import/export workflow | Completed | CLI JSON import/export implemented using the public parser/validator, SQLite storage, master/derived materialization, deterministic export formatting, and tests |
 | `#65` | Curriculum editing and selection MVP | Completed | Section/entry listing, derived metadata, immediate selection validation, unsupported field-edit messaging, and tests implemented |
 | `#66` | LaTeX export from Open CVN | Completed | Jinja-based deterministic `.tex` export from stored master or derived Open CVN versions implemented |
-| `#67` | PDF generation and preview handoff | Planned | Optional local TeX compilation and generated-PDF path handoff |
+| `#67` | PDF generation and preview handoff | Completed | Optional `latexmk`/`pdflatex` compilation, structured missing-compiler behavior, mocked tests, and explicit `--open` preview handoff implemented |
 | `#68` | Application MVP tests and documentation | Planned | End-to-end MVP tests, user docs, and epic `#60` closure |
 | `#69` | LLM-assisted import spike | Planned | Post-MVP exploration for PDFs without deterministic XML extraction |
 

--- a/docs/roadmap/issues/issue-67-pdf-generation-and-preview-handoff.md
+++ b/docs/roadmap/issues/issue-67-pdf-generation-and-preview-handoff.md
@@ -40,6 +40,274 @@ rendered but no local TeX distribution is installed.
 7. add tests with mocked compiler behavior
 8. document installation requirements and fallback behavior
 
+## Detailed Execution Plan
+
+This plan is the accepted execution plan for implementing issue `#67`.
+During execution, each work update must identify the active task and, when
+applicable, the active subtask. Each task or subtask update should include:
+
+- initial summary of the task or subtask goal
+- current task and subtask identifier
+- whether the user must modify any file manually
+- next step to follow
+
+Unless explicitly requested otherwise, code edits are expected to be performed by
+the user. Documentation edits may be applied when the user asks to establish or
+update the issue plan.
+
+### Task 1 - Confirm Scope And Constraints
+
+- Subtask 1.1: confirm the CLI shape remains
+  `open-cvn pdf generate OUTPUT [--store PATH] [--version NAME] [--open]`.
+- Subtask 1.2: confirm PDF generation reads stored curriculum versions through
+  `CurriculumRepository.materialize_version(...)`.
+- Subtask 1.3: confirm the intermediate LaTeX source is rendered through the
+  existing issue `#66` LaTeX rendering path, not a separate template pipeline.
+- Subtask 1.4: confirm local TeX tooling remains optional and is not added as a
+  Python dependency.
+- Subtask 1.5: confirm a missing compiler returns a structured user-facing
+  failure rather than breaking unrelated workflows or tests.
+- Subtask 1.6: confirm preview handoff is disabled by default and only attempted
+  when `--open` is explicitly provided.
+- Subtask 1.7: confirm `src/generated/` remains untouched.
+
+Expected output: final implementation boundary for issue `#67` before code work.
+
+### Task 2 - Define PDF Generation Module Contract
+
+- Subtask 2.1: create `src/open_cvn_app/pdf.py` for hand-maintained PDF
+  generation logic.
+- Subtask 2.2: define small dataclasses for compiler discovery, compiler
+  diagnostics, compilation result, and PDF generation result when they keep CLI
+  handling clear.
+- Subtask 2.3: define focused exceptions such as `PdfGenerationUnavailable`,
+  `PdfCompilationError`, and `PdfPreviewError`.
+- Subtask 2.4: expose a compact public helper such as
+  `generate_pdf_document(repository, version, output_path, open_pdf=False)`.
+- Subtask 2.5: avoid creating a broad export framework until multiple PDF
+  backends or preview strategies require it.
+
+Expected output: focused module boundary for optional PDF generation without
+duplicating storage or LaTeX rendering behavior.
+
+### Task 3 - Implement TeX Compiler Discovery
+
+- Subtask 3.1: use `shutil.which("latexmk")` to detect `latexmk` first.
+- Subtask 3.2: use `shutil.which("pdflatex")` as the fallback compiler.
+- Subtask 3.3: return compiler name, executable path, and strategy information.
+- Subtask 3.4: keep discovery testable by allowing internal injection or
+  monkeypatching of the lookup function.
+- Subtask 3.5: return structured unavailable behavior when neither compiler is
+  found.
+
+Expected output: deterministic compiler selection that prefers `latexmk` and
+falls back to `pdflatex` without requiring either in test environments.
+
+### Task 4 - Implement Safe Compiler Invocation
+
+- Subtask 4.1: invoke external compilers with `subprocess.run(...)` and
+  `shell=False`.
+- Subtask 4.2: pass command arguments as a sequence, not a shell string.
+- Subtask 4.3: capture stdout and stderr with text output enabled.
+- Subtask 4.4: use a bounded timeout, for example 60 seconds, to avoid hanging
+  CLI calls.
+- Subtask 4.5: convert timeout failures into structured diagnostics.
+- Subtask 4.6: preserve the process environment while setting
+  `SOURCE_DATE_EPOCH=0` for more reproducible PDF metadata where supported.
+
+Expected output: compiler execution is safe, testable, bounded, and diagnostic.
+
+### Task 5 - Prepare Temporary Build Directory
+
+- Subtask 5.1: create the parent directory for the requested final PDF path.
+- Subtask 5.2: create an isolated temporary build directory for LaTeX source,
+  auxiliary files, logs, and compiler output.
+- Subtask 5.3: render the materialized curriculum to a `.tex` file inside the
+  build directory.
+- Subtask 5.4: compile from the build directory so `.aux`, `.log`, `.fls`, and
+  `.fdb_latexmk` files do not pollute user output directories.
+- Subtask 5.5: copy the generated PDF to the user-requested output path.
+- Subtask 5.6: leave only the final PDF as the durable artifact.
+
+Expected output: PDF generation does not leak transient compiler files into the
+working tree or requested output directory.
+
+### Task 6 - Implement `latexmk` Strategy
+
+- Subtask 6.1: compile with a command equivalent to
+  `latexmk -pdf -interaction=nonstopmode -halt-on-error -outdir BUILD_DIR TEX_FILE`.
+- Subtask 6.2: treat a non-zero return code as `PdfCompilationError`.
+- Subtask 6.3: include command, return code, stdout, and stderr in diagnostics.
+- Subtask 6.4: verify the expected PDF exists after a zero return code.
+- Subtask 6.5: report a structured error if the compiler succeeds but the PDF is
+  missing.
+
+Expected output: preferred compiler path supports normal multi-pass LaTeX
+documents through `latexmk`.
+
+### Task 7 - Implement `pdflatex` Fallback Strategy
+
+- Subtask 7.1: compile with a command equivalent to
+  `pdflatex -interaction=nonstopmode -halt-on-error -output-directory BUILD_DIR TEX_FILE`.
+- Subtask 7.2: run two passes to support basic references when `latexmk` is not
+  available.
+- Subtask 7.3: stop immediately when a pass fails.
+- Subtask 7.4: include per-pass stdout, stderr, command, and return code in
+  diagnostics.
+- Subtask 7.5: verify the expected PDF exists after successful passes.
+
+Expected output: common TeX installations without `latexmk` can still produce PDF
+artifacts.
+
+### Task 8 - Define Result And Diagnostic Behavior
+
+- Subtask 8.1: successful generation reports output path, version name,
+  validation status, and compiler name.
+- Subtask 8.2: missing compiler diagnostics name the searched commands:
+  `latexmk` and `pdflatex`.
+- Subtask 8.3: compiler failures preserve command, return code, stdout, and
+  stderr.
+- Subtask 8.4: CLI output keeps diagnostics concise enough for users while tests
+  can assert the structured data.
+- Subtask 8.5: avoid tracebacks for expected missing compiler or failed compiler
+  cases.
+
+Expected output: users receive actionable errors and tests can inspect precise
+failure causes.
+
+### Task 9 - Implement Preview Handoff
+
+- Subtask 9.1: add `--open` to `open-cvn pdf generate`.
+- Subtask 9.2: use a small preview helper around `webbrowser.open(...)` with a
+  file URI for the generated PDF.
+- Subtask 9.3: do not call preview behavior unless `--open` is explicitly set.
+- Subtask 9.4: return structured failure or diagnostic when preview handoff cannot
+  launch a viewer.
+- Subtask 9.5: mock preview behavior in tests instead of opening real viewers.
+
+Expected output: generated PDFs can be handed off to the platform default viewer
+without making preview part of automated test side effects.
+
+### Task 10 - Integrate PDF Command Into CLI
+
+- Subtask 10.1: replace the issue `#67` placeholder in `_handle_pdf_generate(...)`.
+- Subtask 10.2: keep existing command shape
+  `open-cvn pdf generate OUTPUT [--store PATH] [--version NAME]`.
+- Subtask 10.3: add the optional `--open` flag.
+- Subtask 10.4: resolve the local store through `OpenCvnAppConfig` and
+  `CurriculumRepository` as other app commands do.
+- Subtask 10.5: call the PDF generation helper and report successful output path,
+  version name, validation status, and compiler.
+- Subtask 10.6: catch storage, rendering, filesystem, missing compiler,
+  compilation, and preview failures as `AppResult.failed(...)` responses.
+
+Expected output: the existing `pdf generate` command becomes functional while
+remaining consistent with earlier CLI groups.
+
+### Task 11 - Add PDF Module Unit Tests
+
+- Subtask 11.1: create `tests/test_open_cvn_app_pdf_unit.py`.
+- Subtask 11.2: test compiler discovery prefers `latexmk` over `pdflatex`.
+- Subtask 11.3: test compiler discovery uses `pdflatex` when `latexmk` is absent.
+- Subtask 11.4: test missing compiler raises or returns structured unavailable
+  behavior.
+- Subtask 11.5: test mocked successful compilation creates or copies the expected
+  PDF output path.
+- Subtask 11.6: test compiler failure preserves stdout, stderr, command, and
+  return code.
+- Subtask 11.7: test timeout handling preserves useful diagnostics.
+- Subtask 11.8: test output parent directory creation.
+- Subtask 11.9: test `SOURCE_DATE_EPOCH` is included in the compiler environment.
+- Subtask 11.10: test preview handoff with a mocked opener.
+
+Expected output: PDF generation logic is covered without requiring a local TeX
+installation.
+
+### Task 12 - Add CLI PDF Tests
+
+- Subtask 12.1: replace the existing placeholder PDF CLI test with real behavior.
+- Subtask 12.2: test missing compiler CLI behavior with mocked discovery.
+- Subtask 12.3: test successful CLI PDF generation with mocked compiler execution.
+- Subtask 12.4: test derived-version PDF generation reflects materialized
+  selection state.
+- Subtask 12.5: test `--open` triggers mocked preview handoff.
+- Subtask 12.6: test missing version failure.
+- Subtask 12.7: test compiler failure reports useful diagnostics through stderr.
+- Subtask 12.8: ensure CLI tests do not depend on `latexmk`, `pdflatex`, or a real
+  PDF viewer being installed.
+
+Expected output: CLI coverage proves storage-to-LaTeX-to-PDF orchestration and
+optional preview behavior.
+
+### Task 13 - Run Optional Console Smoke Workflow
+
+- Subtask 13.1: initialize a temporary store under `/tmp/opencode/`.
+- Subtask 13.2: import an Open CVN JSON example as the master version.
+- Subtask 13.3: create a derived version.
+- Subtask 13.4: apply at least one include/exclude selection to the derived
+  version.
+- Subtask 13.5: run `open-cvn pdf generate` for the derived version without
+  `--open`.
+- Subtask 13.6: verify the generated PDF path exists when a compiler is available.
+- Subtask 13.7: if no compiler is available, record the expected missing compiler
+  behavior instead of treating it as a repository failure.
+
+Expected output: console-script smoke verifies installed CLI behavior when the
+local environment supports it, while preserving optional compiler semantics.
+
+### Task 14 - Update Persistent Documentation
+
+- Subtask 14.1: update this issue document with implementation notes,
+  implemented artifacts, verification results, deviations, and final status.
+- Subtask 14.2: create or update focused PDF workflow documentation under
+  `docs/development/`, such as `docs/development/pdf_generation_workflow.md`.
+- Subtask 14.3: document recommended TeX installation path: `latexmk` preferred,
+  `pdflatex` fallback, TeX distribution required outside Python dependencies.
+- Subtask 14.4: document master and derived PDF generation commands.
+- Subtask 14.5: document `--open` preview behavior and its limitations.
+- Subtask 14.6: document missing compiler fallback behavior.
+- Subtask 14.7: link the PDF workflow from `docs/development/latex_export_workflow.md`.
+- Subtask 14.8: update `docs/context/current_status.md` with issue `#67` outcome.
+- Subtask 14.9: update `docs/roadmap/cvn_generation_roadmap.md` if issue status
+  changes there.
+- Subtask 14.10: update `docs/pipeline/known_limitations.md` only if a new durable
+  limitation is found.
+- Subtask 14.11: update `PROJECT_GUIDE.md` only if the human-facing document map
+  changes.
+
+Expected output: repository documentation remains aligned with the implemented
+optional PDF generation workflow.
+
+### Task 15 - Verify Test Suite
+
+- Subtask 15.1: run targeted PDF and CLI tests with
+  `uv run pytest -n auto tests/test_open_cvn_app_pdf_unit.py tests/test_open_cvn_app_cli_unit.py -v`.
+- Subtask 15.2: run application regression tests covering LaTeX, storage,
+  versioning, and editing behavior.
+- Subtask 15.3: run full repository verification with
+  `uv run pytest -n auto tests`.
+- Subtask 15.4: document any failure that cannot be fixed in the same session with
+  cause, affected command, and follow-up.
+
+Expected output: issue `#67` changes are verified against targeted PDF behavior
+and repository regression coverage.
+
+### Acceptance Criteria
+
+- Stored master curriculum version generates a PDF when a supported compiler is
+  available.
+- Stored derived curriculum version generates a PDF from materialized selection
+  state.
+- Missing TeX compiler returns structured unsupported behavior and does not break
+  unrelated tests or workflows.
+- Compiler failures report command, return code, stdout, and stderr.
+- Existing CLI command shape remains stable, with `--open` added as an explicit
+  optional preview handoff.
+- Automated tests cover compiler discovery, missing compiler behavior, mocked
+  success, mocked failure, CLI generation, derived-version behavior, and preview
+  handoff without requiring a real TeX installation.
+- Full repository verification passes or any failure is documented with cause.
+
 ## Expected Output
 
 - PDF generation wrapper
@@ -59,6 +327,69 @@ rendered but no local TeX distribution is installed.
 - issue `#68` documents end-to-end MVP export workflow
 - future UI work can call this wrapper for preview/export actions
 
+## Implementation Notes
+
+- Added optional PDF generation logic in `src/open_cvn_app/pdf.py`.
+- Replaced the issue `#67` CLI placeholder with functional
+  `open-cvn pdf generate OUTPUT [--store PATH] [--version NAME] [--open]`
+  behavior.
+- PDF generation reads master or derived curriculum versions through
+  `CurriculumRepository.materialize_version(...)`.
+- PDF generation reuses the issue `#66` LaTeX renderer instead of adding a second
+  template pipeline.
+- Compiler discovery prefers `latexmk` and falls back to `pdflatex`.
+- `latexmk` uses one delegated multi-pass command; `pdflatex` fallback runs two
+  passes.
+- Compiler execution uses `subprocess.run(...)` with `shell=False`, captured
+  stdout/stderr, bounded timeout, and `SOURCE_DATE_EPOCH=0` in the compiler
+  environment.
+- Compilation happens in an isolated temporary directory so auxiliary TeX files do
+  not remain as durable output artifacts.
+- Missing compiler behavior is structured through `PdfGenerationUnavailable`.
+- Compiler failures preserve command, return code, timeout status, stdout, and
+  stderr through `CompilerRunDiagnostic`.
+- The explicit `--open` flag performs best-effort preview handoff through the
+  platform default viewer and is mocked in automated tests.
+
+## Implemented Artifacts
+
+- `src/open_cvn_app/pdf.py`
+- `src/open_cvn_app/cli.py`
+- `tests/test_open_cvn_app_pdf_unit.py`
+- `tests/test_open_cvn_app_cli_unit.py`
+- `docs/development/pdf_generation_workflow.md`
+- `docs/development/latex_export_workflow.md`
+- `docs/context/current_status.md`
+- `docs/roadmap/cvn_generation_roadmap.md`
+- `docs/context/project_context_index.md`
+- `PROJECT_GUIDE.md`
+- `AGENTS.md`
+
+## Implemented Verification
+
+- Targeted PDF and CLI verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_pdf_unit.py tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `40 passed in 52.02s`
+- Storage, versioning, editing, and LaTeX regression verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_latex_unit.py tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py tests/test_open_cvn_app_editing_unit.py -v`
+  - result: `29 passed in 45.92s`
+- Console-script smoke verification passed for store initialization, JSON import
+  as master, derived creation, derived selection exclusion, and expected
+  missing-compiler PDF generation behavior.
+- Local environment had neither `latexmk` nor `pdflatex` installed, so real PDF
+  compilation smoke was not executed.
+- Full-suite verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `439 passed in 355.05s (0:05:55)`
+
+## Implementation Deviations
+
+- The accepted plan allowed documenting the local TeX requirement and fallback
+  behavior; a focused `docs/development/pdf_generation_workflow.md` document was
+  added for that purpose.
+- No new durable pipeline limitation was found, so
+  `docs/pipeline/known_limitations.md` was not changed.
+
 ## Status
 
-- Status: planned
+- Status: completed

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-66-latex-export-from-open-cvn.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 66. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-67-pdf-generation-and-preview-handoff.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 67. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-66-latex-export-from-open-cvn.md
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-67-pdf-generation-and-preview-handoff.md
 
 
 

--- a/src/open_cvn_app/cli.py
+++ b/src/open_cvn_app/cli.py
@@ -11,6 +11,13 @@ from open_cvn_app import __version__
 from open_cvn_app.config import OpenCvnAppConfig
 from open_cvn_app.editing import list_curriculum_entries, list_curriculum_sections
 from open_cvn_app.latex import export_latex_document
+from open_cvn_app.pdf import (
+    PdfCompilationError,
+    PdfGenerationUnavailable,
+    PdfPreviewError,
+    format_compilation_diagnostics,
+    generate_pdf_document,
+)
 from open_cvn_app.results import AppResult
 from open_cvn_app.storage import (
     SCHEMA_VERSION,
@@ -144,6 +151,11 @@ def build_parser() -> argparse.ArgumentParser:
     pdf_subparsers = pdf_parser.add_subparsers(dest="pdf_command")
     pdf_generate_parser = pdf_subparsers.add_parser("generate", help="Generate PDF file.")
     pdf_generate_parser.add_argument("output", help="Output PDF file.")
+    pdf_generate_parser.add_argument(
+        "--open",
+        action="store_true",
+        help="Open the generated PDF with the platform default viewer.",
+    )
     _add_store_path_option(pdf_generate_parser)
     _add_version_option(pdf_generate_parser)
     pdf_generate_parser.set_defaults(handler=_handle_pdf_generate)
@@ -458,7 +470,35 @@ def _handle_latex_export(args: argparse.Namespace) -> AppResult:
 
 
 def _handle_pdf_generate(args: argparse.Namespace) -> AppResult:
-    return _planned_result("PDF generation", "#67", args)
+    repository = _repository_from_args(args)
+    try:
+        result = generate_pdf_document(
+            repository,
+            version=args.version_name,
+            output_path=args.output,
+            open_pdf=args.open,
+        )
+    except StorageError as exc:
+        return AppResult.failed("PDF generation failed.", error=str(exc))
+    except PdfGenerationUnavailable as exc:
+        return AppResult.failed("PDF generation unavailable.", error=str(exc))
+    except PdfCompilationError as exc:
+        return AppResult.failed(
+            "PDF generation failed.",
+            error="\n".join((str(exc), format_compilation_diagnostics(exc.diagnostics))),
+        )
+    except PdfPreviewError as exc:
+        return AppResult.failed("PDF preview failed.", error=str(exc))
+    except OSError as exc:
+        return AppResult.failed("PDF generation failed.", error=str(exc))
+    lines = [
+        f"Generated PDF version '{result.version_name}' to {result.output_path}.",
+        f"Validation status: {result.validation_status}",
+        f"Compiler: {result.compiler_name}",
+    ]
+    if result.preview_opened:
+        lines.append("Preview handoff: opened")
+    return AppResult.ok("\n".join(lines))
 
 
 def _repository_from_args(args: argparse.Namespace) -> CurriculumRepository:

--- a/src/open_cvn_app/pdf.py
+++ b/src/open_cvn_app/pdf.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import webbrowser
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from open_cvn_app.latex import render_latex_document
+from open_cvn_app.storage import CurriculumRepository
+
+
+DEFAULT_COMPILERS = ("latexmk", "pdflatex")
+DEFAULT_TIMEOUT_SECONDS = 60
+
+
+@dataclass(frozen=True)
+class TexCompiler:
+    name: str
+    executable: str
+
+
+@dataclass(frozen=True)
+class CompilerRunDiagnostic:
+    command: tuple[str, ...]
+    return_code: int | None
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+
+
+@dataclass(frozen=True)
+class PdfGenerationResult:
+    output_path: Path
+    version_name: str
+    validation_status: str
+    compiler_name: str
+    preview_opened: bool
+
+
+class PdfGenerationUnavailable(RuntimeError):
+    def __init__(self, searched_compilers: Sequence[str]) -> None:
+        self.searched_compilers = tuple(searched_compilers)
+        super().__init__(
+            "No supported TeX compiler found. "
+            f"Install one of: {', '.join(self.searched_compilers)}."
+        )
+
+
+class PdfCompilationError(RuntimeError):
+    def __init__(self, message: str, diagnostics: Sequence[CompilerRunDiagnostic]) -> None:
+        self.diagnostics = tuple(diagnostics)
+        super().__init__(message)
+
+
+class PdfPreviewError(RuntimeError):
+    pass
+
+
+CompilerLookup = Callable[[str], str | None]
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+PreviewOpener = Callable[[str], bool]
+
+
+def discover_tex_compiler(
+    *,
+    lookup: CompilerLookup = shutil.which,
+    compiler_order: Sequence[str] = DEFAULT_COMPILERS,
+) -> TexCompiler:
+    for compiler_name in compiler_order:
+        executable = lookup(compiler_name)
+        if executable:
+            return TexCompiler(name=compiler_name, executable=executable)
+    raise PdfGenerationUnavailable(compiler_order)
+
+
+def generate_pdf_document(
+    repository: CurriculumRepository,
+    *,
+    version: str,
+    output_path: str | Path,
+    open_pdf: bool = False,
+    compiler_lookup: CompilerLookup = shutil.which,
+    runner: Runner = subprocess.run,
+    preview_opener: PreviewOpener = webbrowser.open,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> PdfGenerationResult:
+    materialized = repository.materialize_version(version)
+    compiler = discover_tex_compiler(lookup=compiler_lookup)
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="open-cvn-pdf-") as build_dir_name:
+        build_dir = Path(build_dir_name)
+        tex_path = build_dir / f"{path.stem}.tex"
+        tex_path.write_text(
+            render_latex_document(materialized.document, version_name=materialized.version.name),
+            encoding="utf-8",
+        )
+        built_pdf = _compile_tex(
+            compiler,
+            tex_path,
+            build_dir=build_dir,
+            runner=runner,
+            timeout_seconds=timeout_seconds,
+        )
+        shutil.copyfile(built_pdf, path)
+
+    preview_opened = False
+    if open_pdf:
+        preview_opened = _open_pdf(path, opener=preview_opener)
+
+    return PdfGenerationResult(
+        output_path=path,
+        version_name=materialized.version.name,
+        validation_status=materialized.validation_status,
+        compiler_name=compiler.name,
+        preview_opened=preview_opened,
+    )
+
+
+def format_compilation_diagnostics(diagnostics: Sequence[CompilerRunDiagnostic]) -> str:
+    if not diagnostics:
+        return "-"
+    lines: list[str] = []
+    for index, diagnostic in enumerate(diagnostics, start=1):
+        lines.extend(
+            (
+                f"Run {index}:",
+                f"Command: {' '.join(diagnostic.command)}",
+                f"Return code: {diagnostic.return_code if diagnostic.return_code is not None else '-'}",
+                f"Timed out: {diagnostic.timed_out}",
+                f"Stdout: {_compact_output(diagnostic.stdout)}",
+                f"Stderr: {_compact_output(diagnostic.stderr)}",
+            )
+        )
+    return "\n".join(lines)
+
+
+def _compile_tex(
+    compiler: TexCompiler,
+    tex_path: Path,
+    *,
+    build_dir: Path,
+    runner: Runner,
+    timeout_seconds: int,
+) -> Path:
+    expected_pdf = build_dir / f"{tex_path.stem}.pdf"
+    diagnostics = (
+        _run_latexmk(compiler, tex_path, build_dir=build_dir, runner=runner, timeout_seconds=timeout_seconds)
+        if compiler.name == "latexmk"
+        else _run_pdflatex(compiler, tex_path, build_dir=build_dir, runner=runner, timeout_seconds=timeout_seconds)
+    )
+    failing = next((diagnostic for diagnostic in diagnostics if diagnostic.return_code != 0), None)
+    if failing is not None:
+        raise PdfCompilationError("PDF compilation failed.", diagnostics)
+    if not expected_pdf.exists():
+        raise PdfCompilationError("PDF compiler finished but did not create the expected PDF.", diagnostics)
+    return expected_pdf
+
+
+def _run_latexmk(
+    compiler: TexCompiler,
+    tex_path: Path,
+    *,
+    build_dir: Path,
+    runner: Runner,
+    timeout_seconds: int,
+) -> tuple[CompilerRunDiagnostic, ...]:
+    command = (
+        compiler.executable,
+        "-pdf",
+        "-interaction=nonstopmode",
+        "-halt-on-error",
+        "-outdir",
+        str(build_dir),
+        str(tex_path),
+    )
+    return (_run_compiler(command, build_dir=build_dir, runner=runner, timeout_seconds=timeout_seconds),)
+
+
+def _run_pdflatex(
+    compiler: TexCompiler,
+    tex_path: Path,
+    *,
+    build_dir: Path,
+    runner: Runner,
+    timeout_seconds: int,
+) -> tuple[CompilerRunDiagnostic, ...]:
+    command = (
+        compiler.executable,
+        "-interaction=nonstopmode",
+        "-halt-on-error",
+        "-output-directory",
+        str(build_dir),
+        str(tex_path),
+    )
+    diagnostics: list[CompilerRunDiagnostic] = []
+    for _ in range(2):
+        diagnostic = _run_compiler(command, build_dir=build_dir, runner=runner, timeout_seconds=timeout_seconds)
+        diagnostics.append(diagnostic)
+        if diagnostic.return_code != 0:
+            break
+    return tuple(diagnostics)
+
+
+def _run_compiler(
+    command: Sequence[str],
+    *,
+    build_dir: Path,
+    runner: Runner,
+    timeout_seconds: int,
+) -> CompilerRunDiagnostic:
+    try:
+        completed = runner(
+            tuple(command),
+            cwd=build_dir,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+            env=_compiler_environment(os.environ),
+        )
+    except subprocess.TimeoutExpired as exc:
+        return CompilerRunDiagnostic(
+            command=tuple(command),
+            return_code=None,
+            stdout=_timeout_output(exc.stdout),
+            stderr=_timeout_output(exc.stderr),
+            timed_out=True,
+        )
+    return CompilerRunDiagnostic(
+        command=tuple(command),
+        return_code=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+def _compiler_environment(base_environment: Mapping[str, str]) -> dict[str, str]:
+    environment = dict(base_environment)
+    environment.setdefault("SOURCE_DATE_EPOCH", "0")
+    return environment
+
+
+def _open_pdf(path: Path, *, opener: PreviewOpener) -> bool:
+    opened = opener(path.resolve().as_uri())
+    if not opened:
+        raise PdfPreviewError(f"Could not open generated PDF for preview: {path}")
+    return opened
+
+
+def _timeout_output(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return str(value)
+
+
+def _compact_output(value: str, *, limit: int = 1200) -> str:
+    if not value:
+        return "-"
+    normalized = value.strip()
+    if len(normalized) <= limit:
+        return normalized
+    return f"{normalized[:limit]}... <truncated>"

--- a/tests/test_open_cvn_app_cli_unit.py
+++ b/tests/test_open_cvn_app_cli_unit.py
@@ -6,8 +6,10 @@ from pathlib import Path
 import pytest
 
 from open_cvn import CvnValidationStatus, validate_open_cvn_json
+import open_cvn_app.cli as cli_module
 from open_cvn_app import __version__
 from open_cvn_app.cli import build_parser, run
+from open_cvn_app.pdf import CompilerRunDiagnostic, PdfCompilationError, PdfGenerationResult, PdfGenerationUnavailable
 from open_cvn_app.storage import CurriculumCreate, CurriculumRepository, initialize_store
 
 
@@ -439,9 +441,149 @@ def test_latex_export_reports_missing_version(capsys: pytest.CaptureFixture[str]
     assert "Curriculum version not found: missing" in captured.err
 
 
-def test_pdf_generate_routes_to_issue_67_placeholder(capsys: pytest.CaptureFixture[str]):
+def test_pdf_generate_reports_missing_compiler(capsys: pytest.CaptureFixture[str], monkeypatch):
+    def unavailable(*args, **kwargs):
+        raise PdfGenerationUnavailable(("latexmk", "pdflatex"))
+
+    monkeypatch.setattr(cli_module, "generate_pdf_document", unavailable)
+
     exit_code = run(["pdf", "generate", "cv.pdf"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "PDF generation unavailable." in captured.err
+    assert "No supported TeX compiler found" in captured.err
+
+
+def test_pdf_generate_writes_master_pdf(capsys: pytest.CaptureFixture[str], monkeypatch, tmp_path):
+    store_path, curriculum = _create_store_with_curriculum(tmp_path)
+    repository = CurriculumRepository(store_path)
+    repository.assign_master_curriculum(curriculum.id)
+    output_path = tmp_path / "exports" / "cv.pdf"
+    calls = []
+
+    def fake_generate_pdf_document(repository, **kwargs):
+        calls.append(kwargs)
+        output = Path(kwargs["output_path"])
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(b"%PDF-1.4\n")
+        return PdfGenerationResult(
+            output_path=output,
+            version_name="master",
+            validation_status="valid",
+            compiler_name="latexmk",
+            preview_opened=False,
+        )
+
+    monkeypatch.setattr(cli_module, "generate_pdf_document", fake_generate_pdf_document)
+
+    exit_code = run(["pdf", "generate", str(output_path), "--store", str(store_path), "--version", "master"])
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert "PDF generation is planned for issue #67" in output
+    assert output_path.exists()
+    assert "Generated PDF version 'master'" in output
+    assert "Validation status: valid" in output
+    assert "Compiler: latexmk" in output
+    assert calls == [{"version": "master", "output_path": str(output_path), "open_pdf": False}]
+
+
+def test_pdf_generate_writes_materialized_derived_pdf(capsys: pytest.CaptureFixture[str], monkeypatch, tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    document = json.loads((EXAMPLES_DIR / "research_entry.json").read_text(encoding="utf-8"))
+    curriculum = repository.create_curriculum(CurriculumCreate(display_name="Master CV", document=document))
+    repository.assign_master_curriculum(curriculum.id)
+    repository.create_derived_version("public")
+    repository.exclude_from_version("public", "/curriculum/research")
+    output_path = tmp_path / "public.pdf"
+    materialized_versions = []
+
+    def fake_generate_pdf_document(repository, **kwargs):
+        materialized_versions.append(repository.materialize_version(kwargs["version"]).document)
+        output = Path(kwargs["output_path"])
+        output.write_bytes(b"%PDF-1.4\n")
+        return PdfGenerationResult(
+            output_path=output,
+            version_name="public",
+            validation_status="valid",
+            compiler_name="pdflatex",
+            preview_opened=False,
+        )
+
+    monkeypatch.setattr(cli_module, "generate_pdf_document", fake_generate_pdf_document)
+
+    exit_code = run(["pdf", "generate", str(output_path), "--store", str(store_path), "--version", "public"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Generated PDF version 'public'" in output
+    assert "Compiler: pdflatex" in output
+    assert materialized_versions[0]["curriculum"]["research"] == []
+
+
+def test_pdf_generate_open_triggers_preview_flag(capsys: pytest.CaptureFixture[str], monkeypatch, tmp_path):
+    store_path, curriculum = _create_store_with_curriculum(tmp_path)
+    CurriculumRepository(store_path).assign_master_curriculum(curriculum.id)
+    output_path = tmp_path / "cv.pdf"
+    calls = []
+
+    def fake_generate_pdf_document(repository, **kwargs):
+        calls.append(kwargs)
+        output = Path(kwargs["output_path"])
+        output.write_bytes(b"%PDF-1.4\n")
+        return PdfGenerationResult(
+            output_path=output,
+            version_name="master",
+            validation_status="valid",
+            compiler_name="latexmk",
+            preview_opened=True,
+        )
+
+    monkeypatch.setattr(cli_module, "generate_pdf_document", fake_generate_pdf_document)
+
+    exit_code = run(["pdf", "generate", str(output_path), "--store", str(store_path), "--open"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Preview handoff: opened" in output
+    assert calls[0]["open_pdf"] is True
+
+
+def test_pdf_generate_reports_missing_version(capsys: pytest.CaptureFixture[str], tmp_path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    output_path = tmp_path / "missing.pdf"
+
+    exit_code = run(["pdf", "generate", str(output_path), "--store", str(store_path), "--version", "missing"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "PDF generation failed." in captured.err
+    assert "Curriculum version not found: missing" in captured.err
+
+
+def test_pdf_generate_reports_compiler_failure(capsys: pytest.CaptureFixture[str], monkeypatch, tmp_path):
+    store_path, curriculum = _create_store_with_curriculum(tmp_path)
+    CurriculumRepository(store_path).assign_master_curriculum(curriculum.id)
+    diagnostic = CompilerRunDiagnostic(
+        command=("latexmk", "cv.tex"),
+        return_code=1,
+        stdout="compiler stdout",
+        stderr="compiler stderr",
+    )
+
+    def fake_generate_pdf_document(repository, **kwargs):
+        raise PdfCompilationError("PDF compilation failed.", (diagnostic,))
+
+    monkeypatch.setattr(cli_module, "generate_pdf_document", fake_generate_pdf_document)
+
+    exit_code = run(["pdf", "generate", str(tmp_path / "cv.pdf"), "--store", str(store_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "PDF generation failed." in captured.err
+    assert "PDF compilation failed." in captured.err
+    assert "compiler stdout" in captured.err
+    assert "compiler stderr" in captured.err

--- a/tests/test_open_cvn_app_pdf_unit.py
+++ b/tests/test_open_cvn_app_pdf_unit.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from open_cvn_app.pdf import (
+    PdfCompilationError,
+    PdfGenerationUnavailable,
+    PdfPreviewError,
+    discover_tex_compiler,
+    format_compilation_diagnostics,
+    generate_pdf_document,
+)
+from open_cvn_app.storage import CurriculumCreate, CurriculumRepository, initialize_store
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "open_cvn"
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples" / "open_cvn"
+
+
+def _repository_with_master(tmp_path: Path, document_path: Path | None = None) -> CurriculumRepository:
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    repository = CurriculumRepository(store_path)
+    source = document_path or FIXTURES_DIR / "valid_minimal.json"
+    document = json.loads(source.read_text(encoding="utf-8"))
+    curriculum = repository.create_curriculum(CurriculumCreate(display_name="Master CV", document=document))
+    repository.assign_master_curriculum(curriculum.id)
+    return repository
+
+
+def test_discover_tex_compiler_prefers_latexmk():
+    def lookup(name: str) -> str | None:
+        return {"latexmk": "/usr/bin/latexmk", "pdflatex": "/usr/bin/pdflatex"}.get(name)
+
+    compiler = discover_tex_compiler(lookup=lookup)
+
+    assert compiler.name == "latexmk"
+    assert compiler.executable == "/usr/bin/latexmk"
+
+
+def test_discover_tex_compiler_uses_pdflatex_fallback():
+    def lookup(name: str) -> str | None:
+        return {"pdflatex": "/usr/bin/pdflatex"}.get(name)
+
+    compiler = discover_tex_compiler(lookup=lookup)
+
+    assert compiler.name == "pdflatex"
+    assert compiler.executable == "/usr/bin/pdflatex"
+
+
+def test_discover_tex_compiler_reports_missing_compiler():
+    with pytest.raises(PdfGenerationUnavailable, match="No supported TeX compiler found") as exc_info:
+        discover_tex_compiler(lookup=lambda name: None)
+
+    assert exc_info.value.searched_compilers == ("latexmk", "pdflatex")
+
+
+def test_generate_pdf_document_with_latexmk_copies_expected_pdf(tmp_path):
+    repository = _repository_with_master(tmp_path)
+    output_path = tmp_path / "exports" / "cv.pdf"
+    calls: list[tuple[str, ...]] = []
+    environments: list[dict[str, str]] = []
+
+    def runner(command: tuple[str, ...], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        environments.append(kwargs["env"])
+        tex_path = Path(command[-1])
+        (Path(kwargs["cwd"]) / f"{tex_path.stem}.pdf").write_bytes(b"%PDF-1.4\n")
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    result = generate_pdf_document(
+        repository,
+        version="master",
+        output_path=output_path,
+        compiler_lookup=lambda name: "/usr/bin/latexmk" if name == "latexmk" else None,
+        runner=runner,
+    )
+
+    assert result.output_path == output_path
+    assert result.version_name == "master"
+    assert result.validation_status == "valid"
+    assert result.compiler_name == "latexmk"
+    assert result.preview_opened is False
+    assert output_path.read_bytes() == b"%PDF-1.4\n"
+    assert len(calls) == 1
+    assert calls[0][1:5] == ("-pdf", "-interaction=nonstopmode", "-halt-on-error", "-outdir")
+    assert environments[0]["SOURCE_DATE_EPOCH"] == "0"
+
+
+def test_generate_pdf_document_with_pdflatex_runs_two_passes(tmp_path):
+    repository = _repository_with_master(tmp_path)
+    output_path = tmp_path / "cv.pdf"
+    calls: list[tuple[str, ...]] = []
+
+    def runner(command: tuple[str, ...], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        tex_path = Path(command[-1])
+        (Path(kwargs["cwd"]) / f"{tex_path.stem}.pdf").write_bytes(b"%PDF-1.4\n")
+        return subprocess.CompletedProcess(command, 0, stdout=f"pass {len(calls)}", stderr="")
+
+    result = generate_pdf_document(
+        repository,
+        version="master",
+        output_path=output_path,
+        compiler_lookup=lambda name: "/usr/bin/pdflatex" if name == "pdflatex" else None,
+        runner=runner,
+    )
+
+    assert result.compiler_name == "pdflatex"
+    assert output_path.exists()
+    assert len(calls) == 2
+    assert all(call[1:4] == ("-interaction=nonstopmode", "-halt-on-error", "-output-directory") for call in calls)
+
+
+def test_generate_pdf_document_preserves_compiler_failure_diagnostics(tmp_path):
+    repository = _repository_with_master(tmp_path)
+    command_result = subprocess.CompletedProcess(("latexmk",), 12, stdout="compiler stdout", stderr="compiler stderr")
+
+    def runner(command: tuple[str, ...], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return command_result
+
+    with pytest.raises(PdfCompilationError, match="PDF compilation failed") as exc_info:
+        generate_pdf_document(
+            repository,
+            version="master",
+            output_path=tmp_path / "cv.pdf",
+            compiler_lookup=lambda name: "/usr/bin/latexmk" if name == "latexmk" else None,
+            runner=runner,
+        )
+
+    diagnostics = exc_info.value.diagnostics
+    assert len(diagnostics) == 1
+    assert diagnostics[0].return_code == 12
+    assert diagnostics[0].stdout == "compiler stdout"
+    assert diagnostics[0].stderr == "compiler stderr"
+    assert "compiler stdout" in format_compilation_diagnostics(diagnostics)
+
+
+def test_generate_pdf_document_preserves_timeout_diagnostics(tmp_path):
+    repository = _repository_with_master(tmp_path)
+
+    def runner(command: tuple[str, ...], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(command, timeout=1, output=b"partial stdout", stderr=b"partial stderr")
+
+    with pytest.raises(PdfCompilationError, match="PDF compilation failed") as exc_info:
+        generate_pdf_document(
+            repository,
+            version="master",
+            output_path=tmp_path / "cv.pdf",
+            compiler_lookup=lambda name: "/usr/bin/latexmk" if name == "latexmk" else None,
+            runner=runner,
+            timeout_seconds=1,
+        )
+
+    diagnostic = exc_info.value.diagnostics[0]
+    assert diagnostic.return_code is None
+    assert diagnostic.timed_out is True
+    assert diagnostic.stdout == "partial stdout"
+    assert diagnostic.stderr == "partial stderr"
+
+
+def test_generate_pdf_document_reports_missing_pdf_after_success(tmp_path):
+    repository = _repository_with_master(tmp_path)
+
+    def runner(command: tuple[str, ...], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    with pytest.raises(PdfCompilationError, match="did not create the expected PDF"):
+        generate_pdf_document(
+            repository,
+            version="master",
+            output_path=tmp_path / "cv.pdf",
+            compiler_lookup=lambda name: "/usr/bin/latexmk" if name == "latexmk" else None,
+            runner=runner,
+        )
+
+
+def test_generate_pdf_document_opens_preview_when_requested(tmp_path):
+    repository = _repository_with_master(tmp_path, EXAMPLES_DIR / "research_entry.json")
+    opened_urls: list[str] = []
+
+    def runner(command: tuple[str, ...], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        tex_path = Path(command[-1])
+        (Path(kwargs["cwd"]) / f"{tex_path.stem}.pdf").write_bytes(b"%PDF-1.4\n")
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    result = generate_pdf_document(
+        repository,
+        version="master",
+        output_path=tmp_path / "cv.pdf",
+        open_pdf=True,
+        compiler_lookup=lambda name: "/usr/bin/latexmk" if name == "latexmk" else None,
+        runner=runner,
+        preview_opener=lambda url: opened_urls.append(url) is None or True,
+    )
+
+    assert result.preview_opened is True
+    assert opened_urls == [(tmp_path / "cv.pdf").resolve().as_uri()]
+
+
+def test_generate_pdf_document_reports_preview_failure(tmp_path):
+    repository = _repository_with_master(tmp_path)
+
+    def runner(command: tuple[str, ...], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        tex_path = Path(command[-1])
+        (Path(kwargs["cwd"]) / f"{tex_path.stem}.pdf").write_bytes(b"%PDF-1.4\n")
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    with pytest.raises(PdfPreviewError, match="Could not open generated PDF"):
+        generate_pdf_document(
+            repository,
+            version="master",
+            output_path=tmp_path / "cv.pdf",
+            open_pdf=True,
+            compiler_lookup=lambda name: "/usr/bin/latexmk" if name == "latexmk" else None,
+            runner=runner,
+            preview_opener=lambda url: False,
+        )


### PR DESCRIPTION
## Summary
- Implement optional PDF generation for stored master and derived Open CVN versions.
- Add `open-cvn pdf generate OUTPUT [--store PATH] [--version NAME] [--open]`.
- Add structured handling for missing TeX compiler, compiler failures, and preview handoff.
## Details
- Prefer `latexmk`; fallback to `pdflatex`.
- Reuse existing LaTeX renderer from issue #66.
- Compile in isolated temp dir; keep only final PDF.
- Keep TeX optional: no Python dependency added.
- Mock compiler/viewer behavior in tests.
## Verification
- `uv run pytest -n auto tests/test_open_cvn_app_pdf_unit.py tests/test_open_cvn_app_cli_unit.py -v`
- `40 passed in 52.02s`
- `uv run pytest -n auto tests/test_open_cvn_app_latex_unit.py tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py tests/test_open_cvn_app_editing_unit.py -v`
- `29 passed in 45.92s`
- `uv run pytest -n auto tests`
- `439 passed in 355.05s (0:05:55)`
## Notes
- Local smoke reached expected missing-compiler behavior because no `latexmk` or `pdflatex` executable was installed.

closes #67 