### PR TITLE
Implement semantic CVN XML import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,8 @@ Every new session should read these files in order before making changes:
   `docs/roadmap/issues/issue-68-application-mvp-tests-and-documentation.md`
 - issue `#69`:
   `docs/roadmap/issues/issue-69-llm-assisted-import-spike.md`
+- issue `#70`:
+  `docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md`
 - hotfix `#1`: `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`
 - hotfix `#2`: `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`
 - hotfix `#3`:

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -146,6 +146,8 @@ files in order:
   planned application MVP tests and documentation issue
 - `docs/roadmap/issues/issue-69-llm-assisted-import-spike.md`: planned post-MVP
   LLM import exploration
+- `docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md`:
+  authoritative record of semantic CVN XML import into Open CVN JSON
 - `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`: maintenance
   record for the runner logging convention update
 - `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`: maintenance

--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -2,7 +2,7 @@
 
 ## Status Date
 
-- Last updated: 2026-07-15
+- Last updated: 2026-07-17
 
 ## Completed Or Stabilized Work
 
@@ -647,11 +647,12 @@
 - `parse_cvn_xml(...)` now accepts path, inline XML string, and XML bytes inputs
 - CVN XML import performs well-formedness checks, CVN plausibility checks, XML path
   trace extraction, and CVN code-like trace extraction
-- plausible CVN XML currently maps to a conservative Open CVN trace-only document
-  with import diagnostics under `extensions["x-open-cvn.import"]`
-- full semantic XML-to-domain mapping remains a documented limitation because the
-  runtime importer does not yet have enough curated mapping behavior for arbitrary
-  CVN XML records
+- plausible CVN XML now maps recognized `CvnItem` group and field codes into a
+  semantic partial Open CVN document with import diagnostics under
+  `extensions["x-open-cvn.xml_import"]`
+- complete semantic XML-to-domain mapping remains a documented limitation because
+  arbitrary CVN XML records and rare source-package edge cases are not yet fully
+  covered
 - synthetic JSON and XML fixtures exist under:
   - `tests/fixtures/open_cvn/`
   - `tests/fixtures/cvn_xml/`
@@ -672,7 +673,7 @@
 - the guide documents:
   - public `open_cvn` parser imports
   - Open CVN JSON parsing and validation
-  - direct CVN XML parsing and trace-only output interpretation
+  - direct CVN XML parsing and semantic partial output interpretation
   - deterministic CVN PDF XML extraction and PDF-to-XML handoff
   - structured parser errors
   - parser trace metadata
@@ -1101,6 +1102,41 @@
   - `uv run pytest -n auto tests`
   - result: `464 passed in 816.22s (0:13:36)`
 
+### Issue `#70`
+
+- the semantic CVN XML import issue is implemented under:
+  - `src/open_cvn/xml_semantic_mapping.py`
+  - `src/open_cvn/xml_semantic_extraction.py`
+  - `src/open_cvn/xml_value_conversion.py`
+  - `src/open_cvn/xml_semantic_import.py`
+  - `src/open_cvn/xml_import.py`
+- `parse_cvn_xml(...)` now uses a runtime mapping index built from
+  `schemas/open_cvn.schema.json` annotations instead of returning only a
+  trace-only empty curriculum for recognized CVN XML
+- recognized `CvnItem` records can populate `curriculum.identity`,
+  `curriculum.education[]`, `curriculum.research[]`, and other canonical Open CVN
+  sections
+- unmapped items and fields are preserved through import diagnostics, trace, or
+  `curriculum.other[]`
+- generated documents are validated through `validate_open_cvn_json(...)` before
+  successful parser results are returned
+- PDF import with embedded compatible XML now gets semantic partial Open CVN JSON
+  before any configured LLM fallback is considered
+- synthetic non-personal XML fixtures and semantic import tests are implemented
+  under `tests/fixtures/cvn_xml/` and `tests/test_xml_semantic_*_unit.py`
+- targeted semantic XML verification passed with:
+  - `uv run pytest -n auto tests/test_xml_semantic_mapping_unit.py tests/test_xml_semantic_extraction_unit.py tests/test_xml_value_conversion_unit.py tests/test_xml_semantic_import_unit.py -v`
+  - result: `11 passed in 20.45s`
+- targeted parser/PDF/CLI verification passed with:
+  - `uv run pytest -n auto tests/test_cvn_xml_import_unit.py tests/test_pdf_xml_extraction_unit.py tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `55 passed in 20.45s`
+- MVP workflow verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_app_mvp_workflow.py -v`
+  - result: `5 passed in 17.88s`
+- full-suite verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `477 passed in 985.71s (0:16:25)`
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -1112,9 +1148,9 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#68`: issue `#69` LLM-assisted PDF import fallback
-  is completed
-- Epic `#60` has been expanded into issues `#61` through `#69`
+- Next work item after issue `#69`: issue `#70` semantic CVN XML import is
+  implemented
+- Epic `#60` has been expanded into issues `#61` through `#70`
 - MVP direction:
   - CLI-first local prototype
   - SQLite local storage
@@ -1125,7 +1161,8 @@
   - optional PDF generation and preview handoff
   - application MVP tests and user documentation
   - basic opt-in LLM-assisted PDF import fallback
-- Next implementation issue: none currently documented after issue `#69`
+  - semantic partial CVN XML import before LLM fallback
+- Next implementation issue: none currently documented after issue `#70`
 
 ## Blocking Or Relevant Limitations
 
@@ -1141,8 +1178,9 @@
   hotfix `#7` evidence in the normalization-to-semantic handoff
 - wrapper-aware domain attachment requires normalization runs that provide
   `cvn_xsd_path` and `common_xsd_path`; canonical generation provides them
-- issue `#49` XML import is currently trace-only for plausible CVN XML and does
-  not yet perform full semantic XML-to-domain mapping
+- issue `#70` XML import is semantic partial for recognized CVN XML but does not
+  yet perform complete semantic XML-to-domain mapping for every source-package
+  edge case
 - issue `#69` LLM-assisted PDF import is provider-dependent and may produce
   incomplete or hallucinated content, so output is accepted only after local Open
   CVN JSON validation and should be reviewed by the user

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -33,12 +33,13 @@ Agents should also read `AGENTS.md` before this file.
   parser/validator contract, CLI shell, local SQLite storage, master/derived
   curriculum versioning, Open CVN JSON application import/export, curriculum
   editing/selection MVP, LaTeX export, optional PDF generation, application MVP
-  workflow tests/documentation, and LLM-assisted PDF import fallback completed
+  workflow tests/documentation, LLM-assisted PDF import fallback, and semantic
+  partial CVN XML import completed
 - Last documented issues: `#11`, `#12`, `#13`, `#14`, `#15`, `#16`, `#17`,
   `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, `#47`, `#48`, `#49`, `#50`,
-  `#61`, `#62`, `#63`, `#64`, `#65`, `#66`, `#67`, `#68`, and `#69`
+  `#61`, `#62`, `#63`, `#64`, `#65`, `#66`, `#67`, `#68`, `#69`, and `#70`
 - Latest documented hotfix records: `#3`, `#4`, `#5`, `#6`, `#7`, `#8`
-- Next planned issue: none currently documented after `#69`
+- Next planned issue: none currently documented after `#70`
 - Canonical source package: `docs/CvnXML_v1.4.3_2.1_17012025/`
 
 ## Documentation Map
@@ -127,6 +128,8 @@ Agents should also read `AGENTS.md` before this file.
   planned application MVP closure issue
 - `docs/roadmap/issues/issue-69-llm-assisted-import-spike.md`: planned post-MVP
   LLM import exploration
+- `docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md`:
+  implementation record for semantic CVN XML import into Open CVN JSON
 - `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`: maintenance
   record for the runner logging convention update
 - `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`: maintenance

--- a/docs/development/application_mvp_workflow.md
+++ b/docs/development/application_mvp_workflow.md
@@ -256,8 +256,8 @@ uv run pytest -n auto tests
 - The store is local, single-user SQLite storage.
 - Field-level edits are not supported; derived versions use section or entry
   include/exclude selection.
-- CVN XML import remains trace-only for plausible XML and does not perform full
-  semantic XML-to-domain mapping.
+- CVN XML import is semantic partial for recognized `CvnItem` records and does
+  not perform complete semantic XML-to-domain mapping for every CVN edge case.
 - LLM-assisted PDF import is opt-in, provider-dependent, and never bypasses local
   Open CVN JSON validation.
 - PDF generation requires an external TeX distribution and is optional.

