### PR TITLE
test(app): close MVP workflow coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ Every new session should read these files in order before making changes:
 - setup and commands: `docs/development/setup.md`
 - complete regeneration workflow: `docs/development/regeneration_workflow.md`
 - parser workflow: `docs/development/parser_workflow.md`
+- application MVP workflow: `docs/development/application_mvp_workflow.md`
 - LaTeX export workflow: `docs/development/latex_export_workflow.md`
 - PDF generation workflow: `docs/development/pdf_generation_workflow.md`
 - code style and conventions: `docs/development/code_style.md`

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -176,6 +176,8 @@ files in order:
   verification workflow
 - `docs/development/parser_workflow.md`: contributor guide for using and testing
   the public PDF/XML/JSON parser workflow
+- `docs/development/application_mvp_workflow.md`: issue `#68` user workflow for
+  the local CLI-first CV management MVP
 - `docs/development/latex_export_workflow.md`: issue `#66` user workflow for
   exporting stored Open CVN master or derived versions to LaTeX
 - `docs/development/pdf_generation_workflow.md`: issue `#67` user workflow for

--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -2,7 +2,7 @@
 
 ## Status Date
 
-- Last updated: 2026-07-10
+- Last updated: 2026-07-13
 
 ## Completed Or Stabilized Work
 
@@ -1023,6 +1023,44 @@
   - result: `439 passed in 355.05s (0:05:55)`
 - no new durable limitations were found
 
+### Issue `#68`
+
+- the application MVP tests and documentation closure issue is implemented
+- end-to-end workflow tests were added in:
+  - `tests/test_open_cvn_app_mvp_workflow.py`
+- a user-facing local application MVP guide now exists at:
+  - `docs/development/application_mvp_workflow.md`
+- the MVP workflow tests cover:
+  - store initialization over temporary SQLite paths
+  - Open CVN JSON import with master assignment
+  - derived version creation
+  - section and entry listing
+  - derived selection exclusion
+  - derived Open CVN JSON export and revalidation
+  - derived LaTeX export
+  - structured missing-compiler PDF behavior
+  - invalid import without storage pollution
+  - isolation between temporary stores
+- documentation entry points and related workflow docs now link the application
+  MVP guide
+- issue `#60` is now closed as a local CLI-first application MVP through completed
+  issues `#61` through `#68`
+- issue `#69` remains post-MVP exploratory LLM-assisted import work
+- targeted MVP workflow verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_mvp_workflow.py -v`
+  - result: `3 passed in 27.66s`
+- application MVP regression verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_mvp_workflow.py tests/test_open_cvn_app_cli_unit.py tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py tests/test_open_cvn_app_editing_unit.py tests/test_open_cvn_app_latex_unit.py tests/test_open_cvn_app_pdf_unit.py -v`
+  - result: `72 passed in 90.20s (0:01:30)`
+- console-script smoke verification passed through store initialization, JSON
+  import as master, derived creation, derived selection exclusion, derived JSON
+  export, derived LaTeX export, and expected missing-compiler PDF behavior because
+  no `latexmk` or `pdflatex` executable is installed in the local environment
+- full-suite verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `442 passed in 359.41s (0:05:59)`
+- no new durable limitations were found
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -1034,8 +1072,7 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#67`: issue `#68` application MVP tests and
-  documentation
+- Next work item after issue `#68`: issue `#69` LLM-assisted import spike
 - Epic `#60` has been expanded into issues `#61` through `#69`
 - MVP direction:
   - CLI-first local prototype
@@ -1047,7 +1084,7 @@
   - optional PDF generation and preview handoff
   - application MVP tests and user documentation
   - post-MVP LLM-assisted import spike
-- Next implementation issue: `#68` application MVP tests and documentation
+- Next implementation issue: `#69` LLM-assisted import spike
 
 ## Blocking Or Relevant Limitations
 

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -32,12 +32,13 @@ Agents should also read `AGENTS.md` before this file.
   semantic policy, domain generation, conceptual schema, Open CVN JSON format,
   parser/validator contract, CLI shell, local SQLite storage, master/derived
   curriculum versioning, Open CVN JSON application import/export, curriculum
-  editing/selection MVP, and LaTeX export completed
+  editing/selection MVP, LaTeX export, optional PDF generation, and application
+  MVP workflow tests/documentation completed
 - Last documented issues: `#11`, `#12`, `#13`, `#14`, `#15`, `#16`, `#17`,
   `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, `#47`, `#48`, `#49`, `#50`,
-  `#61`, `#62`, `#63`, `#64`, `#65`, and `#66`
+  `#61`, `#62`, `#63`, `#64`, `#65`, `#66`, `#67`, and `#68`
 - Latest documented hotfix records: `#3`, `#4`, `#5`, `#6`, `#7`, `#8`
-- Next planned issue: `#67`
+- Next planned issue: `#69`
 - Canonical source package: `docs/CvnXML_v1.4.3_2.1_17012025/`
 
 ## Documentation Map
@@ -155,6 +156,8 @@ Agents should also read `AGENTS.md` before this file.
   verification workflow
 - `docs/development/parser_workflow.md`: contributor guide for using and testing
   the public PDF/XML/JSON parser workflow
+- `docs/development/application_mvp_workflow.md`: issue `#68` user workflow for
+  the local CLI-first CV management MVP
 - `docs/development/latex_export_workflow.md`: issue `#66` workflow for exporting
   stored Open CVN master or derived versions to LaTeX
 - `docs/development/pdf_generation_workflow.md`: issue `#67` workflow for optional

--- a/docs/development/application_mvp_workflow.md
+++ b/docs/development/application_mvp_workflow.md
@@ -1,0 +1,232 @@
+# Application MVP Workflow
+
+## Purpose
+
+This guide describes the issue `#68` end-to-end workflow for the local Open CVN
+management MVP.
+
+The MVP proves this path:
+
+```text
+Open CVN JSON input
+-> validated local SQLite storage
+-> master curriculum
+-> derived curriculum version
+-> section or entry selection
+-> Open CVN JSON export
+-> LaTeX export
+-> optional PDF generation
+```
+
+## Setup
+
+Synchronize the environment and install the project in editable mode:
+
+```bash
+uv sync --group codegen --group testing
+uv pip install -e .
+```
+
+Check that the CLI is available:
+
+```bash
+uv run open-cvn --help
+```
+
+## Initialize A Local Store
+
+Create a local SQLite store:
+
+```bash
+uv run open-cvn store init --path /tmp/open-cvn-demo.sqlite
+```
+
+The store is a single-user local SQLite file. Back it up like any other local data
+file if it contains useful curriculum data.
+
+## Import Open CVN JSON As Master
+
+Import a valid Open CVN JSON document and assign it as the master curriculum:
+
+```bash
+uv run open-cvn json import examples/open_cvn/research_entry.json \
+  --store /tmp/open-cvn-demo.sqlite \
+  --as-master
+```
+
+The import path uses the public Open CVN parser and validator. Invalid JSON is
+rejected before storage.
+
+## Create A Derived Version
+
+Create a derived version named `public` from the master curriculum:
+
+```bash
+uv run open-cvn versions derive public --store /tmp/open-cvn-demo.sqlite
+```
+
+List available versions:
+
+```bash
+uv run open-cvn versions list --store /tmp/open-cvn-demo.sqlite
+```
+
+## Discover Sections And Entries
+
+List curriculum sections in the derived version:
+
+```bash
+uv run open-cvn versions sections public --store /tmp/open-cvn-demo.sqlite
+```
+
+List entries in a repeated section:
+
+```bash
+uv run open-cvn versions entries public research --store /tmp/open-cvn-demo.sqlite
+```
+
+Selectors use JSON Pointer-style paths under `/curriculum`, for example:
+
+```text
+/curriculum/research
+/curriculum/research/0
+```
+
+## Customize Derived Content
+
+Exclude one entry from the derived version:
+
+```bash
+uv run open-cvn versions exclude public /curriculum/research/0 \
+  --store /tmp/open-cvn-demo.sqlite
+```
+
+Include it again if needed:
+
+```bash
+uv run open-cvn versions include public /curriculum/research/0 \
+  --store /tmp/open-cvn-demo.sqlite
+```
+
+Set optional derived-version metadata:
+
+```bash
+uv run open-cvn versions metadata public \
+  --store /tmp/open-cvn-demo.sqlite \
+  --display-name "Public CV" \
+  --purpose "grant application"
+```
+
+Field-level edits are intentionally unsupported in the MVP. Use section or entry
+include/exclude selection instead.
+
+## Export Open CVN JSON
+
+Export the master version:
+
+```bash
+uv run open-cvn json export /tmp/master.json \
+  --store /tmp/open-cvn-demo.sqlite \
+  --version master
+```
+
+Export the derived version:
+
+```bash
+uv run open-cvn json export /tmp/public.json \
+  --store /tmp/open-cvn-demo.sqlite \
+  --version public
+```
+
+Exported JSON is deterministic, revalidable Open CVN JSON.
+
+## Export LaTeX
+
+Export the derived version to LaTeX:
+
+```bash
+uv run open-cvn latex export /tmp/public.tex \
+  --store /tmp/open-cvn-demo.sqlite \
+  --version public
+```
+
+The template is an MVP technical proof. It is deterministic and escapes common
+LaTeX-sensitive text, but it is not a final CV design.
+
+More details:
+
+- `docs/development/latex_export_workflow.md`
+
+## Generate PDF Optionally
+
+Generate a PDF from the derived version when a supported TeX compiler is installed:
+
+```bash
+uv run open-cvn pdf generate /tmp/public.pdf \
+  --store /tmp/open-cvn-demo.sqlite \
+  --version public
+```
+
+Open the generated PDF with the platform default viewer:
+
+```bash
+uv run open-cvn pdf generate /tmp/public.pdf \
+  --store /tmp/open-cvn-demo.sqlite \
+  --version public \
+  --open
+```
+
+PDF generation looks for `latexmk` first and `pdflatex` second. If neither exists,
+the command reports structured unavailable behavior similar to:
+
+```text
+PDF generation unavailable.
+No supported TeX compiler found. Install one of: latexmk, pdflatex.
+```
+
+This is expected on machines without a TeX distribution. JSON and LaTeX workflows
+still work.
+
+More details:
+
+- `docs/development/pdf_generation_workflow.md`
+
+## Verification Commands
+
+Run the MVP workflow tests:
+
+```bash
+uv run pytest -n auto tests/test_open_cvn_app_mvp_workflow.py -v
+```
+
+Run all application MVP tests:
+
+```bash
+uv run pytest -n auto \
+  tests/test_open_cvn_app_mvp_workflow.py \
+  tests/test_open_cvn_app_cli_unit.py \
+  tests/test_open_cvn_app_storage_unit.py \
+  tests/test_open_cvn_app_versioning_unit.py \
+  tests/test_open_cvn_app_editing_unit.py \
+  tests/test_open_cvn_app_latex_unit.py \
+  tests/test_open_cvn_app_pdf_unit.py \
+  -v
+```
+
+Run the full repository test suite:
+
+```bash
+uv run pytest -n auto tests
+```
+
+## MVP Limits
+
+- The application is CLI-first and has no GUI.
+- The store is local, single-user SQLite storage.
+- Field-level edits are not supported; derived versions use section or entry
+  include/exclude selection.
+- CVN XML import remains trace-only for plausible XML and does not perform full
+  semantic XML-to-domain mapping.
+- PDF generation requires an external TeX distribution and is optional.
+- PDF preview is best-effort and only runs when `--open` is explicitly passed.
+- LLM-assisted reconstruction from arbitrary PDFs is deferred to issue `#69`.