--- a/docs/development/llm_import_workflow.md
+++ b/docs/development/llm_import_workflow.md
@@ -44,8 +44,10 @@ uv run open-cvn pdf import /path/to/cvn.pdf \
 ```
 
 If embedded XML or XML metadata is found and can be imported, the resulting Open
-CVN JSON is stored. Current CVN XML import is trace-only, so embedded XML imports
-may preserve trace metadata without populating all curriculum sections.
+CVN JSON is stored. Current CVN XML import is semantic partial: recognized
+`CvnItem` records can populate canonical curriculum sections before any LLM
+fallback is considered, while unmapped source data remains preserved in trace,
+extensions, or `curriculum.other[]`.
 
 ## LLM Fallback Import
 

--- a/docs/development/parser_workflow.md
+++ b/docs/development/parser_workflow.md
@@ -8,7 +8,7 @@ and validator workflow implemented by issues `#47`, `#48`, and `#49`.
 Use this guide when you need to:
 
 - validate an Open CVN JSON document
-- import direct CVN XML into the current trace-only Open CVN shape
+- import direct CVN XML into the current semantic partial Open CVN shape
 - extract embedded CVN XML from a PDF
 - inspect structured parser errors and trace metadata
 - run parser-focused regression tests
@@ -154,18 +154,23 @@ result_from_bytes = parse_cvn_xml(
 )
 ```
 
-Current XML import behavior is conservative:
+Current XML import behavior is conservative semantic partial import:
 
 - validates XML well-formedness
 - checks for plausible CVN evidence
 - preserves simplified XML paths
 - preserves CVN code-like values when detected
-- returns a trace-only Open CVN document for plausible CVN XML
-- does not perform full semantic XML-to-domain mapping
+- maps recognized `CvnItem` group and field codes into canonical Open CVN
+  curriculum sections using `schemas/open_cvn.schema.json` annotations
+- validates generated Open CVN JSON through `validate_open_cvn_json(...)`
+- preserves unmapped source items in trace/extensions or `curriculum.other[]`
+- does not perform complete semantic XML-to-domain mapping for every CVN edge case
 
-For plausible CVN XML, `data["extensions"]["x-open-cvn.import"]` records
-`mapping_status = "trace_only"`. Treat that as an import diagnostic, not proof
-that all curriculum content was converted.
+For plausible CVN XML, `data["extensions"]["x-open-cvn.xml_import"]` records
+`mapping_status = "semantic_partial"` when at least one item maps. Inputs with
+CVN evidence but no recognized semantic items may still report
+`mapping_status = "trace_only"`. Treat either status as an import diagnostic,
+not proof that all curriculum content was converted.
 
 XML errors use these codes:
 
@@ -201,8 +206,10 @@ PDF handling is extraction-only:
 - stores extraction metadata in `data["extraction"]`
 - leaves XML interpretation to `parse_cvn_xml(...)`
 
-PDF handling does not attempt OCR, page text reconstruction, LLM reconstruction,
-or direct XML-to-domain mapping.
+PDF handling does not attempt OCR or page text reconstruction. When
+`validate_extracted_xml=True`, extracted XML is handed to `parse_cvn_xml(...)`,
+which can now produce semantic partial Open CVN JSON before any configured LLM
+fallback is considered.
 
 PDF errors use these codes:
 

--- a/docs/development/regeneration_workflow.md
+++ b/docs/development/regeneration_workflow.md
@@ -261,7 +261,7 @@ The implemented tests cover:
 - JSON Schema generation, metadata, enum/open-reference treatment, determinism,
   and CLI output
 - parser contract, deterministic PDF XML extraction, Open CVN JSON validation,
-  trace-only CVN XML import, structured errors, and trace preservation
+  semantic partial CVN XML import, structured errors, and trace preservation
 - source coverage for manual, tree, auxiliary, semantic, and generated artifacts
 
 Tests that regenerate `src/generated/*` use `tests/xsdata_generation_lock.py` so

--- a/docs/pipeline/known_limitations.md
+++ b/docs/pipeline/known_limitations.md
@@ -123,22 +123,32 @@ do not need to rediscover them.
 
 ## Parser And Import Limitations
 
-### CVN XML Import Is Trace-Only For Plausible CVN XML
+### CVN XML Import Is Semantic Partial For Recognized CVN Items
 
 - Confirmed behavior:
-  - issue `#49` can read CVN XML inputs, check XML well-formedness, detect basic
-    CVN evidence, preserve XML paths, and preserve CVN code-like trace values
-  - plausible CVN XML maps to an Open CVN document with empty curriculum sections
-    and import diagnostics under `extensions["x-open-cvn.import"]`
-  - arbitrary CVN XML records are not yet semantically mapped into domain entries
+  - issue `#49` introduced CVN XML input reading, XML well-formedness checks,
+    basic CVN evidence detection, XML path preservation, and CVN code-like trace
+    preservation
+  - issue `#70` maps recognized `CvnItem` group and field codes into Open CVN
+    `identity`, `education`, `research`, `professional_experience`,
+    `achievements`, and `other` sections using `schemas/open_cvn.schema.json`
+    annotations
+  - generated Open CVN JSON is validated through `validate_open_cvn_json(...)`
+    before successful parser results are returned
+  - unmapped CVN items and fields are preserved through trace, import diagnostics,
+    and `curriculum.other[]` where applicable
+  - arbitrary CVN XML records and rare source-package edge cases are not yet fully
+    semantically mapped into domain entries
 - Impact:
-  - XML import now provides structured validation and trace preservation, but it is
-    not yet a full CVN XML-to-Open-CVN semantic converter
-  - downstream consumers should treat `mapping_status = "trace_only"` as an import
-    diagnostic, not as proof that all curriculum content was converted
+  - XML import now provides structured validation, trace preservation, and partial
+    semantic population, but it is not a complete CVN XML-to-Open-CVN converter
+  - downstream consumers should treat `mapping_status = "semantic_partial"` or
+    `mapping_status = "trace_only"` as import diagnostics, not as proof that all
+    curriculum content was converted
 - Expected follow-up:
-  - a later issue should define curated XML-to-domain mapping rules before the
-    importer converts real CVN XML records into populated Open CVN sections
+  - later work should add curated XML-to-domain mapping rules, richer controlled
+    reference label resolution, and broader fixture coverage before treating the
+    importer as a complete real-world CVN XML converter
 
 ### JSON Schema Validation Runs Before Runtime Model Validation
 

--- a/docs/pipeline/parser_validator_contract.md
+++ b/docs/pipeline/parser_validator_contract.md
@@ -189,9 +189,13 @@ Implemented behavior:
 - rejects mapping inputs as `unsupported_input_format`
 - validates XML well-formedness with `xml.etree.ElementTree`
 - records simplified XML paths and detected CVN code-like values in trace metadata
-- emits a conservative Open CVN JSON document with trace-only import diagnostics
-  for plausible CVN XML
-- does not yet perform full semantic XML-to-domain mapping from real CVN records
+- maps recognized `CvnItem` group and field codes to semantic partial Open CVN
+  JSON sections using `schemas/open_cvn.schema.json` annotations
+- validates generated Open CVN JSON through `validate_open_cvn_json(...)`
+- preserves unmapped CVN source items and fields in trace, import diagnostics, or
+  `curriculum.other[]`
+- does not yet perform complete semantic XML-to-domain mapping for every real CVN
+  source-package edge case
 
 ### JSON
 
@@ -414,19 +418,20 @@ Implemented behavior:
 }
 ```
 
-### Successful Trace-Only CVN XML Import
+### Successful Semantic Partial CVN XML Import
 
 ```json
 {
   "source_format": "cvn_xml",
-  "source_identifier": "minimal_cvn.xml",
+  "source_identifier": "semantic_education.xml",
   "data": {
     "schema_version": "0.1.0",
     "metadata": {
+      "language": "es",
       "source": {
         "format": "cvn_xml",
-        "identifier": "minimal_cvn.xml",
-        "path": "minimal_cvn.xml",
+        "identifier": "semantic_education.xml",
+        "path": "semantic_education.xml",
         "root": "CVNRoot"
       },
       "policy": {
@@ -436,7 +441,24 @@ Implemented behavior:
     },
     "curriculum": {
       "identity": {},
-      "education": [],
+      "education": [
+        {
+          "id": "education-020-010-010-000-001",
+          "type": "education.estudiosde1y2ciclo_020_010_010_000",
+          "data": {
+            "nombre_del_titulo": {
+              "label": "Synthetic Computer Science Degree",
+              "raw_value": "Synthetic Computer Science Degree",
+              "source": "CVN_TITLE_B"
+            }
+          },
+          "trace": {
+            "cvn_codes": ["020.010.010.000"],
+            "xml_paths": ["CVNRoot/CVNItem[1]"],
+            "confidence": "medium"
+          }
+        }
+      ],
       "research": [],
       "professional_experience": [],
       "achievements": [],
@@ -444,9 +466,19 @@ Implemented behavior:
     },
     "extensions": {
       "x-open-cvn.import": {
-        "cvn_codes": ["000.010.000.000"],
+        "cvn_codes": ["020.010.010.000", "020.010.010.030"],
         "xml_paths": ["CVNRoot", "CVNRoot/CVNItem[1]"],
-        "mapping_status": "trace_only"
+        "mapping_status": "semantic_partial"
+      },
+      "x-open-cvn.xml_import": {
+        "mapping_status": "semantic_partial",
+        "items_seen": 1,
+        "items_mapped": 1,
+        "items_unmapped": 0,
+        "fields_seen": 1,
+        "fields_mapped": 1,
+        "fields_unmapped": 0,
+        "unmapped_codes": []
       }
     }
   },
@@ -455,10 +487,10 @@ Implemented behavior:
   "errors": [],
   "trace": {
     "source_format": "cvn_xml",
-    "source_identifier": "minimal_cvn.xml",
-    "source_path": "minimal_cvn.xml",
+    "source_identifier": "semantic_education.xml",
+    "source_path": "semantic_education.xml",
     "extracted_from": null,
-    "cvn_codes": ["000.010.000.000"],
+    "cvn_codes": ["020.010.010.000", "020.010.010.030"],
     "xml_paths": ["CVNRoot", "CVNRoot/CVNItem[1]"],
     "schema_version": null,
     "policy_name": null,

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -43,7 +43,7 @@ Goal:
 | `#46` | Define canonical Open CVN JSON format | Completed | Canonical root, metadata, curriculum sections, entries, trace, extensions, examples, and schema alignment implemented |
 | `#47` | Define unified parser and validator contract | Completed | Public `open_cvn` contract package, structured result/error/trace models, deferred parser signatures, docs, and tests implemented |
 | `#48` | Extract CVN XML from PDF inputs | Completed | Deterministic PDF XML extraction implemented behind `parse_cvn_pdf(...)` with embedded-file and XML metadata support |
-| `#49` | Validate XML and JSON import paths | Completed | JSON Schema plus Pydantic Open CVN JSON validation implemented; CVN XML well-formedness, trace extraction, and trace-only Open CVN mapping implemented |
+| `#49` | Validate XML and JSON import paths | Completed | JSON Schema plus Pydantic Open CVN JSON validation implemented; CVN XML well-formedness, trace extraction, and initial trace-only Open CVN mapping implemented |
 | `#50` | Add tests and documentation for parser workflow | Completed | Parser workflow docs, coverage audit, `pydantic_validation_failure` regression, drift checks, and full-suite verification completed |
 | `#60` | Epic: CV management application | Completed | Local CLI-first MVP completed through issues `#61`-`#69`, including opt-in LLM-assisted PDF import fallback |
 | `#61` | Application MVP scope and CLI shell | Completed | CLI-first prototype shell, command surface, console script, placeholders, and smoke tests implemented |
@@ -55,6 +55,7 @@ Goal:
 | `#67` | PDF generation and preview handoff | Completed | Optional `latexmk`/`pdflatex` compilation, structured missing-compiler behavior, mocked tests, and explicit `--open` preview handoff implemented |
 | `#68` | Application MVP tests and documentation | Completed | End-to-end MVP workflow tests, application user guide, verification, and epic `#60` closure completed |
 | `#69` | LLM-assisted PDF import fallback | Completed | Deterministic-first PDF import, explicit external-LLM opt-in, OpenAI Responses provider adapter, local validation, CLI storage, mocked tests, and workflow docs implemented |
+| `#70` | Semantic CVN XML import to Open CVN JSON | Completed | Runtime schema-backed CVN code mapping, semantic partial XML import, deterministic PDF XML handoff before LLM fallback, synthetic fixtures, tests, and documentation implemented |
 
 Corrective planning after hotfixes `#4`, `#5`, and `#6`:
 

--- a/docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md
+++ b/docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md
@@ -187,6 +187,67 @@ Schema rather than re-running the generation pipeline at import time.
 
 ## Execution Plan
 
+### Accepted Execution Protocol
+
+Status: accepted for execution.
+
+This issue must be executed task by task. Every work update must identify the
+current task and, when applicable, the current subtask using this format:
+
+```text
+Task N/Subtask N.M activo.
+```
+
+Each task or subtask update must include:
+
+- a short summary of what the task or subtask is for
+- whether the user must modify any files before continuing
+- the next step to follow
+
+Default collaboration rule:
+
+- documentation changes may be made by the agent when they record accepted plans,
+  status, verification, or deviations
+- code changes should be left for the user unless the user explicitly authorizes
+  the agent to modify code files
+- if a code change is required, the agent should state the exact files and the
+  intended change before the user edits them
+- generated files under `src/generated/` must not be edited manually
+
+Required reporting cadence:
+
+- at the start of each task, state the task goal and first subtask
+- at the start of each subtask, state the subtask goal and expected files touched
+- at the end of each subtask, state completion status, user action needed, and
+  next subtask
+- at the end of each task, state task result, deviations, tests or checks run,
+  user action needed, and next task
+
+External research may be performed at any point when repository evidence is not
+enough. Repository-local source artifacts remain canonical for implementation.
+
+### Accepted High-Level Task Flow
+
+1. Confirm baseline trace-only XML behavior and current parser/PDF/CLI tests.
+2. Build a runtime semantic mapping index from `schemas/open_cvn.schema.json`.
+3. Extract semantic `CvnItem` records and field candidates from namespaced and
+   non-namespaced XML without depending on generated bindings.
+4. Convert extracted raw XML values into conservative Open CVN JSON-compatible
+   primitives, controlled references, wrappers, and `raw_value` fallbacks.
+5. Build semantic partial Open CVN documents with populated canonical curriculum
+   sections, trace, diagnostics, and validation through `validate_open_cvn_json(...)`.
+6. Integrate semantic import into `parse_cvn_xml(...)` while preserving structured
+   errors and parser contract behavior.
+7. Add synthetic non-personal XML fixtures for identity, education, research, and
+   unmapped cases.
+8. Add and update unit/integration tests for mapping, extraction, conversion,
+   semantic import, XML parser, PDF handoff, CLI storage, and LLM fallback
+   boundaries.
+9. Update persistent documentation so future sessions no longer treat CVN XML
+   import as trace-only.
+10. Run targeted parser/PDF/CLI/MVP verification and the full repository suite,
+    then record final results in this issue.
+
 ### Task 1 - Baseline And Scope Confirmation
 
 Summary: confirm current trace-only behavior, record target behavior, and avoid
@@ -418,6 +479,71 @@ Summary: run targeted and full verification, then record final status.
 - updated documentation replacing the old trace-only limitation with a semantic
   partial import limitation
 
+## Implementation Notes
+
+- Implemented semantic XML import modules:
+  - `src/open_cvn/xml_semantic_mapping.py`
+  - `src/open_cvn/xml_semantic_extraction.py`
+  - `src/open_cvn/xml_value_conversion.py`
+  - `src/open_cvn/xml_semantic_import.py`
+- `src/open_cvn/xml_import.py` now delegates plausible CVN XML to the semantic
+  importer after well-formedness and CVN-evidence checks.
+- The runtime mapping index is built from `schemas/open_cvn.schema.json` and uses
+  `x-open-cvn-entity-id`, `x-open-cvn-domain-area-id`,
+  `x-open-cvn-source-group-key`, `x-open-cvn-code`,
+  `x-open-cvn-domain-shape-kind`, and related annotations.
+- Identity is handled through the generated schema source group
+  `__no_cvn_item__`, with runtime fallback for `000.*` CVN identity-like codes.
+- XML extraction supports namespace-safe simplified fixtures and official-like
+  `CvnItem` item-code structures without using generated structural bindings.
+- Value conversion is conservative: known primitive, date, array, controlled
+  reference, and wrapper-like values are converted; unrecognized values preserve
+  raw source data.
+- Generated documents include `metadata.language = "es"`, parser source metadata,
+  policy metadata, canonical curriculum sections, legacy import diagnostics under
+  `extensions["x-open-cvn.import"]`, and semantic import diagnostics under
+  `extensions["x-open-cvn.xml_import"]`.
+- Generated documents are validated through `validate_open_cvn_json(...)` before
+  successful parser results are returned.
+- PDF import with `validate_extracted_xml=True` now receives semantic partial Open
+  CVN JSON from embedded compatible XML before any configured LLM fallback.
+
+## Implemented Artifacts
+
+- Added tests:
+  - `tests/test_xml_semantic_mapping_unit.py`
+  - `tests/test_xml_semantic_extraction_unit.py`
+  - `tests/test_xml_value_conversion_unit.py`
+  - `tests/test_xml_semantic_import_unit.py`
+- Added synthetic non-personal fixtures:
+  - `tests/fixtures/cvn_xml/semantic_identity.xml`
+  - `tests/fixtures/cvn_xml/semantic_education.xml`
+  - `tests/fixtures/cvn_xml/semantic_research.xml`
+  - `tests/fixtures/cvn_xml/semantic_unmapped.xml`
+- Updated parser/PDF/CLI tests for semantic partial XML import and deterministic
+  PDF XML handoff before LLM fallback.
+- Updated persistent documentation in parser, LLM import, MVP workflow,
+  regeneration workflow, limitations, roadmap, current status, and entry-point
+  maps.
+
+## Verification Results
+
+- Baseline before implementation:
+  `uv run pytest -n auto tests/test_cvn_xml_import_unit.py tests/test_pdf_xml_extraction_unit.py tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `53 passed in 10.57s`
+- Semantic XML unit verification:
+  `uv run pytest -n auto tests/test_xml_semantic_mapping_unit.py tests/test_xml_semantic_extraction_unit.py tests/test_xml_value_conversion_unit.py tests/test_xml_semantic_import_unit.py -v`
+  - result: `11 passed in 20.45s`
+- Parser/PDF/CLI regression verification:
+  `uv run pytest -n auto tests/test_cvn_xml_import_unit.py tests/test_pdf_xml_extraction_unit.py tests/test_open_cvn_app_cli_unit.py -v`
+  - result: `55 passed in 20.45s`
+- MVP workflow verification:
+  `uv run pytest -n auto tests/test_open_cvn_app_mvp_workflow.py -v`
+  - result: `5 passed in 17.88s`
+- Full-suite verification:
+  `uv run pytest -n auto tests`
+  - result: `477 passed in 985.71s (0:16:25)`
+
 ## Status
 
-- Status: planned
+- Status: completed

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,8 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-69-llm-assisted-import-spike.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 69. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 70. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-69-llm-assisted-import-spike.md
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md
 
 
 

--- a/src/open_cvn/xml_import.py
+++ b/src/open_cvn/xml_import.py
@@ -6,7 +6,6 @@ from typing import Mapping
 from xml.etree import ElementTree
 
 from open_cvn.import_utils import load_text_input, make_error, make_trace
-from open_cvn.open_cvn_models import OPEN_CVN_SCHEMA_VERSION
 from open_cvn.parser_contract import (
     CvnErrorCode,
     CvnInput,
@@ -15,11 +14,10 @@ from open_cvn.parser_contract import (
     CvnSourceFormat,
     CvnValidationStatus,
 )
+from open_cvn.xml_semantic_import import import_cvn_xml_semantically
 
 
 CVN_CODE_RE = re.compile(r"\b\d{3}\.\d{3}\.\d{3}\.\d{3}\b")
-DEFAULT_POLICY_NAME = "default_cvn_semantic_policy"
-DEFAULT_POLICY_VERSION = "0.1.0"
 
 
 def parse_cvn_xml(source: CvnInput, *, source_identifier: str | None = None) -> CvnParseResult:
@@ -98,13 +96,27 @@ def parse_cvn_xml(source: CvnInput, *, source_identifier: str | None = None) -> 
             trace=trace,
         )
 
-    document = _map_xml_to_open_cvn(
-        source_identifier=loaded.source_identifier,
-        source_path=loaded.source_path,
-        root=root,
-        cvn_codes=cvn_codes,
-        xml_paths=xml_paths,
-    )
+    try:
+        document = import_cvn_xml_semantically(
+            source_identifier=loaded.source_identifier,
+            source_path=loaded.source_path,
+            root=root,
+        )
+    except ValueError as exc:
+        return CvnParseResult(
+            source_format=CvnSourceFormat.CVN_XML,
+            source_identifier=loaded.source_identifier,
+            validation_status=CvnValidationStatus.INVALID,
+            errors=(
+                make_error(
+                    code=CvnErrorCode.XML_SEMANTICALLY_UNMAPPABLE,
+                    message="CVN XML is readable but cannot be mapped to valid Open CVN JSON.",
+                    path=(xml_paths[0],) if xml_paths else (),
+                    details={"error": str(exc)},
+                ),
+            ),
+            trace=trace,
+        )
     return CvnParseResult(
         source_format=CvnSourceFormat.CVN_XML,
         source_identifier=loaded.source_identifier,
@@ -112,46 +124,6 @@ def parse_cvn_xml(source: CvnInput, *, source_identifier: str | None = None) -> 
         validation_status=CvnValidationStatus.VALID,
         trace=trace,
     )
-
-
-def _map_xml_to_open_cvn(
-    *,
-    source_identifier: str | None,
-    source_path: str | None,
-    root: ElementTree.Element,
-    cvn_codes: tuple[str, ...],
-    xml_paths: tuple[str, ...],
-) -> dict[str, object]:
-    return {
-        "schema_version": OPEN_CVN_SCHEMA_VERSION,
-        "metadata": {
-            "source": {
-                "format": CvnSourceFormat.CVN_XML.value,
-                "identifier": source_identifier,
-                "path": source_path,
-                "root": _local_name(root.tag),
-            },
-            "policy": {
-                "name": DEFAULT_POLICY_NAME,
-                "version": DEFAULT_POLICY_VERSION,
-            },
-        },
-        "curriculum": {
-            "identity": {},
-            "education": [],
-            "research": [],
-            "professional_experience": [],
-            "achievements": [],
-            "other": [],
-        },
-        "extensions": {
-            "x-open-cvn.import": {
-                "cvn_codes": list(cvn_codes),
-                "xml_paths": list(xml_paths),
-                "mapping_status": "trace_only",
-            }
-        },
-    }
 
 
 def _xml_paths(root: ElementTree.Element) -> tuple[str, ...]:

--- a/src/open_cvn/xml_semantic_extraction.py
+++ b/src/open_cvn/xml_semantic_extraction.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from xml.etree import ElementTree
+
+
+CVN_CODE_RE = re.compile(r"\b\d{3}\.\d{3}\.\d{3}\.\d{3}\b")
+
+
+@dataclass(frozen=True)
+class ExtractedXmlField:
+    code: str
+    raw_value: str
+    xml_path: str
+
+
+@dataclass(frozen=True)
+class ExtractedXmlItem:
+    code: str
+    xml_path: str
+    fields: tuple[ExtractedXmlField, ...]
+
+
+@dataclass(frozen=True)
+class XmlSemanticExtractionResult:
+    items: tuple[ExtractedXmlItem, ...]
+    cvn_codes: tuple[str, ...]
+    xml_paths: tuple[str, ...]
+
+
+def extract_xml_semantic_items(root: ElementTree.Element) -> XmlSemanticExtractionResult:
+    paths = _element_paths(root)
+    codes = _cvn_codes(root)
+    items: list[ExtractedXmlItem] = []
+
+    for element in root.iter():
+        if _local_name(element.tag).lower() not in {"cvnitem", "cvn_item"}:
+            continue
+        item_code = _item_code(element)
+        if item_code is None:
+            continue
+        item_path = paths.get(id(element), _local_name(element.tag))
+        fields = _item_fields(element, item_code=item_code, paths=paths)
+        items.append(ExtractedXmlItem(code=item_code, xml_path=item_path, fields=tuple(fields)))
+
+    return XmlSemanticExtractionResult(items=tuple(items), cvn_codes=codes, xml_paths=tuple(paths.values())[:200])
+
+
+def _item_fields(
+    element: ElementTree.Element,
+    *,
+    item_code: str,
+    paths: dict[int, str],
+) -> list[ExtractedXmlField]:
+    fields: list[ExtractedXmlField] = []
+    seen: set[tuple[str, str, str]] = set()
+    for descendant in element.iter():
+        if descendant is element:
+            continue
+        field_code = _element_code(descendant)
+        if field_code is None:
+            continue
+        raw_value = _raw_value(descendant)
+        if not raw_value:
+            continue
+        if field_code == item_code and _is_item_identifier_path(descendant):
+            continue
+        xml_path = paths.get(id(descendant), _local_name(descendant.tag))
+        key = (field_code, raw_value, xml_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        fields.append(ExtractedXmlField(code=field_code, raw_value=raw_value, xml_path=xml_path))
+
+    if not fields:
+        raw_value = _raw_value(element)
+        if raw_value and raw_value != item_code:
+            fields.append(
+                ExtractedXmlField(
+                    code=item_code,
+                    raw_value=raw_value,
+                    xml_path=paths.get(id(element), _local_name(element.tag)),
+                )
+            )
+    return fields
+
+
+def _item_code(element: ElementTree.Element) -> str | None:
+    code = _element_code(element)
+    if code is not None:
+        return code
+    for descendant in element.iter():
+        name = _local_name(descendant.tag).lower()
+        if name in {"codecvnitem", "cvncode", "code"}:
+            code = _element_code(descendant)
+            if code is not None:
+                return code
+    return None
+
+
+def _element_code(element: ElementTree.Element) -> str | None:
+    for value in element.attrib.values():
+        match = CVN_CODE_RE.search(str(value))
+        if match:
+            return match.group(0)
+    if element.text:
+        match = CVN_CODE_RE.search(element.text)
+        if match:
+            return match.group(0)
+    for child in list(element):
+        if _local_name(child.tag).lower() == "item" and child.text:
+            match = CVN_CODE_RE.search(child.text)
+            if match:
+                return match.group(0)
+    return None
+
+
+def _raw_value(element: ElementTree.Element) -> str:
+    values: list[str] = []
+    for value in element.attrib.values():
+        text = str(value).strip()
+        if text and not CVN_CODE_RE.fullmatch(text):
+            values.append(text)
+    for descendant in element.iter():
+        if descendant.text:
+            text = descendant.text.strip()
+            if text and not CVN_CODE_RE.fullmatch(text):
+                values.append(text)
+    return " ".join(dict.fromkeys(values)).strip()
+
+
+def _is_item_identifier_path(element: ElementTree.Element) -> bool:
+    names = {_local_name(descendant.tag).lower() for descendant in element.iter()}
+    return bool({"codecvnitem", "cvnitemid"} & names)
+
+
+def _element_paths(root: ElementTree.Element) -> dict[int, str]:
+    paths: dict[int, str] = {}
+
+    def visit(element: ElementTree.Element, path: str) -> None:
+        paths[id(element)] = path
+        counts: dict[str, int] = {}
+        for child in list(element):
+            child_name = _local_name(child.tag)
+            counts[child_name] = counts.get(child_name, 0) + 1
+            visit(child, f"{path}/{child_name}[{counts[child_name]}]")
+
+    visit(root, _local_name(root.tag))
+    return paths
+
+
+def _cvn_codes(root: ElementTree.Element) -> tuple[str, ...]:
+    codes: list[str] = []
+    seen: set[str] = set()
+    for element in root.iter():
+        values = [str(element.tag), *(str(value) for value in element.attrib.values())]
+        if element.text:
+            values.append(element.text)
+        for value in values:
+            for match in CVN_CODE_RE.findall(value):
+                if match not in seen:
+                    seen.add(match)
+                    codes.append(match)
+    return tuple(codes)
+
+
+def _local_name(tag: object) -> str:
+    text = str(tag)
+    if "}" in text:
+        return text.rsplit("}", maxsplit=1)[1]
+    return text

--- a/src/open_cvn/xml_semantic_import.py
+++ b/src/open_cvn/xml_semantic_import.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+from xml.etree import ElementTree
+
+from open_cvn.json_import import validate_open_cvn_json
+from open_cvn.open_cvn_models import OPEN_CVN_SCHEMA_VERSION
+from open_cvn.parser_contract import CvnSourceFormat, CvnValidationStatus
+from open_cvn.xml_semantic_extraction import ExtractedXmlItem, extract_xml_semantic_items
+from open_cvn.xml_semantic_mapping import XmlEntityMapping, load_xml_semantic_mapping_index
+from open_cvn.xml_value_conversion import convert_xml_value
+
+
+DEFAULT_POLICY_NAME = "default_cvn_semantic_policy"
+DEFAULT_POLICY_VERSION = "0.1.0"
+
+
+def import_cvn_xml_semantically(
+    *,
+    root: ElementTree.Element,
+    source_identifier: str | None,
+    source_path: str | None,
+) -> dict[str, Any]:
+    extraction = extract_xml_semantic_items(root)
+    index = load_xml_semantic_mapping_index()
+    counters: Counter[str] = Counter()
+    curriculum: dict[str, Any] = {
+        "identity": {},
+        "education": [],
+        "research": [],
+        "professional_experience": [],
+        "achievements": [],
+        "other": [],
+    }
+    section_counts: Counter[str] = Counter()
+    unmapped_codes: list[str] = []
+
+    for item in extraction.items:
+        counters["items_seen"] += 1
+        entity = index.entity_for_group(item.code)
+        if entity is None:
+            counters["items_unmapped"] += 1
+            unmapped_codes.append(item.code)
+            _append_unmapped_item(curriculum, item)
+            counters["fields_seen"] += len(item.fields)
+            counters["fields_unmapped"] += len(item.fields)
+            continue
+
+        counters["items_mapped"] += 1
+        data: dict[str, Any] = {}
+        xml_paths = [item.xml_path]
+        for field in item.fields:
+            counters["fields_seen"] += 1
+            field_mappings = index.fields_for_code(field.code, group_code=item.code)
+            if not field_mappings:
+                counters["fields_unmapped"] += 1
+                if field.code not in unmapped_codes:
+                    unmapped_codes.append(field.code)
+                continue
+            field_mapping = field_mappings[0]
+            data[field_mapping.field_name] = convert_xml_value(field.raw_value, field_mapping)
+            xml_paths.append(field.xml_path)
+            counters["fields_mapped"] += 1
+
+        if entity.domain_area_id == "identity":
+            curriculum["identity"].update(data)
+        else:
+            section = _section_name(entity)
+            section_counts[section] += 1
+            curriculum[section].append(
+                {
+                    "id": _entry_id(section, item.code, section_counts[section]),
+                    "type": entity.entity_id,
+                    "data": data,
+                    "trace": {
+                        "cvn_codes": [item.code],
+                        "xml_paths": xml_paths,
+                        "confidence": "medium" if data else "low",
+                    },
+                }
+            )
+
+    mapping_status = "semantic_partial" if counters["items_mapped"] else "trace_only"
+    document = {
+        "schema_version": OPEN_CVN_SCHEMA_VERSION,
+        "metadata": {
+            "language": "es",
+            "source": {
+                "format": CvnSourceFormat.CVN_XML.value,
+                "identifier": source_identifier,
+                "path": source_path,
+                "root": _local_name(root.tag),
+            },
+            "policy": {"name": DEFAULT_POLICY_NAME, "version": DEFAULT_POLICY_VERSION},
+        },
+        "curriculum": curriculum,
+        "extensions": {
+            "x-open-cvn.import": {
+                "cvn_codes": list(extraction.cvn_codes),
+                "xml_paths": list(extraction.xml_paths),
+                "mapping_status": mapping_status,
+            },
+            "x-open-cvn.xml_import": {
+                "mapping_status": mapping_status,
+                "items_seen": counters["items_seen"],
+                "items_mapped": counters["items_mapped"],
+                "items_unmapped": counters["items_unmapped"],
+                "fields_seen": counters["fields_seen"],
+                "fields_mapped": counters["fields_mapped"],
+                "fields_unmapped": counters["fields_unmapped"],
+                "unmapped_codes": unmapped_codes,
+            },
+        },
+    }
+    validation = validate_open_cvn_json(document, source_identifier=source_identifier, source_path=source_path)
+    if validation.validation_status in {CvnValidationStatus.INVALID, CvnValidationStatus.FAILED}:
+        raise ValueError(
+            "Semantic CVN XML import produced invalid Open CVN JSON: "
+            f"{[issue.model_dump(mode='json') for issue in validation.errors]}"
+        )
+    return dict(validation.data or document)
+
+
+def _append_unmapped_item(curriculum: dict[str, Any], item: ExtractedXmlItem) -> None:
+    curriculum["other"].append(
+        {
+            "id": _entry_id("other", item.code, len(curriculum["other"]) + 1),
+            "type": "other.unmapped_cvn_item",
+            "data": {},
+            "trace": {
+                "cvn_codes": [item.code],
+                "xml_paths": [item.xml_path, *(field.xml_path for field in item.fields)],
+                "confidence": "low",
+            },
+            "extensions": {
+                "x-open-cvn.xml_import": {
+                    "raw_fields": [
+                        {"code": field.code, "raw_value": field.raw_value, "xml_path": field.xml_path}
+                        for field in item.fields
+                    ]
+                }
+            },
+        }
+    )
+
+
+def _section_name(entity: XmlEntityMapping) -> str:
+    if entity.domain_area_id in {
+        "education",
+        "research",
+        "professional_experience",
+        "achievements",
+        "other",
+    }:
+        return entity.domain_area_id
+    return "other"
+
+
+def _entry_id(section: str, code: str, number: int) -> str:
+    return f"{section}-{code.replace('.', '-')}-{number:03d}"
+
+
+def _local_name(tag: object) -> str:
+    text = str(tag)
+    if "}" in text:
+        return text.rsplit("}", maxsplit=1)[1]
+    return text

--- a/src/open_cvn/xml_semantic_mapping.py
+++ b/src/open_cvn/xml_semantic_mapping.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class XmlFieldMapping:
+    code: str
+    field_name: str
+    entity_id: str
+    domain_area_id: str
+    source_group_key: str
+    domain_shape_kind: str | None
+    vocabulary_kind: str | None
+    source_reference: str | None
+    schema: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class XmlEntityMapping:
+    entity_id: str
+    domain_area_id: str
+    source_group_key: str
+    fields: tuple[XmlFieldMapping, ...]
+
+
+@dataclass(frozen=True)
+class XmlSemanticMappingIndex:
+    entities_by_group_code: Mapping[str, XmlEntityMapping]
+    fields_by_code: Mapping[str, tuple[XmlFieldMapping, ...]]
+    fields_by_group_code: Mapping[str, tuple[XmlFieldMapping, ...]]
+
+    def entity_for_group(self, code: str) -> XmlEntityMapping | None:
+        entity = self.entities_by_group_code.get(code)
+        if entity is not None:
+            return entity
+        if code.startswith("000."):
+            return self.entities_by_group_code.get("__no_cvn_item__")
+        return None
+
+    def fields_for_code(self, code: str, *, group_code: str | None = None) -> tuple[XmlFieldMapping, ...]:
+        fields = self.fields_by_code.get(code, ())
+        if group_code is None:
+            return fields
+        if group_code.startswith("000."):
+            scoped = tuple(field for field in fields if field.source_group_key == "__no_cvn_item__")
+            if scoped:
+                return scoped
+        scoped = tuple(field for field in fields if field.source_group_key == group_code)
+        return scoped or fields
+
+
+@lru_cache(maxsize=1)
+def load_xml_semantic_mapping_index() -> XmlSemanticMappingIndex:
+    schema = json.loads(_schema_path().read_text(encoding="utf-8"))
+    defs = schema.get("$defs", {})
+    if not isinstance(defs, Mapping):
+        return XmlSemanticMappingIndex({}, {}, {})
+
+    entities_by_group_code: dict[str, XmlEntityMapping] = {}
+    fields_by_code: dict[str, list[XmlFieldMapping]] = {}
+    fields_by_group_code: dict[str, list[XmlFieldMapping]] = {}
+
+    for definition in defs.values():
+        if not isinstance(definition, Mapping):
+            continue
+        entity_id = _string_or_none(definition.get("x-open-cvn-entity-id"))
+        domain_area_id = _string_or_none(definition.get("x-open-cvn-domain-area-id"))
+        source_group_key = _string_or_none(definition.get("x-open-cvn-source-group-key"))
+        if entity_id is None or domain_area_id is None or source_group_key is None:
+            continue
+
+        properties = definition.get("properties", {})
+        entity_fields: list[XmlFieldMapping] = []
+        if isinstance(properties, Mapping):
+            for field_name, field_schema in properties.items():
+                if not isinstance(field_name, str) or not isinstance(field_schema, Mapping):
+                    continue
+                field_code = _string_or_none(field_schema.get("x-open-cvn-code"))
+                if field_code is None:
+                    continue
+                field_mapping = XmlFieldMapping(
+                    code=field_code,
+                    field_name=field_name,
+                    entity_id=entity_id,
+                    domain_area_id=domain_area_id,
+                    source_group_key=source_group_key,
+                    domain_shape_kind=_string_or_none(field_schema.get("x-open-cvn-domain-shape-kind")),
+                    vocabulary_kind=_string_or_none(field_schema.get("x-open-cvn-vocabulary-kind")),
+                    source_reference=_string_or_none(field_schema.get("x-open-cvn-source-reference")),
+                    schema=field_schema,
+                )
+                entity_fields.append(field_mapping)
+                fields_by_code.setdefault(field_code, []).append(field_mapping)
+                fields_by_group_code.setdefault(source_group_key, []).append(field_mapping)
+
+        entities_by_group_code[source_group_key] = XmlEntityMapping(
+            entity_id=entity_id,
+            domain_area_id=domain_area_id,
+            source_group_key=source_group_key,
+            fields=tuple(entity_fields),
+        )
+
+    return XmlSemanticMappingIndex(
+        entities_by_group_code=entities_by_group_code,
+        fields_by_code={code: tuple(fields) for code, fields in fields_by_code.items()},
+        fields_by_group_code={code: tuple(fields) for code, fields in fields_by_group_code.items()},
+    )
+
+
+def _schema_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "schemas" / "open_cvn.schema.json"
+
+
+def _string_or_none(value: object) -> str | None:
+    if isinstance(value, str):
+        return value
+    return None

--- a/src/open_cvn/xml_value_conversion.py
+++ b/src/open_cvn/xml_value_conversion.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+
+from open_cvn.xml_semantic_mapping import XmlFieldMapping
+
+
+def convert_xml_value(raw_value: str, mapping: XmlFieldMapping) -> object:
+    value = raw_value.strip()
+    if not value:
+        return {"raw_value": raw_value}
+
+    if _is_controlled_reference(mapping):
+        converted = {"source": mapping.source_reference, "raw_value": value}
+        if _looks_like_code(value):
+            converted["code"] = value
+        else:
+            converted["label"] = value
+        return converted
+
+    ref = mapping.schema.get("$ref")
+    if ref == "#/$defs/FlexibleDateValue":
+        return _flexible_date(value)
+    if ref == "#/$defs/OfficialIdValue":
+        return {"raw_value": value}
+    if ref == "#/$defs/EntityNameValue":
+        return {"raw_value": value}
+    if ref == "#/$defs/EntityTypeValue":
+        return {"raw_value": value}
+
+    schema_type = mapping.schema.get("type")
+    if schema_type == "array":
+        return [value]
+    if _schema_accepts_bool(schema_type):
+        boolean = _boolean_or_none(value)
+        if boolean is not None:
+            return boolean
+    if _schema_accepts_number(schema_type):
+        decimal = _decimal_or_none(value)
+        if decimal is not None:
+            return decimal
+    return value
+
+
+def _is_controlled_reference(mapping: XmlFieldMapping) -> bool:
+    shape = mapping.domain_shape_kind or ""
+    return "reference" in shape or mapping.source_reference is not None
+
+
+def _looks_like_code(value: str) -> bool:
+    return bool(value) and not any(character.isspace() for character in value)
+
+
+def _schema_accepts_bool(schema_type: object) -> bool:
+    return schema_type == "boolean" or (isinstance(schema_type, list) and "boolean" in schema_type)
+
+
+def _schema_accepts_number(schema_type: object) -> bool:
+    if isinstance(schema_type, list):
+        return bool({"number", "integer"} & set(schema_type))
+    return schema_type in {"number", "integer"}
+
+
+def _boolean_or_none(value: str) -> bool | None:
+    normalized = value.strip().lower()
+    if normalized in {"true", "1", "si", "sí"}:
+        return True
+    if normalized in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def _decimal_or_none(value: str) -> int | float | None:
+    try:
+        decimal = Decimal(value.replace(",", "."))
+    except InvalidOperation:
+        return None
+    if decimal == decimal.to_integral_value():
+        return int(decimal)
+    return float(decimal)
+
+
+def _flexible_date(value: str) -> dict[str, object]:
+    parts = value.split("-")
+    result: dict[str, object] = {"raw_value": value}
+    if len(parts) >= 1 and len(parts[0]) == 4 and parts[0].isdigit():
+        result["year"] = int(parts[0])
+    if len(parts) >= 2 and len(parts[1]) in {1, 2} and parts[1].isdigit():
+        result["month"] = int(parts[1])
+    if len(parts) >= 3 and len(parts[2]) in {1, 2} and parts[2].isdigit():
+        result["day"] = int(parts[2])
+    return result

--- a/tests/fixtures/cvn_xml/semantic_education.xml
+++ b/tests/fixtures/cvn_xml/semantic_education.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CVNRoot>
+  <CVNItem code="020.010.010.000">
+    <Field code="020.010.010.030">Synthetic Computer Science Degree</Field>
+    <Field code="020.010.010.130">2024-06-30</Field>
+  </CVNItem>
+</CVNRoot>

--- a/tests/fixtures/cvn_xml/semantic_identity.xml
+++ b/tests/fixtures/cvn_xml/semantic_identity.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CVNRoot xmlns="https://example.test/cvn">
+  <CVNItem code="000.010.000.000">
+    <Field code="000.010.000.020">Ada</Field>
+    <Field code="000.010.000.010">Lovelace Synthetic</Field>
+  </CVNItem>
+</CVNRoot>

--- a/tests/fixtures/cvn_xml/semantic_research.xml
+++ b/tests/fixtures/cvn_xml/semantic_research.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CVNRoot>
+  <CVNItem code="060.010.040.000">
+    <Field code="060.010.040.350">Synthetic Author</Field>
+    <Field code="060.010.040.340">Synthetic outreach activity</Field>
+  </CVNItem>
+</CVNRoot>

--- a/tests/fixtures/cvn_xml/semantic_unmapped.xml
+++ b/tests/fixtures/cvn_xml/semantic_unmapped.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CVNRoot>
+  <CVNItem code="999.999.999.999">
+    <Field code="999.999.999.998">Synthetic unmapped value</Field>
+  </CVNItem>
+</CVNRoot>

--- a/tests/test_cvn_xml_import_unit.py
+++ b/tests/test_cvn_xml_import_unit.py
@@ -17,6 +17,18 @@ def test_parse_cvn_xml_accepts_path_input():
     assert "000.010.000.000" in result.trace.cvn_codes
 
 
+def test_parse_cvn_xml_populates_semantic_partial_document():
+    result = parse_cvn_xml(FIXTURES / "semantic_education.xml")
+
+    assert result.validation_status == CvnValidationStatus.VALID
+    assert result.data is not None
+    assert result.data["extensions"]["x-open-cvn.xml_import"]["mapping_status"] == "semantic_partial"
+    assert result.data["curriculum"]["education"]
+    assert result.data["curriculum"]["education"][0]["data"]["nombre_del_titulo"]["raw_value"] == (
+        "Synthetic Computer Science Degree"
+    )
+
+
 def test_parse_cvn_xml_accepts_inline_xml_string():
     payload = (FIXTURES / "minimal_cvn.xml").read_text(encoding="utf-8")
 

--- a/tests/test_open_cvn_app_cli_unit.py
+++ b/tests/test_open_cvn_app_cli_unit.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+import pymupdf
 
 from open_cvn import (
     CvnErrorCode,
@@ -24,6 +25,13 @@ from open_cvn_app.storage import CurriculumCreate, CurriculumRepository, initial
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "open_cvn"
 EXAMPLES_DIR = Path(__file__).parent.parent / "examples" / "open_cvn"
+SEMANTIC_CVN_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<CVNRoot xmlns="https://example.test/cvn">
+  <CVNItem code="020.010.010.000">
+    <Field code="020.010.010.030">Synthetic Computer Science Degree</Field>
+  </CVNItem>
+</CVNRoot>
+"""
 
 
 def _create_store_with_curriculum(tmp_path):
@@ -33,6 +41,14 @@ def _create_store_with_curriculum(tmp_path):
     document = json.loads((FIXTURES_DIR / "valid_minimal.json").read_text(encoding="utf-8"))
     curriculum = repository.create_curriculum(CurriculumCreate(display_name="Master CV", document=document))
     return store_path, curriculum
+
+
+def _save_pdf_with_embedded_xml(path: Path, xml_text: str = SEMANTIC_CVN_XML) -> None:
+    document = pymupdf.open()
+    document.new_page()
+    document.embfile_add("cvn.xml", xml_text.encode("utf-8"), filename="cvn.xml")
+    document.save(path)
+    document.close()
 
 
 def test_cli_help_contains_program_and_command_groups(capsys: pytest.CaptureFixture[str]):
@@ -206,6 +222,36 @@ def test_pdf_import_stores_valid_pdf_parse_result(
     assert "Assigned master curriculum version 'master'" in output
     assert len(repository.list_curricula()) == 1
     assert len(repository.list_versions()) == 1
+
+
+def test_pdf_import_stores_semantic_embedded_xml_without_llm(capsys: pytest.CaptureFixture[str], tmp_path: Path):
+    store_path = tmp_path / "open-cvn.sqlite"
+    initialize_store(store_path)
+    input_path = tmp_path / "cv.pdf"
+    _save_pdf_with_embedded_xml(input_path)
+
+    exit_code = run([
+        "pdf",
+        "import",
+        str(input_path),
+        "--store",
+        str(store_path),
+        "--name",
+        "Semantic PDF CV",
+    ])
+
+    output = capsys.readouterr().out
+    repository = CurriculumRepository(store_path)
+    curricula = repository.list_curricula()
+    stored = repository.get_curriculum(curricula[0].id)
+    assert exit_code == 0
+    assert "Imported PDF as curriculum 'Semantic PDF CV'." in output
+    assert "Import path: embedded_file:cvn.xml" in output
+    assert len(curricula) == 1
+    assert stored is not None
+    assert stored.document["curriculum"]["education"][0]["data"]["nombre_del_titulo"]["raw_value"] == (
+        "Synthetic Computer Science Degree"
+    )
 
 
 def test_pdf_import_requires_explicit_external_llm_opt_in(

--- a/tests/test_pdf_xml_extraction_unit.py
+++ b/tests/test_pdf_xml_extraction_unit.py
@@ -10,7 +10,9 @@ from open_cvn.pdf_xml_extraction import extract_cvn_xml_from_pdf
 
 CVN_XML = """<?xml version="1.0" encoding="UTF-8"?>
 <CVNRoot xmlns="https://example.test/cvn">
-  <CVNCode>000.010.000.000</CVNCode>
+  <CVNItem code="020.010.010.000">
+    <Field code="020.010.010.030">Synthetic Computer Science Degree</Field>
+  </CVNItem>
 </CVNRoot>
 """
 
@@ -117,10 +119,13 @@ def test_parse_cvn_pdf_can_validate_extracted_xml_to_open_cvn_json(tmp_path):
     assert result.source_format == CvnSourceFormat.PDF
     assert result.validation_status == CvnValidationStatus.VALID
     assert result.data is not None
-    assert result.data["extensions"]["x-open-cvn.import"]["mapping_status"] == "trace_only"
+    assert result.data["extensions"]["x-open-cvn.xml_import"]["mapping_status"] == "semantic_partial"
+    assert result.data["curriculum"]["education"][0]["data"]["nombre_del_titulo"]["raw_value"] == (
+        "Synthetic Computer Science Degree"
+    )
     assert result.trace is not None
     assert result.trace.extracted_from == "embedded_file:cvn.xml"
-    assert result.trace.cvn_codes == ("000.010.000.000",)
+    assert result.trace.cvn_codes == ("020.010.010.000", "020.010.010.030")
 
 
 def test_parse_cvn_pdf_does_not_call_llm_when_extracted_xml_validates(tmp_path):

--- a/tests/test_xml_semantic_extraction_unit.py
+++ b/tests/test_xml_semantic_extraction_unit.py
@@ -1,0 +1,41 @@
+from xml.etree import ElementTree
+
+from open_cvn.xml_semantic_extraction import extract_xml_semantic_items
+
+
+def test_extracts_simplified_namespaced_cvn_item_fields():
+    root = ElementTree.fromstring(
+        """
+        <CVNRoot xmlns="https://example.test/cvn">
+          <CVNItem code="020.010.010.000">
+            <Field code="020.010.010.030">Synthetic Degree</Field>
+          </CVNItem>
+        </CVNRoot>
+        """
+    )
+
+    result = extract_xml_semantic_items(root)
+
+    assert result.items[0].code == "020.010.010.000"
+    assert result.items[0].fields[0].code == "020.010.010.030"
+    assert result.items[0].fields[0].raw_value == "Synthetic Degree"
+    assert result.items[0].xml_path == "CVNRoot/CVNItem[1]"
+
+
+def test_extracts_official_like_cvn_item_code():
+    root = ElementTree.fromstring(
+        """
+        <CVN>
+          <CvnItem>
+            <CvnItemID><CodeCVNItem><Item>020.010.010.000</Item></CodeCVNItem></CvnItemID>
+            <Title code="020.010.010.030"><Name>Synthetic Degree</Name></Title>
+          </CvnItem>
+        </CVN>
+        """
+    )
+
+    result = extract_xml_semantic_items(root)
+
+    assert result.items[0].code == "020.010.010.000"
+    assert result.items[0].fields[0].code == "020.010.010.030"
+    assert result.items[0].fields[0].raw_value == "Synthetic Degree"

--- a/tests/test_xml_semantic_import_unit.py
+++ b/tests/test_xml_semantic_import_unit.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from xml.etree import ElementTree
+
+from open_cvn import CvnValidationStatus, validate_open_cvn_json
+from open_cvn.xml_semantic_import import import_cvn_xml_semantically
+
+
+FIXTURES = Path("tests/fixtures/cvn_xml")
+
+
+def _import_fixture(name: str):
+    root = ElementTree.fromstring((FIXTURES / name).read_text(encoding="utf-8"))
+    return import_cvn_xml_semantically(root=root, source_identifier=name, source_path=str(FIXTURES / name))
+
+
+def test_semantic_import_populates_identity():
+    document = _import_fixture("semantic_identity.xml")
+
+    assert document["curriculum"]["identity"]["nombre"] == "Ada"
+    assert document["curriculum"]["identity"]["apellidos"] == "Lovelace Synthetic"
+    assert document["extensions"]["x-open-cvn.xml_import"]["mapping_status"] == "semantic_partial"
+
+
+def test_semantic_import_populates_education_entry_and_validates():
+    document = _import_fixture("semantic_education.xml")
+    validation = validate_open_cvn_json(document, source_identifier="semantic_education.xml")
+
+    assert validation.validation_status == CvnValidationStatus.VALID
+    entry = document["curriculum"]["education"][0]
+    assert entry["id"] == "education-020-010-010-000-001"
+    assert entry["type"].startswith("education.")
+    assert entry["data"]["nombre_del_titulo"]["raw_value"] == "Synthetic Computer Science Degree"
+
+
+def test_semantic_import_populates_research_entry():
+    document = _import_fixture("semantic_research.xml")
+
+    entry = document["curriculum"]["research"][0]
+    assert entry["type"].startswith("research.")
+    assert entry["data"]["autores_as_p_o_de_firma"] == ["Synthetic Author"]
+    assert entry["data"]["ciudad_de_la_entidad_organizadora"] == "Synthetic outreach activity"
+
+
+def test_semantic_import_preserves_unmapped_item():
+    document = _import_fixture("semantic_unmapped.xml")
+
+    diagnostic = document["extensions"]["x-open-cvn.xml_import"]
+
+    assert diagnostic["mapping_status"] == "trace_only"
+    assert diagnostic["items_unmapped"] == 1
+    assert document["curriculum"]["other"][0]["type"] == "other.unmapped_cvn_item"

--- a/tests/test_xml_semantic_mapping_unit.py
+++ b/tests/test_xml_semantic_mapping_unit.py
@@ -1,0 +1,30 @@
+from open_cvn.xml_semantic_mapping import load_xml_semantic_mapping_index
+
+
+def test_mapping_index_contains_representative_entities_and_fields():
+    index = load_xml_semantic_mapping_index()
+
+    identity = index.entity_for_group("000.010.000.000")
+    education = index.entity_for_group("020.010.010.000")
+    research = index.entity_for_group("060.010.040.000")
+
+    assert identity is not None
+    assert identity.entity_id == "identity.person"
+    assert identity.source_group_key == "__no_cvn_item__"
+    assert education is not None
+    assert education.domain_area_id == "education"
+    assert research is not None
+    assert research.domain_area_id == "research"
+    assert index.fields_for_code("000.010.000.020", group_code="000.010.000.000")[0].field_name == "nombre"
+    assert index.fields_for_code("020.010.010.030", group_code="020.010.010.000")[0].field_name == (
+        "nombre_del_titulo"
+    )
+
+
+def test_mapping_index_scopes_duplicate_codes_by_group():
+    index = load_xml_semantic_mapping_index()
+
+    fields = index.fields_for_code("020.010.010.000", group_code="020.010.010.000")
+
+    assert fields
+    assert all(field.source_group_key == "020.010.010.000" for field in fields)

--- a/tests/test_xml_value_conversion_unit.py
+++ b/tests/test_xml_value_conversion_unit.py
@@ -1,0 +1,37 @@
+from open_cvn.xml_semantic_mapping import load_xml_semantic_mapping_index
+from open_cvn.xml_value_conversion import convert_xml_value
+
+
+def test_converts_controlled_reference_with_raw_value():
+    mapping = load_xml_semantic_mapping_index().fields_for_code(
+        "020.010.010.030",
+        group_code="020.010.010.000",
+    )[0]
+
+    value = convert_xml_value("Synthetic Degree", mapping)
+
+    assert value == {
+        "label": "Synthetic Degree",
+        "source": "CVN_TITLE_B",
+        "raw_value": "Synthetic Degree",
+    }
+
+
+def test_converts_flexible_date_value():
+    mapping = load_xml_semantic_mapping_index().fields_for_code(
+        "020.010.010.130",
+        group_code="020.010.010.000",
+    )[0]
+
+    value = convert_xml_value("2024-06-30", mapping)
+
+    assert value == {"raw_value": "2024-06-30", "year": 2024, "month": 6, "day": 30}
+
+
+def test_converts_plain_array_value():
+    mapping = load_xml_semantic_mapping_index().fields_for_code(
+        "060.010.040.350",
+        group_code="060.010.040.000",
+    )[0]
+
+    assert convert_xml_value("Synthetic Author", mapping) == ["Synthetic Author"]


### PR DESCRIPTION
## Summary
- Add schema-backed semantic CVN XML mapping, extraction, value conversion, and import modules
- Populate Open CVN JSON sections from recognized `CvnItem` records
- Preserve unmapped XML data through diagnostics, trace, and `curriculum.other[]`
- Integrate semantic XML import into PDF deterministic XML handoff before LLM fallback
- Update parser, workflow, limitation, roadmap, and status documentation

## Verification
- `uv run pytest -n auto tests/test_xml_semantic_mapping_unit.py tests/test_xml_semantic_extraction_unit.py tests/test_xml_value_conversion_unit.py tests/test_xml_semantic_import_unit.py -v`
- `uv run pytest -n auto tests/test_cvn_xml_import_unit.py tests/test_pdf_xml_extraction_unit.py tests/test_open_cvn_app_cli_unit.py -v`
- `uv run pytest -n auto tests/test_open_cvn_app_mvp_workflow.py -v`
- `uv run pytest -n auto tests`

Full suite: `477 passed in 985.71s`


closes #78 