--- a/docs/development/latex_export_workflow.md
+++ b/docs/development/latex_export_workflow.md
@@ -11,6 +11,12 @@ to a deterministic `.tex` file.
 
 ## Command
 
+For the complete local application workflow from import to export, see:
+
+```text
+docs/development/application_mvp_workflow.md
+```
+
 Export the master version:
 
 ```bash

--- a/docs/development/pdf_generation_workflow.md
+++ b/docs/development/pdf_generation_workflow.md
@@ -10,6 +10,12 @@ JSON, and render LaTeX when no local TeX distribution is installed.
 
 ## Command
 
+For the complete local application workflow from import to export, see:
+
+```text
+docs/development/application_mvp_workflow.md
+```
+
 Generate a PDF for the master version:
 
 ```bash

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -45,7 +45,7 @@ Goal:
 | `#48` | Extract CVN XML from PDF inputs | Completed | Deterministic PDF XML extraction implemented behind `parse_cvn_pdf(...)` with embedded-file and XML metadata support |
 | `#49` | Validate XML and JSON import paths | Completed | JSON Schema plus Pydantic Open CVN JSON validation implemented; CVN XML well-formedness, trace extraction, and trace-only Open CVN mapping implemented |
 | `#50` | Add tests and documentation for parser workflow | Completed | Parser workflow docs, coverage audit, `pydantic_validation_failure` regression, drift checks, and full-suite verification completed |
-| `#60` | Epic: CV management application | Planned | MVP application roadmap for local storage, master/derived versions, JSON import/export, LaTeX/PDF export, and post-MVP LLM spike expanded |
+| `#60` | Epic: CV management application | Completed | Local CLI-first MVP completed through issues `#61`-`#68`; issue `#69` remains post-MVP LLM spike |
 | `#61` | Application MVP scope and CLI shell | Completed | CLI-first prototype shell, command surface, console script, placeholders, and smoke tests implemented |
 | `#62` | Local storage with SQLite | Completed | SQLite store initialization, schema metadata, curriculum repository, diagnostics, CLI store init, and tests implemented |
 | `#63` | Master and derived curriculum versions | Completed | Schema v2 migration, master/derived repository operations, selection materialization, CLI commands, and tests implemented |
@@ -53,7 +53,7 @@ Goal:
 | `#65` | Curriculum editing and selection MVP | Completed | Section/entry listing, derived metadata, immediate selection validation, unsupported field-edit messaging, and tests implemented |
 | `#66` | LaTeX export from Open CVN | Completed | Jinja-based deterministic `.tex` export from stored master or derived Open CVN versions implemented |
 | `#67` | PDF generation and preview handoff | Completed | Optional `latexmk`/`pdflatex` compilation, structured missing-compiler behavior, mocked tests, and explicit `--open` preview handoff implemented |
-| `#68` | Application MVP tests and documentation | Planned | End-to-end MVP tests, user docs, and epic `#60` closure |
+| `#68` | Application MVP tests and documentation | Completed | End-to-end MVP workflow tests, application user guide, verification, and epic `#60` closure completed |
 | `#69` | LLM-assisted import spike | Planned | Post-MVP exploration for PDFs without deterministic XML extraction |
 
 Corrective planning after hotfixes `#4`, `#5`, and `#6`:

--- a/docs/roadmap/issues/issue-60-epic-cv-management-application.md
+++ b/docs/roadmap/issues/issue-60-epic-cv-management-application.md
@@ -162,6 +162,35 @@ The epic should later revisit:
 - tests for storage, import/export, versioning, and LaTeX rendering
 - user documentation for running the prototype
 
+## Implementation Notes
+
+- Issues `#61` through `#68` now complete the local application MVP delivery path.
+- The implemented MVP provides:
+  - CLI-first application shell through `open-cvn`
+  - local SQLite store initialization and repository behavior
+  - master curriculum assignment
+  - derived curriculum versions
+  - section and entry include/exclude selection
+  - Open CVN JSON import and export through the public parser/validator contract
+  - deterministic LaTeX export
+  - optional PDF generation with structured missing-compiler behavior
+  - user-facing MVP workflow documentation
+- The issue `#68` closure guide exists at:
+  - `docs/development/application_mvp_workflow.md`
+- Post-MVP issue `#69` remains the planned LLM-assisted import spike and does not
+  block the local storage and export MVP.
+
+## Verification Performed For MVP Closure
+
+- Issue `#68` added end-to-end application workflow tests in:
+  - `tests/test_open_cvn_app_mvp_workflow.py`
+- Application MVP regression verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_mvp_workflow.py tests/test_open_cvn_app_cli_unit.py tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py tests/test_open_cvn_app_editing_unit.py tests/test_open_cvn_app_latex_unit.py tests/test_open_cvn_app_pdf_unit.py -v`
+  - result: `72 passed in 90.20s (0:01:30)`
+- Full repository verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `442 passed in 359.41s (0:05:59)`
+
 ## Verification Strategy
 
 - unit tests for storage repositories and versioning logic
@@ -174,5 +203,6 @@ The epic should later revisit:
 
 ## Status
 
-- Status: planned
-- Details expanded after epic `#41` completion
+- Status: completed
+- Issues `#61` through `#68` complete the local application MVP.
+- Issue `#69` remains post-MVP exploratory work.

--- a/docs/roadmap/issues/issue-68-application-mvp-tests-and-documentation.md
+++ b/docs/roadmap/issues/issue-68-application-mvp-tests-and-documentation.md
@@ -48,12 +48,311 @@ This issue is part of epic `#60`.
 7. run full repository verification
 8. update epic `#60`, current status, roadmap, and limitation docs
 
+## Detailed Execution Plan
+
+This plan is the accepted execution plan for implementing issue `#68`.
+During execution, each work update must identify the active task and, when
+applicable, the active subtask. Each task or subtask update should include:
+
+- initial summary of the task or subtask goal
+- current task and subtask identifier
+- whether the user must modify any file manually
+- next step to follow
+
+Unless explicitly requested otherwise, code edits are expected to be performed by
+the user. Documentation edits may be applied when the user asks to establish or
+update the issue plan.
+
+### Task 1 - Confirm Scope And Constraints
+
+- Subtask 1.1: confirm issue `#68` closes the issue `#60` MVP delivery path with
+  tests and documentation, not new application features.
+- Subtask 1.2: confirm no manual edits are made under `src/generated/`.
+- Subtask 1.3: confirm workflow tests use temporary stores and output paths.
+- Subtask 1.4: confirm PDF generation remains optional and missing local TeX
+  compilers are expected behavior, not a failing MVP condition.
+- Subtask 1.5: confirm issue `#69` remains post-MVP exploratory LLM work and does
+  not block issue `#68`.
+
+Expected output: final implementation boundary for issue `#68` before test and
+documentation work.
+
+### Task 2 - Audit Implemented MVP Surface
+
+- Subtask 2.1: audit issues `#61` through `#67` and confirm completed command
+  surface.
+- Subtask 2.2: audit `src/open_cvn_app/` modules for CLI, storage, versioning,
+  editing, LaTeX, and PDF behavior.
+- Subtask 2.3: audit current application test files under `tests/` and record what
+  is already covered.
+- Subtask 2.4: audit available Open CVN examples and fixtures for workflow tests.
+- Subtask 2.5: identify only the remaining issue `#68` gaps so new tests do not
+  duplicate unit coverage unnecessarily.
+
+Expected output: coverage and artifact map for the completed application MVP.
+
+### Task 3 - Build MVP Coverage Matrix
+
+- Subtask 3.1: map issue `#68` planned coverage to existing tests and missing
+  end-to-end scenarios.
+- Subtask 3.2: mark existing coverage for store initialization, JSON import/export,
+  versioning, editing, LaTeX rendering, and PDF wrapper behavior.
+- Subtask 3.3: mark missing integration coverage for complete import-to-export CLI
+  workflow over a temporary store.
+- Subtask 3.4: mark missing integration coverage for invalid JSON import not
+  polluting storage.
+- Subtask 3.5: mark missing isolation coverage for multiple temporary stores or
+  nested output paths if not already covered by focused tests.
+
+Expected output: concise test plan for the additional issue `#68` workflow suite.
+
+### Task 4 - Add End-To-End Application Workflow Tests
+
+- Subtask 4.1: create a focused test module such as
+  `tests/test_open_cvn_app_mvp_workflow.py`.
+- Subtask 4.2: initialize a temporary SQLite store through the CLI behavior.
+- Subtask 4.3: import a valid Open CVN JSON example as the master curriculum.
+- Subtask 4.4: create a derived version from the master curriculum.
+- Subtask 4.5: list sections and repeated entries for the derived version.
+- Subtask 4.6: exclude a section or entry from the derived version.
+- Subtask 4.7: export the derived version as Open CVN JSON.
+- Subtask 4.8: validate the exported JSON with the public Open CVN validator.
+- Subtask 4.9: export the derived version to LaTeX and assert deterministic file
+  output.
+- Subtask 4.10: run PDF generation for the derived version and assert either a
+  generated PDF when a compiler is available or the documented missing-compiler
+  failure when no supported compiler exists.
+
+Expected output: one workflow test proving the MVP from local store initialization
+through JSON, LaTeX, and optional PDF output.
+
+### Task 5 - Add Invalid Import Workflow Tests
+
+- Subtask 5.1: import `tests/fixtures/open_cvn/wrong_shape.json` or an equivalent
+  invalid fixture through the CLI workflow.
+- Subtask 5.2: assert the command exits with code `1`.
+- Subtask 5.3: assert output includes structured parser failure information such as
+  `json_schema_validation_failure`.
+- Subtask 5.4: assert no curriculum records are stored after the failed import.
+- Subtask 5.5: add malformed JSON coverage only if the current focused CLI tests do
+  not already make the behavior clear enough.
+
+Expected output: invalid input cannot pollute the local MVP store.
+
+### Task 6 - Add Temporary Store Isolation Workflow Tests
+
+- Subtask 6.1: create two temporary stores in one test or targeted workflow.
+- Subtask 6.2: import data into one store only.
+- Subtask 6.3: assert version and curriculum listing in the second store remains
+  empty.
+- Subtask 6.4: export to a nested temporary output path and assert parent
+  directories are created when this behavior is not already sufficiently covered.
+
+Expected output: workflow coverage proves stores and generated outputs remain local
+and isolated.
+
+### Task 7 - Avoid Duplicate Or Brittle Test Coverage
+
+- Subtask 7.1: keep existing focused unit tests for CLI, storage, versioning,
+  editing, LaTeX, and PDF behavior.
+- Subtask 7.2: keep new issue `#68` tests focused on cross-component workflow.
+- Subtask 7.3: avoid real PDF compiler or viewer requirements in automated tests.
+- Subtask 7.4: if an issue `#68` test exposes a real bug, fix the smallest
+  blocking bug and add the narrowest regression assertion needed.
+
+Expected output: stable workflow coverage without duplicating every lower-level
+test case.
+
+### Task 8 - Write Application MVP User Guide
+
+- Subtask 8.1: create a user-facing guide such as
+  `docs/development/application_mvp_workflow.md`.
+- Subtask 8.2: document setup expectations and the installed `open-cvn` command.
+- Subtask 8.3: document local store initialization and the SQLite file role.
+- Subtask 8.4: document importing valid Open CVN JSON and assigning the master
+  curriculum.
+- Subtask 8.5: document derived-version creation and section or entry selection.
+- Subtask 8.6: document Open CVN JSON export for master and derived versions.
+- Subtask 8.7: document LaTeX export for master and derived versions.
+- Subtask 8.8: document optional PDF generation, compiler requirements, and
+  missing-compiler behavior.
+- Subtask 8.9: document MVP limits: no GUI, no field-level editing, trace-only XML
+  semantic mapping limits, optional PDF preview, local single-user storage, and no
+  LLM reconstruction until issue `#69`.
+
+Expected output: evaluator-ready guide for running the local CV management MVP.
+
+### Task 9 - Link Application Documentation
+
+- Subtask 9.1: link the new MVP guide from `PROJECT_GUIDE.md` if the human-facing
+  document map changes.
+- Subtask 9.2: link the new MVP guide from `docs/context/project_context_index.md`.
+- Subtask 9.3: link the new MVP guide from `AGENTS.md` if the operational document
+  map changes.
+- Subtask 9.4: link the new MVP guide from existing LaTeX or PDF workflow docs
+  when it helps users find the full application workflow.
+
+Expected output: new user guide is discoverable from repository entry points.
+
+### Task 10 - Update Issue And Epic Records
+
+- Subtask 10.1: update this issue document with implementation notes, tests added,
+  verification results, deviations, and status.
+- Subtask 10.2: update issue `#60` to record that issues `#61` through `#68` close
+  the local application MVP delivery path.
+- Subtask 10.3: keep issue `#69` recorded as post-MVP exploratory work.
+- Subtask 10.4: update issue documents `#61` through `#67` only if cross-links or
+  issue `#68` closure notes are needed.
+
+Expected output: roadmap issue history accurately records MVP closure.
+
+### Task 11 - Update Persistent Project Context
+
+- Subtask 11.1: update `docs/context/current_status.md` with issue `#68` outcome,
+  test results, and next planned work.
+- Subtask 11.2: update `docs/roadmap/cvn_generation_roadmap.md` so issue `#68` is
+  marked complete and issue `#69` remains the next post-MVP item.
+- Subtask 11.3: update `docs/pipeline/known_limitations.md` only if issue `#68`
+  uncovers a new durable limitation.
+- Subtask 11.4: update `PROJECT_GUIDE.md` when the new application guide changes
+  human-facing orientation or document maps.
+- Subtask 11.5: update `AGENTS.md` only when operational maps or rules change.
+
+Expected output: future sessions can resume from the documented issue `#68` state.
+
+### Task 12 - Run Targeted Verification
+
+- Subtask 12.1: run the new MVP workflow tests, for example
+  `uv run pytest -n auto tests/test_open_cvn_app_mvp_workflow.py -v`.
+- Subtask 12.2: run application regression tests covering CLI, storage, versioning,
+  editing, LaTeX, and PDF behavior.
+- Subtask 12.3: record exact commands and pass/fail results in this issue document.
+- Subtask 12.4: document any skipped verification with cause and follow-up.
+
+Expected output: targeted issue `#68` coverage passes.
+
+### Task 13 - Run Full Repository Verification
+
+- Subtask 13.1: run `uv run pytest -n auto tests`.
+- Subtask 13.2: record the exact result in this issue document and
+  `docs/context/current_status.md`.
+- Subtask 13.3: if full verification cannot complete, record the command, failure
+  point, cause, and planned follow-up.
+
+Expected output: complete repository test suite passes or has a documented blocker.
+
+### Task 14 - Run Console Script Smoke Workflow
+
+- Subtask 14.1: initialize a smoke store under `/tmp/opencode/`.
+- Subtask 14.2: import `examples/open_cvn/research_entry.json` as master.
+- Subtask 14.3: create a derived version named `public`.
+- Subtask 14.4: exclude `/curriculum/research/0` from the derived version.
+- Subtask 14.5: export the derived version as Open CVN JSON.
+- Subtask 14.6: export the derived version as LaTeX.
+- Subtask 14.7: run PDF generation for the derived version and record either real
+  PDF output or expected missing-compiler behavior.
+
+Expected output: installed `open-cvn` command proves the documented MVP workflow
+outside direct unit tests.
+
+### Task 15 - Final Documentation Closure
+
+- Subtask 15.1: finalize this issue document with status `completed` after tests
+  and documentation updates are complete.
+- Subtask 15.2: ensure all new or changed documentation records exact verification
+  commands and results.
+- Subtask 15.3: ensure no stale references still describe issue `#68` as planned
+  once implementation is complete.
+
+Expected output: issue `#68` closes with tests, documentation, verification, and
+project context aligned.
+
 ## Expected Output
 
 - application MVP test suite
 - user guide for local CV management prototype
 - verification record for epic `#60`
 - documented limitations and follow-up work
+
+## Implementation Notes
+
+- The issue `#68` workflow test suite was added at:
+  - `tests/test_open_cvn_app_mvp_workflow.py`
+- The new tests cover:
+  - full CLI workflow from store initialization to JSON, LaTeX, and optional PDF
+    output
+  - invalid Open CVN JSON import without polluting local storage
+  - isolation between temporary SQLite stores
+  - nested export path creation in the MVP workflow
+  - missing TeX compiler behavior during PDF generation
+- The user-facing application guide was added at:
+  - `docs/development/application_mvp_workflow.md`
+- The guide documents:
+  - setup and CLI discovery
+  - local SQLite store initialization
+  - Open CVN JSON import as master
+  - derived version creation
+  - section and entry discovery
+  - include/exclude selection
+  - Open CVN JSON export
+  - LaTeX export
+  - optional PDF generation and missing-compiler behavior
+  - MVP limitations and issue `#69` LLM deferral
+- Documentation entry points were updated to link the new application guide:
+  - `PROJECT_GUIDE.md`
+  - `AGENTS.md`
+  - `docs/context/project_context_index.md`
+  - `docs/development/latex_export_workflow.md`
+  - `docs/development/pdf_generation_workflow.md`
+- `src/generated/` was not modified.
+
+## Tests Added Or Updated
+
+- Added `tests/test_open_cvn_app_mvp_workflow.py`.
+
+The MVP workflow tests cover:
+
+- `store init` over a temporary SQLite path
+- valid Open CVN JSON import with `--as-master`
+- derived version creation
+- section and entry listing
+- entry exclusion from a derived version
+- derived Open CVN JSON export and revalidation
+- derived LaTeX export
+- structured missing-compiler PDF behavior
+- invalid JSON import leaving curricula and versions empty
+- isolation between independent temporary stores
+
+## Verification Performed
+
+- `uv run pytest -n auto tests/test_open_cvn_app_mvp_workflow.py -v`
+  - result: `3 passed in 27.66s`
+- `uv run pytest -n auto tests/test_open_cvn_app_mvp_workflow.py tests/test_open_cvn_app_cli_unit.py tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py tests/test_open_cvn_app_editing_unit.py tests/test_open_cvn_app_latex_unit.py tests/test_open_cvn_app_pdf_unit.py -v`
+  - result: `72 passed in 90.20s (0:01:30)`
+- Console-script smoke workflow:
+  - `uv run open-cvn store init --path /tmp/opencode/open-cvn-issue-68-smoke.sqlite`
+  - `uv run open-cvn json import examples/open_cvn/research_entry.json --store /tmp/opencode/open-cvn-issue-68-smoke.sqlite --as-master`
+  - `uv run open-cvn versions derive public --store /tmp/opencode/open-cvn-issue-68-smoke.sqlite`
+  - `uv run open-cvn versions exclude public /curriculum/research/0 --store /tmp/opencode/open-cvn-issue-68-smoke.sqlite`
+  - `uv run open-cvn json export /tmp/opencode/open-cvn-issue-68-public.json --store /tmp/opencode/open-cvn-issue-68-smoke.sqlite --version public`
+  - `uv run open-cvn latex export /tmp/opencode/open-cvn-issue-68-public.tex --store /tmp/opencode/open-cvn-issue-68-smoke.sqlite --version public`
+  - `uv run open-cvn pdf generate /tmp/opencode/open-cvn-issue-68-public.pdf --store /tmp/opencode/open-cvn-issue-68-smoke.sqlite --version public`
+  - result: workflow initialized schema version `2`, imported a master document,
+    created a derived version, excluded one research entry, exported valid derived
+    JSON, exported valid derived LaTeX, and reported expected missing-compiler PDF
+    behavior because no `latexmk` or `pdflatex` executable is installed locally
+- `uv run pytest -n auto tests`
+  - result: `442 passed in 359.41s (0:05:59)`
+
+## Deviations From Planned Scope
+
+- No functional deviations.
+- PDF generation remains optional. The issue `#68` smoke workflow records the
+  expected missing-compiler behavior instead of requiring a local TeX installation.
+
+## New Limitations Found
+
+- No new durable limitations were found.
 
 ## Verification
 
@@ -68,4 +367,4 @@ This issue is part of epic `#60`.
 
 ## Status
 
-- Status: planned
+- Status: completed

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-67-pdf-generation-and-preview-handoff.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 67. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-68-application-mvp-tests-and-documentation.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 68. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-67-pdf-generation-and-preview-handoff.md
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-68-application-mvp-tests-and-documentation.md
 
 
 

--- a/tests/test_open_cvn_app_mvp_workflow.py
+++ b/tests/test_open_cvn_app_mvp_workflow.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from open_cvn import CvnValidationStatus, validate_open_cvn_json
+import open_cvn_app.cli as cli_module
+from open_cvn_app.cli import run
+from open_cvn_app.pdf import PdfGenerationUnavailable
+from open_cvn_app.storage import CurriculumRepository
+
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples" / "open_cvn"
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "open_cvn"
+
+
+def test_mvp_cli_workflow_imports_derives_exports_latex_and_reports_pdf_unavailable(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    store_path = tmp_path / "open-cvn.sqlite"
+    exported_json_path = tmp_path / "exports" / "public.json"
+    exported_tex_path = tmp_path / "exports" / "public.tex"
+    pdf_path = tmp_path / "exports" / "public.pdf"
+    input_path = EXAMPLES_DIR / "research_entry.json"
+
+    def unavailable_after_materialization(repository, **kwargs):
+        repository.materialize_version(kwargs["version"])
+        raise PdfGenerationUnavailable(("latexmk", "pdflatex"))
+
+    monkeypatch.setattr(cli_module, "generate_pdf_document", unavailable_after_materialization)
+
+    assert run(["store", "init", "--path", str(store_path)]) == 0
+    assert run(["json", "import", str(input_path), "--store", str(store_path), "--as-master"]) == 0
+    assert run(["versions", "derive", "public", "--store", str(store_path)]) == 0
+    assert run(["versions", "sections", "public", "--store", str(store_path)]) == 0
+    assert run(["versions", "entries", "public", "research", "--store", str(store_path)]) == 0
+    assert run(["versions", "exclude", "public", "/curriculum/research/0", "--store", str(store_path)]) == 0
+    assert run(["json", "export", str(exported_json_path), "--store", str(store_path), "--version", "public"]) == 0
+    assert run(["latex", "export", str(exported_tex_path), "--store", str(store_path), "--version", "public"]) == 0
+    assert run(["pdf", "generate", str(pdf_path), "--store", str(store_path), "--version", "public"]) == 1
+
+    captured = capsys.readouterr()
+    exported_document = json.loads(exported_json_path.read_text(encoding="utf-8"))
+    exported_latex = exported_tex_path.read_text(encoding="utf-8")
+    validation_result = validate_open_cvn_json(exported_document, source_identifier="issue-68-public")
+
+    assert "Curriculum sections for version 'public':" in captured.out
+    assert "Entries for version 'public' section 'research':" in captured.out
+    assert "Excluded /curriculum/research/0" in captured.out
+    assert "PDF generation unavailable." in captured.err
+    assert "No supported TeX compiler found" in captured.err
+    assert validation_result.validation_status == CvnValidationStatus.VALID
+    assert exported_document["curriculum"]["research"] == []
+    assert exported_document["extensions"]["x-open-cvn.versioning"]["version_name"] == "public"
+    assert "\\item[Version] public" in exported_latex
+    assert "Open CVN data representation" not in exported_latex
+    assert exported_latex.endswith("\n")
+    assert not pdf_path.exists()
+
+
+def test_mvp_invalid_import_workflow_leaves_store_empty(capsys: pytest.CaptureFixture[str], tmp_path: Path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    input_path = FIXTURES_DIR / "wrong_shape.json"
+
+    assert run(["store", "init", "--path", str(store_path)]) == 0
+    exit_code = run(["json", "import", str(input_path), "--store", str(store_path)])
+
+    captured = capsys.readouterr()
+    repository = CurriculumRepository(store_path)
+    assert exit_code == 1
+    assert "Open CVN JSON import failed." in captured.err
+    assert "json_schema_validation_failure" in captured.err
+    assert repository.list_curricula() == ()
+    assert repository.list_versions() == ()
+
+
+def test_mvp_temporary_stores_are_isolated_and_nested_exports_work(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+):
+    first_store = tmp_path / "first.sqlite"
+    second_store = tmp_path / "second.sqlite"
+    input_path = EXAMPLES_DIR / "minimal.json"
+    nested_export = tmp_path / "nested" / "outputs" / "master.json"
+
+    assert run(["store", "init", "--path", str(first_store)]) == 0
+    assert run(["store", "init", "--path", str(second_store)]) == 0
+    assert run(["json", "import", str(input_path), "--store", str(first_store), "--as-master"]) == 0
+    assert run(["versions", "list", "--store", str(second_store)]) == 0
+    assert run(["json", "export", str(nested_export), "--store", str(first_store), "--version", "master"]) == 0
+
+    output = capsys.readouterr().out
+    first_repository = CurriculumRepository(first_store)
+    second_repository = CurriculumRepository(second_store)
+    exported_document = json.loads(nested_export.read_text(encoding="utf-8"))
+
+    assert len(first_repository.list_curricula()) == 1
+    assert len(first_repository.list_versions()) == 1
+    assert second_repository.list_curricula() == ()
+    assert second_repository.list_versions() == ()
+    assert "No curriculum versions found." in output
+    assert nested_export.exists()
+    assert validate_open_cvn_json(exported_document).validation_status == CvnValidationStatus.VALID


### PR DESCRIPTION
## Summary
- Add end-to-end MVP workflow tests for import, derived selection, JSON export, LaTeX export, and optional PDF fallback.
- Add local application MVP user guide and link it from project entry docs.
- Mark issue #68 and epic #60 complete, with verification results recorded.
## Verification
- `uv run pytest -n auto tests/test_open_cvn_app_mvp_workflow.py -v`
- `uv run pytest -n auto tests/test_open_cvn_app_mvp_workflow.py tests/test_open_cvn_app_cli_unit.py tests/test_open_cvn_app_storage_unit.py tests/test_open_cvn_app_versioning_unit.py tests/test_open_cvn_app_editing_unit.py tests/test_open_cvn_app_latex_unit.py tests/test_open_cvn_app_pdf_unit.py -v`
- `uv run pytest -n auto tests`
Closes #68