### PR TITLE
Complete issue 71 limitations hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,8 @@ Every new session should read these files in order before making changes:
   `docs/roadmap/issues/issue-69-llm-assisted-import-spike.md`
 - issue `#70`:
   `docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md`
+- issue `#71`:
+  `docs/roadmap/issues/issue-71-limitations-hardening-and-documentation.md`
 - hotfix `#1`: `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`
 - hotfix `#2`: `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`
 - hotfix `#3`:

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -148,6 +148,9 @@ files in order:
   LLM import exploration
 - `docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md`:
   authoritative record of semantic CVN XML import into Open CVN JSON
+- `docs/roadmap/issues/issue-71-limitations-hardening-and-documentation.md`:
+  authoritative record of limitations hardening, documentation, PDF engine, and
+  diagram usability work
 - `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`: maintenance
   record for the runner logging convention update
 - `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`: maintenance

--- a/docs/context/current_status.md
+++ b/docs/context/current_status.md
@@ -2,7 +2,7 @@
 
 ## Status Date
 
-- Last updated: 2026-07-17
+- Last updated: 2026-07-18
 
 ## Completed Or Stabilized Work
 
@@ -1137,6 +1137,31 @@
   - `uv run pytest -n auto tests`
   - result: `477 passed in 985.71s (0:16:25)`
 
+### Issue `#71`
+
+- the limitations hardening and documentation issue is implemented
+- completed hardening areas include:
+  - classified limitation matrix in `docs/pipeline/known_limitations.md`
+  - explicit boundary between generated structural bindings and the Open CVN JSON
+    runtime contract
+  - conservative Open CVN semantic warnings after JSON Schema and Pydantic
+    validation
+  - XML semantic partial import coverage diagnostics
+  - managed Tectonic PDF engine discovery/cache/download strategy
+  - `open-cvn pdf doctor` environment diagnostics
+  - explicit LLM provenance fields marking assisted imports as review-required and
+    non-authoritative
+  - diagram PNG audit, split readable diagram output, and a compact presentation
+    overview diagram
+- issue `#71` must not modify `docs/memoria/` or manually edit `src/generated/`
+  and this constraint was preserved
+- targeted issue `#71` verification passed with:
+  - `uv run pytest -n auto tests/test_open_cvn_semantic_validation_unit.py tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py tests/test_xml_semantic_import_unit.py tests/test_cvn_xml_import_unit.py tests/test_open_cvn_app_pdf_unit.py tests/test_open_cvn_app_cli_unit.py tests/test_llm_import_unit.py tests/test_llm_providers_unit.py tests/test_conceptual_model_diagrams_unit.py tests/test_generation_pipeline_conceptual_diagrams.py -v`
+  - result: `108 passed in 69.88s (0:01:09)`
+- full-suite verification passed with:
+  - `uv run pytest -n auto tests`
+  - result: `488 passed in 845.43s (0:14:05)`
+
 ## Current Technical Baseline
 
 - Build backend: `setuptools`
@@ -1148,8 +1173,8 @@
 
 ## Next Planned Work
 
-- Next work item after issue `#69`: issue `#70` semantic CVN XML import is
-  implemented
+- Next work item after issue `#70`: issue `#71` limitations hardening and
+  documentation is completed
 - Epic `#60` has been expanded into issues `#61` through `#70`
 - MVP direction:
   - CLI-first local prototype
@@ -1162,7 +1187,7 @@
   - application MVP tests and user documentation
   - basic opt-in LLM-assisted PDF import fallback
   - semantic partial CVN XML import before LLM fallback
-- Next implementation issue: none currently documented after issue `#70`
+- Current implementation issue: none selected after issue `#71` completion
 
 ## Blocking Or Relevant Limitations
 
@@ -1250,23 +1275,24 @@ Then continue with these supporting files as needed:
 6. `docs/development/regeneration_workflow.md`
 7. `docs/development/parser_workflow.md`
 8. `docs/development/llm_import_workflow.md`
-9. `docs/roadmap/issues/issue-60-epic-cv-management-application.md`
-10. `docs/roadmap/issues/issue-61-application-mvp-scope-and-cli-shell.md`
-11. `docs/roadmap/issues/issue-62-local-storage-sqlite-repository.md`
-12. `docs/pipeline/known_limitations.md`
-13. `docs/pipeline/parser_validator_contract.md`
-14. `docs/roadmap/hotfixes/`
-15. `docs/cvn_source_package_auxiliary_artifacts.md`
-16. `docs/cvn_source_package_annex_table_coverage.md`
-17. `docs/cvn_annex_priority_table_families.md`
-18. `docs/cvn_annex_table_families_batch3.md`
-19. `docs/cvn_annex_table_families_batch4.md`
-20. `docs/cvn_annex_table_families_batch5.md`
-21. `docs/cvn_annex_table_families_batch6.md`
-22. `docs/cvn_annex_table_families_batch7.md`
-23. `docs/cvn_annex_table_families_batch8.md`
-24. `docs/cvn_serialization_patterns_reference.md`
-25. `docs/cvn_field_reference_traceability.md`
-26. `docs/roadmap/hotfixes/hotfix-4-structural-scope-correction-for-auxiliary-source-package-artifacts.md`
-27. `docs/roadmap/hotfixes/hotfix-5-normalization-resolution-layer-for-auxiliary-reference-sources.md`
-28. `docs/roadmap/hotfixes/hotfix-6-roadmap-realignment-for-auxiliary-catalog-semantic-integration.md`
+9. `docs/roadmap/issues/issue-71-limitations-hardening-and-documentation.md`
+10. `docs/roadmap/issues/issue-60-epic-cv-management-application.md`
+11. `docs/roadmap/issues/issue-61-application-mvp-scope-and-cli-shell.md`
+12. `docs/roadmap/issues/issue-62-local-storage-sqlite-repository.md`
+13. `docs/pipeline/known_limitations.md`
+14. `docs/pipeline/parser_validator_contract.md`
+15. `docs/roadmap/hotfixes/`
+16. `docs/cvn_source_package_auxiliary_artifacts.md`
+17. `docs/cvn_source_package_annex_table_coverage.md`
+18. `docs/cvn_annex_priority_table_families.md`
+19. `docs/cvn_annex_table_families_batch3.md`
+20. `docs/cvn_annex_table_families_batch4.md`
+21. `docs/cvn_annex_table_families_batch5.md`
+22. `docs/cvn_annex_table_families_batch6.md`
+23. `docs/cvn_annex_table_families_batch7.md`
+24. `docs/cvn_annex_table_families_batch8.md`
+25. `docs/cvn_serialization_patterns_reference.md`
+26. `docs/cvn_field_reference_traceability.md`
+27. `docs/roadmap/hotfixes/hotfix-4-structural-scope-correction-for-auxiliary-source-package-artifacts.md`
+28. `docs/roadmap/hotfixes/hotfix-5-normalization-resolution-layer-for-auxiliary-reference-sources.md`
+29. `docs/roadmap/hotfixes/hotfix-6-roadmap-realignment-for-auxiliary-catalog-semantic-integration.md`

--- a/docs/context/project_context_index.md
+++ b/docs/context/project_context_index.md
@@ -33,13 +33,14 @@ Agents should also read `AGENTS.md` before this file.
   parser/validator contract, CLI shell, local SQLite storage, master/derived
   curriculum versioning, Open CVN JSON application import/export, curriculum
   editing/selection MVP, LaTeX export, optional PDF generation, application MVP
-  workflow tests/documentation, LLM-assisted PDF import fallback, and semantic
-  partial CVN XML import completed
+  workflow tests/documentation, LLM-assisted PDF import fallback, semantic
+  partial CVN XML import, and issue `#71` limitations hardening in progress
 - Last documented issues: `#11`, `#12`, `#13`, `#14`, `#15`, `#16`, `#17`,
   `#25`, `#42`, `#43`, `#44`, `#45`, `#46`, `#47`, `#48`, `#49`, `#50`,
-  `#61`, `#62`, `#63`, `#64`, `#65`, `#66`, `#67`, `#68`, `#69`, and `#70`
+  `#61`, `#62`, `#63`, `#64`, `#65`, `#66`, `#67`, `#68`, `#69`, `#70`,
+  and `#71`
 - Latest documented hotfix records: `#3`, `#4`, `#5`, `#6`, `#7`, `#8`
-- Next planned issue: none currently documented after `#70`
+- Current implementation issue: `#71` limitations hardening and documentation
 - Canonical source package: `docs/CvnXML_v1.4.3_2.1_17012025/`
 
 ## Documentation Map
@@ -130,6 +131,8 @@ Agents should also read `AGENTS.md` before this file.
   LLM import exploration
 - `docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md`:
   implementation record for semantic CVN XML import into Open CVN JSON
+- `docs/roadmap/issues/issue-71-limitations-hardening-and-documentation.md`:
+  implementation record for limitations hardening and documentation
 - `docs/roadmap/hotfixes/hotfix-1-runner-logging-convention.md`: maintenance
   record for the runner logging convention update
 - `docs/roadmap/hotfixes/hotfix-2-human-project-entrypoint.md`: maintenance

--- a/docs/development/llm_import_workflow.md
+++ b/docs/development/llm_import_workflow.md
@@ -94,9 +94,15 @@ LLM-assisted imports add provenance under:
 extensions["x-open-cvn.llm_import"]
 ```
 
-Recorded fields include provider, model, fallback reason, provider metadata, and
-the validation marker. Raw prompts, raw PDF contents, API keys, and full provider
-responses are not stored by default.
+Recorded fields include provider, model, fallback reason, provider metadata, the
+validation marker, `review_required: true`, and `authoritative: false`. Raw
+prompts, raw PDF contents, API keys, and full provider responses are not stored
+by default.
+
+Local Open CVN JSON validation proves only that the provider output matches the
+current structural/runtime contract. It does not prove factual completeness,
+absence of hallucinated content, or semantic equivalence with the original PDF.
+Users must review LLM-assisted imports before relying on them.
 
 ## Failure Behavior
 

--- a/docs/development/parser_workflow.md
+++ b/docs/development/parser_workflow.md
@@ -172,6 +172,18 @@ CVN evidence but no recognized semantic items may still report
 `mapping_status = "trace_only"`. Treat either status as an import diagnostic,
 not proof that all curriculum content was converted.
 
+The XML import diagnostic object is also the place to inspect coverage. Current
+fields include:
+
+- `items_seen`, `items_mapped`, and `items_unmapped`
+- `fields_seen`, `fields_mapped`, and `fields_unmapped`
+- `item_mapping_coverage` and `field_mapping_coverage` ratios
+- `mapped_sections` and `section_counts`
+- `unmapped_codes`
+
+These fields make semantic partial import measurable. They do not mean the XML
+importer is a complete converter for every official CVN XML edge case.
+
 XML errors use these codes:
 
 - `invalid_xml`: XML is malformed

--- a/docs/development/pdf_generation_workflow.md
+++ b/docs/development/pdf_generation_workflow.md
@@ -64,28 +64,64 @@ directory.
 
 The discovery order is:
 
-1. `latexmk`
-2. `pdflatex`
+1. managed `tectonic` cached by Open CVN
+2. system `tectonic`
+3. `latexmk`
+4. `pdflatex`
 
-`latexmk` is preferred because it automates multi-pass LaTeX compilation.
-`pdflatex` is used as a fallback and runs two passes for basic references.
+`tectonic` is preferred because it is distributed as a single executable and can
+be cached by the Python application. When no cached managed executable is
+available, `open-cvn pdf generate` may download the pinned Tectonic release for
+the current platform and store it under:
+
+```text
+~/.cache/open-cvn/tectonic/<version>/
+```
+
+Set `OPEN_CVN_TECTONIC_CACHE` to override the managed cache directory.
+
+If managed Tectonic is unavailable, the application falls back to system
+executables. `latexmk` automates multi-pass LaTeX compilation. `pdflatex` is used
+as a final fallback and runs two passes for basic references.
 
 The project does not install TeX as a Python dependency. Install a TeX
-distribution separately, for example TeX Live, MiKTeX, or MacTeX, and ensure
-`latexmk` or `pdflatex` is on `PATH`.
+distribution separately, for example TeX Live, MiKTeX, or MacTeX, only if the
+managed or system `tectonic` route is not suitable for your environment.
+
+## PDF Doctor
+
+Check local PDF generation readiness without compiling a document:
+
+```bash
+uv run open-cvn pdf doctor
+```
+
+The command reports:
+
+- managed Tectonic cache path
+- cached managed Tectonic executable, if present
+- system `tectonic`, `latexmk`, and `pdflatex` discovery
+- selected engine
+- whether managed Tectonic download is supported on the current platform
+- next recommended action
+
+`pdf doctor` does not download Tectonic by itself. `pdf generate` performs the
+managed download when it needs a managed engine and no cached executable exists.
 
 ## Missing Compiler Behavior
 
-When no supported compiler is installed, the command fails with structured output
+When no supported engine is available and managed Tectonic cannot be downloaded or
+is not supported for the platform, the command fails with structured output
 similar to:
 
 ```text
 PDF generation unavailable.
-No supported TeX compiler found. Install one of: latexmk, pdflatex.
+No supported TeX compiler found. Install one of: tectonic, latexmk, pdflatex.
 ```
 
-This is expected behavior for environments without TeX. It should not break the
-rest of the application workflow or automated tests.
+This is expected behavior for offline or unsupported environments without a
+cached managed engine or local TeX executable. It should not break the rest of
+the application workflow or automated tests.
 
 ## Compiler Failure Diagnostics
 
@@ -114,5 +150,7 @@ Limitations:
 ## Verification
 
 Issue `#67` tests mock compiler discovery, compiler success, compiler failure,
-timeouts, missing compiler behavior, and preview handoff. A local TeX installation
-is not required for automated verification.
+timeouts, missing compiler behavior, and preview handoff. Issue `#71` adds mocked
+coverage for managed Tectonic cache/download behavior and `pdf doctor`. A local
+TeX installation and real network access are not required for automated
+verification.

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -12,7 +12,7 @@ structures as the final domain model.
 ## Canonical Sources
 
 The versioned `.puml` files are the canonical diagram artifacts. They now exist
-in two complementary styles:
+in three complementary styles:
 
 - readable views:
   - `open_cvn_conceptual_overview.puml`: compact overview for humans
@@ -47,11 +47,22 @@ in two complementary styles:
   - `open_cvn_other_reference.puml`
   - `open_cvn_other_040_reference.puml`
   - `open_cvn_other_no_tree_reference.puml`
+- presentation views:
+  - `open_cvn_presentation_overview.puml`: compact high-level figure for slides,
+    the TFG memory, or quick orientation
 
-Readable views prioritize navigation and presentation. Reference views preserve
-the fuller vocabulary and attribute inventory needed for detailed inspection,
-but large or vocabulary-heavy reference areas now use compact index diagrams that
-point to split detailed reference section files.
+Readable views prioritize navigation. Reference views preserve the fuller
+vocabulary and attribute inventory needed for detailed inspection. Presentation
+views intentionally omit attributes and most trace details so they can fit into a
+single human-facing figure. Large or vocabulary-heavy reference areas use compact
+index diagrams that point to split detailed reference section files.
+
+Issue `#71` reviewed the rendered PNG artifacts and identified oversized rendered
+views such as `open_cvn_research_060.png` (`3660 x 1571`),
+`open_cvn_other_040.png` (`3062 x 1065`), and `open_cvn_education_030.png`
+(`3033 x 1318`). Large readable sections should therefore be split in the same
+spirit as large reference sections, while presentation views should stay compact
+enough for documentation figures.
 
 For the largest reference sections, the section-level reference diagram may also
 be an index instead of a full-detail canvas. In those cases, open the listed
@@ -114,6 +125,8 @@ When reviewing regenerated diagrams, check:
 - readable views avoid large vocabulary fan-out and keep big areas split into
   smaller subdiagrams
 - reference views keep fuller vocabulary and trace detail for auditability
+- presentation views stay compact and do not try to replace readable/reference
+  diagrams
 - detailed reference chunks use local `controlled references` notes rather than
   global vocabulary nodes
 - representative attributes preserve CVN code trace

--- a/docs/diagrams/open_cvn_education_030.puml
+++ b/docs/diagrams/open_cvn_education_030.puml
@@ -2,203 +2,34 @@
 title Open CVN - CVN Education - Section 030
 
 skinparam classAttributeIconSize 0
-hide circle
+hide empty members
 
-package "CVN Education - Section 030" as area_education_030 {
-class "AportacionesMasRelevantesDeSuCvDeDocencia" as entity_education_aportacionesmasrelevantesdesucvdedocencia_030_110_000_000 <<entity>> {
-  aportaciones_mas_relevantes_de_su_cv_de_docencia : text <<optional, repeated>>
-  ciudad_de_realizacion_de_la_actividad : text <<optional, single>>
-  comunidad_autonoma_region_de_realizacion_de_la_actividad : controlled_reference <<optional, single>>
-  descripcion : text <<optional, single>>
-  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
-  fecha_de_finalizacion_de_la_actividad : value_object<FlexibleDatesType> <<optional, single>>
-  pais_de_realizacion_de_la_actividad : controlled_reference <<optional, single>>
-  palabras_clave : controlled_reference <<optional, repeated>>
-  .. +2 more attributes ..
+package "CVN Education - Section 030" as readable_section_030_index {
+class "Section 030 Part 1" as section_030_part_01 <<section>> {
+  entities : 7
+  file : open_cvn_education_030_part_01.puml
+  representative : AportacionesMasRelevantesDeSuCvDeDocencia, CodirectorADeTesis, CursosYSeminariosImpartidos, +4 more
 }
 
-class "CodirectorADeTesis" as entity_education_codirectoradetesis_030_040_000_180 <<entity>> {
-  codirector_a_de_tesis : text <<optional, repeated>>
+class "Section 030 Part 2" as section_030_part_02 <<section>> {
+  entities : 12
+  file : open_cvn_education_030_part_02.puml
+  representative : FormacionSanitariaEspecializadaImpartida, ISBNISSNPublicacion, MaterialYOtrasPublicacionesDocentesODeCaracterPedagogico, +9 more
 }
 
-class "CursosYSeminariosImpartidos" as entity_education_cursosyseminariosimpartidos_030_060_000_000 <<entity>> {
-  ciudad_entidad_organizadora : text <<optional, single>>
-  comunidad_autonoma_region_entidad_organizadora : controlled_reference <<optional, single>>
-  cursos_y_seminarios_impartidos : text <<optional, repeated>>
-  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
-  fecha_de_imparticion : value_object<FlexibleDatesType> <<optional, single>>
-  horas_impartidas : decimal_number <<optional, single>>
-  idioma_en_que_se_impartio : controlled_reference <<optional, single>>
-  isbn_issn_publicacion : text <<optional, repeated>>
-  .. +11 more attributes ..
-}
-
-class "DireccionDeTesisDoctoralesYOTrabajosFinDeEstudios" as entity_education_direcciondetesisdoctoralesyotrabajosfindeestudios_030_040_000_000 <<entity>> {
-  alumno_a : text <<optional, single>>
-  calificacion_obtenida : text <<optional, single>>
-  ciudad_de_la_direccion_td : text <<optional, single>>
-  codirector_a_de_tesis : text <<optional, repeated>>
-  comunidad_autonoma_region_de_la_direccion_td : controlled_reference <<optional, single>>
-  direccion_de_tesis_doctorales_y_o_trabajos_fin_de_estudios : text <<optional, repeated>>
-  doctorado_europeo_internacional : boolean <<required, single>>
-  entidad_de_la_direccion_td : value_object<EntityNameType> <<required, single>>
-  .. +12 more attributes ..
-}
-
-class "EventosConIntervencionesOrientadasALaFormacionDocente" as entity_education_eventosconintervencionesorientadasalaformaciondocente_030_090_000_000 <<entity>> {
-  ciudad_de_celebracion : text <<optional, single>>
-  ciudad_de_la_entidad_organizadora : text <<optional, single>>
-  comunidad_autonoma_region_de_celebracion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_organizadora : controlled_reference <<optional, single>>
-  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
-  eventos_con_intervenciones_orientadas_a_la_formacion_docente : text <<optional, repeated>>
-  fecha_de_finalizacion : value_object<FlexibleDatesType> <<required, single>>
-  fecha_de_inicio : value_object<FlexibleDatesType> <<required, single>>
-  .. +15 more attributes ..
-}
-
-class "FormacionAcademicaImpartida" as entity_education_formacionacademicaimpartida_030_010_000_000 <<entity>> {
-  categoria_profesional_del_de_la_solicitante_en_el_momento_en_el_que_desempeno_la_docencia_senalada : text <<optional, single>>
-  ciudad_de_la_entidad_de_evaluacion : text <<optional, single>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  ciudad_de_la_entidad_financiadora : text <<optional, single>>
-  competencias_relacionadas_con_la_asignatura_impartida : text <<optional, single>>
-  comunidad_autonoma_region_de_entidad_de_evaluacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
-  .. +40 more attributes ..
-}
-
-class "FormacionSanitariaEnIDYOPosformacionSanitariaEspecializadaEnIDImpartida" as entity_education_formacionsanitariaenidyoposformacionsanitariaespecializadaenidimpartida_030_030_000_000 <<entity>> {
-  ciudad_de_la_entidad_de_la_realizacion : text <<optional, single>>
-  ciudad_de_la_formacion_impartida : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_donde_ha_impartido_la_formacion : controlled_reference <<optional, single>>
-  departamento : value_object<EntityNameType> <<optional, single>>
-  destinatarios_as_en_palabras_clave : controlled_reference <<optional, repeated>>
-  duracion : duration_like <<optional, single>>
-  entidad_de_la_que_depende_el_programa : value_object<EntityNameType> <<optional, single>>
-  .. +14 more attributes ..
-}
-
-class "FormacionSanitariaEspecializadaImpartida" as entity_education_formacionsanitariaespecializadaimpartida_030_020_000_000 <<entity>> {
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  ciudad_de_la_formacion_impartida : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_donde_ha_impartido_la_formacion : controlled_reference <<optional, single>>
-  departamento : value_object<EntityNameType> <<optional, single>>
-  duracion : duration_like <<optional, single>>
-  entidad_donde_se_llevo_a_cabo : value_object<EntityNameType> <<optional, single>>
-  entidad_que_expide_el_titulo : value_object<EntityNameType> <<optional, single>>
-  .. +17 more attributes ..
-}
-
-class "ISBNISSNPublicacion" as entity_education_isbnissnpublicacion_030_060_000_190 <<entity>> {
-  autor_de_correspondencia : boolean <<optional, single>>
-  identificador_de_publicacion_digital : text <<optional, repeated>>
-  isbn_issn_publicacion : text <<optional, repeated>>
-  tipo_de_identificador_de_publicacion_digital : controlled_reference <<optional, repeated>>
-  tipo_de_identificador_de_publicacion_digital_otros : text <<optional, repeated>>
-}
-
-class "MaterialYOtrasPublicacionesDocentesODeCaracterPedagogico" as entity_education_materialyotraspublicacionesdocentesodecaracterpedagogico_030_070_000_000 <<entity>> {
-  autor_de_correspondencia : boolean <<optional, single>>
-  autores_as_p_o_de_firma_nombres : text <<optional, repeated>>
-  explicacion_narrativa_del_material_elaborado : text <<optional, single>>
-  fecha_de_elaboracion : value_object<FlexibleDatesType> <<optional, single>>
-  grado_de_contribucion : controlled_reference <<required, single>>
-  identificador_de_publicacion_digital : text <<optional, repeated>>
-  material_y_otras_publicaciones_docentes_o_de_caracter_pedagogico : text <<optional, repeated>>
-  nombre_del_material : text <<optional, single>>
-  .. +7 more attributes ..
-}
-
-class "OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior030100000000" as entity_education_otrasactividadesmeritosnoincluidosenlarelacionanterior030100000000_030_100_000_000 <<entity>> {
-  ciudad_de_realizacion_de_la_actividad : text <<optional, single>>
-  comunidad_autonoma_region_de_realizacion_de_la_actividad : controlled_reference <<optional, single>>
-  descripcion_de_la_actividad : text <<optional, single>>
-  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
-  fecha_de_finalizacion_de_la_actividad : value_object<FlexibleDatesType> <<optional, single>>
-  otras_actividades_meritos_no_incluidos_en_la_relacion_anterior : text <<optional, repeated>>
-  pais_de_realizacion_de_la_actividad : controlled_reference <<optional, single>>
-  palabras_clave : controlled_reference <<optional, repeated>>
-  .. +2 more attributes ..
-}
-
-class "OtrosMeritosDeDocencia" as entity_education_otrosmeritosdedocencia_030_100_010_000 <<entity>> {
-  otros_meritos_de_docencia_030_100_010_000 : text <<optional, single>>
-  otros_meritos_de_docencia_030_100_010_010 : text <<optional, single>>
-}
-
-class "PluralidadInterdisciplinariedadYComplejidadDocente" as entity_education_pluralidadinterdisciplinariedadycomplejidaddocente_030_120_000_000 <<entity>> {
-  pluralidad_interdisciplinariedad_y_complejidad_docente_030_120_000_000 : text <<optional, single>>
-  pluralidad_interdisciplinariedad_y_complejidad_docente_030_120_000_010 : text <<optional, single>>
-}
-
-class "ProyectosDeInnovacionDocente" as entity_education_proyectosdeinnovaciondocente_030_080_000_000 <<entity>> {
-  ambito_del_proyecto : controlled_reference <<required, single>>
-  ambito_del_proyecto_otros : text <<optional, single>>
-  aportacion_del_titular_al_proyecto : text <<optional, single>>
-  ciudad_de_realizacion : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  duracion_de_la_participacion : duration_like <<optional, single>>
-  entidad_es_participante_s : value_object<EntityNameType> <<optional, repeated>>
-  entidad_financiadora : value_object<EntityNameType> <<optional, single>>
-  .. +18 more attributes ..
-}
-
-class "PublicacionISBNISSN" as entity_education_publicacionisbnissn_030_090_000_220 <<entity>> {
-  autor_de_correspondencia : boolean <<optional, single>>
-  identificador_de_publicacion_digital : text <<optional, repeated>>
-  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
-  publicacion_deposito_legal : text <<optional, single>>
-  publicacion_direccion_electronica : text <<optional, single>>
-  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
-  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
-  publicacion_isbn_issn : text <<optional, repeated>>
-  .. +8 more attributes ..
-}
-
-class "PublicacionNombre030070000190" as entity_education_publicacionnombre030070000190_030_070_000_190 <<entity>> {
-  publicacion_nombre : text <<optional, single>>
-}
-
-class "PublicacionNombre030090000330" as entity_education_publicacionnombre030090000330_030_090_000_330 <<entity>> {
-  publicacion_nombre : text <<optional, single>>
-}
-
-class "PublicacionTitulo030070000080" as entity_education_publicaciontitulo030070000080_030_070_000_080 <<entity>> {
-  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
-  publicacion_deposito_legal : text <<optional, single>>
-  publicacion_direccion_electronica : text <<optional, single>>
-  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
-  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
-  publicacion_isbn_issn : text <<optional, repeated>>
-  publicacion_nombre : text <<optional, single>>
-  publicacion_pagina_inicial_final : text <<optional, single>>
-  .. +3 more attributes ..
-}
-
-class "TitulacionUniversitaria" as entity_education_titulacionuniversitaria_030_010_000_020 <<entity>> {
-  titulacion_universitaria : controlled_reference <<optional, single>>
-}
-
-class "TituloDeLaSubespecialidad" as entity_education_titulodelasubespecialidad_030_020_000_030 <<entity>> {
-  titulo_de_la_subespecialidad : text <<optional, single>>
-}
-
-class "TutoriasAcademicasDeEstudiantes" as entity_education_tutoriasacademicasdeestudiantes_030_050_000_000 <<entity>> {
-  ciudad_de_la_tutoria : text <<optional, single>>
-  comunidad_autonoma_region_de_la_tutoria : controlled_reference <<optional, single>>
-  entidad_donde_se_ejerce_la_tutoria : value_object<EntityNameType> <<optional, single>>
-  entidad_donde_se_ejerce_la_tutoria_tipo : value_object<EntityTypeType> <<optional, single>>
-  entidad_donde_se_presta_la_tutoria_tipo_otros : text <<optional, single>>
-  explicacion_narrativa_de_la_tutorizacion : text <<optional, single>>
-  frecuencia_de_la_actividad : decimal_number <<optional, single>>
-  nombre_del_programa : controlled_reference <<optional, single>>
-  .. +6 more attributes ..
+class "Section 030 Part 3" as section_030_part_03 <<section>> {
+  entities : 2
+  file : open_cvn_education_030_part_03.puml
+  representative : TituloDeLaSubespecialidad, TutoriasAcademicasDeEstudiantes
 }
 
 }
 
+note bottom
+Readable subsection index for Section 030
+Detailed subsection files:
+- open_cvn_education_030_part_01.puml
+- open_cvn_education_030_part_02.puml
+- open_cvn_education_030_part_03.puml
+end note
 @enduml

--- a/docs/diagrams/open_cvn_education_030_part_01.puml
+++ b/docs/diagrams/open_cvn_education_030_part_01.puml
@@ -1,0 +1,86 @@
+@startuml
+title Open CVN - CVN Education - Section 030 Part 1
+
+skinparam classAttributeIconSize 0
+hide circle
+
+package "CVN Education - Section 030 Part 1" as area_education_030_part_01 {
+class "AportacionesMasRelevantesDeSuCvDeDocencia" as entity_education_aportacionesmasrelevantesdesucvdedocencia_030_110_000_000 <<entity>> {
+  aportaciones_mas_relevantes_de_su_cv_de_docencia : text <<optional, repeated>>
+  ciudad_de_realizacion_de_la_actividad : text <<optional, single>>
+  comunidad_autonoma_region_de_realizacion_de_la_actividad : controlled_reference <<optional, single>>
+  descripcion : text <<optional, single>>
+  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
+  fecha_de_finalizacion_de_la_actividad : value_object<FlexibleDatesType> <<optional, single>>
+  pais_de_realizacion_de_la_actividad : controlled_reference <<optional, single>>
+  palabras_clave : controlled_reference <<optional, repeated>>
+  .. +2 more attributes ..
+}
+
+class "CodirectorADeTesis" as entity_education_codirectoradetesis_030_040_000_180 <<entity>> {
+  codirector_a_de_tesis : text <<optional, repeated>>
+}
+
+class "CursosYSeminariosImpartidos" as entity_education_cursosyseminariosimpartidos_030_060_000_000 <<entity>> {
+  ciudad_entidad_organizadora : text <<optional, single>>
+  comunidad_autonoma_region_entidad_organizadora : controlled_reference <<optional, single>>
+  cursos_y_seminarios_impartidos : text <<optional, repeated>>
+  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
+  fecha_de_imparticion : value_object<FlexibleDatesType> <<optional, single>>
+  horas_impartidas : decimal_number <<optional, single>>
+  idioma_en_que_se_impartio : controlled_reference <<optional, single>>
+  isbn_issn_publicacion : text <<optional, repeated>>
+  .. +11 more attributes ..
+}
+
+class "DireccionDeTesisDoctoralesYOTrabajosFinDeEstudios" as entity_education_direcciondetesisdoctoralesyotrabajosfindeestudios_030_040_000_000 <<entity>> {
+  alumno_a : text <<optional, single>>
+  calificacion_obtenida : text <<optional, single>>
+  ciudad_de_la_direccion_td : text <<optional, single>>
+  codirector_a_de_tesis : text <<optional, repeated>>
+  comunidad_autonoma_region_de_la_direccion_td : controlled_reference <<optional, single>>
+  direccion_de_tesis_doctorales_y_o_trabajos_fin_de_estudios : text <<optional, repeated>>
+  doctorado_europeo_internacional : boolean <<required, single>>
+  entidad_de_la_direccion_td : value_object<EntityNameType> <<required, single>>
+  .. +12 more attributes ..
+}
+
+class "EventosConIntervencionesOrientadasALaFormacionDocente" as entity_education_eventosconintervencionesorientadasalaformaciondocente_030_090_000_000 <<entity>> {
+  ciudad_de_celebracion : text <<optional, single>>
+  ciudad_de_la_entidad_organizadora : text <<optional, single>>
+  comunidad_autonoma_region_de_celebracion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_organizadora : controlled_reference <<optional, single>>
+  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
+  eventos_con_intervenciones_orientadas_a_la_formacion_docente : text <<optional, repeated>>
+  fecha_de_finalizacion : value_object<FlexibleDatesType> <<required, single>>
+  fecha_de_inicio : value_object<FlexibleDatesType> <<required, single>>
+  .. +15 more attributes ..
+}
+
+class "FormacionAcademicaImpartida" as entity_education_formacionacademicaimpartida_030_010_000_000 <<entity>> {
+  categoria_profesional_del_de_la_solicitante_en_el_momento_en_el_que_desempeno_la_docencia_senalada : text <<optional, single>>
+  ciudad_de_la_entidad_de_evaluacion : text <<optional, single>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  ciudad_de_la_entidad_financiadora : text <<optional, single>>
+  competencias_relacionadas_con_la_asignatura_impartida : text <<optional, single>>
+  comunidad_autonoma_region_de_entidad_de_evaluacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
+  .. +40 more attributes ..
+}
+
+class "FormacionSanitariaEnIDYOPosformacionSanitariaEspecializadaEnIDImpartida" as entity_education_formacionsanitariaenidyoposformacionsanitariaespecializadaenidimpartida_030_030_000_000 <<entity>> {
+  ciudad_de_la_entidad_de_la_realizacion : text <<optional, single>>
+  ciudad_de_la_formacion_impartida : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_donde_ha_impartido_la_formacion : controlled_reference <<optional, single>>
+  departamento : value_object<EntityNameType> <<optional, single>>
+  destinatarios_as_en_palabras_clave : controlled_reference <<optional, repeated>>
+  duracion : duration_like <<optional, single>>
+  entidad_de_la_que_depende_el_programa : value_object<EntityNameType> <<optional, single>>
+  .. +14 more attributes ..
+}
+
+}
+
+@enduml

--- a/docs/diagrams/open_cvn_education_030_part_02.puml
+++ b/docs/diagrams/open_cvn_education_030_part_02.puml
@@ -1,0 +1,112 @@
+@startuml
+title Open CVN - CVN Education - Section 030 Part 2
+
+skinparam classAttributeIconSize 0
+hide circle
+
+package "CVN Education - Section 030 Part 2" as area_education_030_part_02 {
+class "FormacionSanitariaEspecializadaImpartida" as entity_education_formacionsanitariaespecializadaimpartida_030_020_000_000 <<entity>> {
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  ciudad_de_la_formacion_impartida : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_donde_ha_impartido_la_formacion : controlled_reference <<optional, single>>
+  departamento : value_object<EntityNameType> <<optional, single>>
+  duracion : duration_like <<optional, single>>
+  entidad_donde_se_llevo_a_cabo : value_object<EntityNameType> <<optional, single>>
+  entidad_que_expide_el_titulo : value_object<EntityNameType> <<optional, single>>
+  .. +17 more attributes ..
+}
+
+class "ISBNISSNPublicacion" as entity_education_isbnissnpublicacion_030_060_000_190 <<entity>> {
+  autor_de_correspondencia : boolean <<optional, single>>
+  identificador_de_publicacion_digital : text <<optional, repeated>>
+  isbn_issn_publicacion : text <<optional, repeated>>
+  tipo_de_identificador_de_publicacion_digital : controlled_reference <<optional, repeated>>
+  tipo_de_identificador_de_publicacion_digital_otros : text <<optional, repeated>>
+}
+
+class "MaterialYOtrasPublicacionesDocentesODeCaracterPedagogico" as entity_education_materialyotraspublicacionesdocentesodecaracterpedagogico_030_070_000_000 <<entity>> {
+  autor_de_correspondencia : boolean <<optional, single>>
+  autores_as_p_o_de_firma_nombres : text <<optional, repeated>>
+  explicacion_narrativa_del_material_elaborado : text <<optional, single>>
+  fecha_de_elaboracion : value_object<FlexibleDatesType> <<optional, single>>
+  grado_de_contribucion : controlled_reference <<required, single>>
+  identificador_de_publicacion_digital : text <<optional, repeated>>
+  material_y_otras_publicaciones_docentes_o_de_caracter_pedagogico : text <<optional, repeated>>
+  nombre_del_material : text <<optional, single>>
+  .. +7 more attributes ..
+}
+
+class "OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior" as entity_education_otrasactividadesmeritosnoincluidosenlarelacionanterior030100000000_030_100_000_000 <<entity>> {
+  ciudad_de_realizacion_de_la_actividad : text <<optional, single>>
+  comunidad_autonoma_region_de_realizacion_de_la_actividad : controlled_reference <<optional, single>>
+  descripcion_de_la_actividad : text <<optional, single>>
+  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
+  fecha_de_finalizacion_de_la_actividad : value_object<FlexibleDatesType> <<optional, single>>
+  otras_actividades_meritos_no_incluidos_en_la_relacion_anterior : text <<optional, repeated>>
+  pais_de_realizacion_de_la_actividad : controlled_reference <<optional, single>>
+  palabras_clave : controlled_reference <<optional, repeated>>
+  .. +2 more attributes ..
+}
+
+class "OtrosMeritosDeDocencia" as entity_education_otrosmeritosdedocencia_030_100_010_000 <<entity>> {
+  otros_meritos_de_docencia_030_100_010_000 : text <<optional, single>>
+  otros_meritos_de_docencia_030_100_010_010 : text <<optional, single>>
+}
+
+class "PluralidadInterdisciplinariedadYComplejidadDocente" as entity_education_pluralidadinterdisciplinariedadycomplejidaddocente_030_120_000_000 <<entity>> {
+  pluralidad_interdisciplinariedad_y_complejidad_docente_030_120_000_000 : text <<optional, single>>
+  pluralidad_interdisciplinariedad_y_complejidad_docente_030_120_000_010 : text <<optional, single>>
+}
+
+class "ProyectosDeInnovacionDocente" as entity_education_proyectosdeinnovaciondocente_030_080_000_000 <<entity>> {
+  ambito_del_proyecto : controlled_reference <<required, single>>
+  ambito_del_proyecto_otros : text <<optional, single>>
+  aportacion_del_titular_al_proyecto : text <<optional, single>>
+  ciudad_de_realizacion : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  duracion_de_la_participacion : duration_like <<optional, single>>
+  entidad_es_participante_s : value_object<EntityNameType> <<optional, repeated>>
+  entidad_financiadora : value_object<EntityNameType> <<optional, single>>
+  .. +18 more attributes ..
+}
+
+class "PublicacionISBNISSN" as entity_education_publicacionisbnissn_030_090_000_220 <<entity>> {
+  autor_de_correspondencia : boolean <<optional, single>>
+  identificador_de_publicacion_digital : text <<optional, repeated>>
+  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
+  publicacion_deposito_legal : text <<optional, single>>
+  publicacion_direccion_electronica : text <<optional, single>>
+  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
+  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
+  publicacion_isbn_issn : text <<optional, repeated>>
+  .. +8 more attributes ..
+}
+
+class "PublicacionNombre" as entity_education_publicacionnombre030070000190_030_070_000_190 <<entity>> {
+  publicacion_nombre : text <<optional, single>>
+}
+
+class "PublicacionNombre" as entity_education_publicacionnombre030090000330_030_090_000_330 <<entity>> {
+  publicacion_nombre : text <<optional, single>>
+}
+
+class "PublicacionTitulo" as entity_education_publicaciontitulo030070000080_030_070_000_080 <<entity>> {
+  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
+  publicacion_deposito_legal : text <<optional, single>>
+  publicacion_direccion_electronica : text <<optional, single>>
+  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
+  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
+  publicacion_isbn_issn : text <<optional, repeated>>
+  publicacion_nombre : text <<optional, single>>
+  publicacion_pagina_inicial_final : text <<optional, single>>
+  .. +3 more attributes ..
+}
+
+class "TitulacionUniversitaria" as entity_education_titulacionuniversitaria_030_010_000_020 <<entity>> {
+  titulacion_universitaria : controlled_reference <<optional, single>>
+}
+
+}
+
+@enduml

--- a/docs/diagrams/open_cvn_education_030_part_03.puml
+++ b/docs/diagrams/open_cvn_education_030_part_03.puml
@@ -1,0 +1,26 @@
+@startuml
+title Open CVN - CVN Education - Section 030 Part 3
+
+skinparam classAttributeIconSize 0
+hide circle
+
+package "CVN Education - Section 030 Part 3" as area_education_030_part_03 {
+class "TituloDeLaSubespecialidad" as entity_education_titulodelasubespecialidad_030_020_000_030 <<entity>> {
+  titulo_de_la_subespecialidad : text <<optional, single>>
+}
+
+class "TutoriasAcademicasDeEstudiantes" as entity_education_tutoriasacademicasdeestudiantes_030_050_000_000 <<entity>> {
+  ciudad_de_la_tutoria : text <<optional, single>>
+  comunidad_autonoma_region_de_la_tutoria : controlled_reference <<optional, single>>
+  entidad_donde_se_ejerce_la_tutoria : value_object<EntityNameType> <<optional, single>>
+  entidad_donde_se_ejerce_la_tutoria_tipo : value_object<EntityTypeType> <<optional, single>>
+  entidad_donde_se_presta_la_tutoria_tipo_otros : text <<optional, single>>
+  explicacion_narrativa_de_la_tutorizacion : text <<optional, single>>
+  frecuencia_de_la_actividad : decimal_number <<optional, single>>
+  nombre_del_programa : controlled_reference <<optional, single>>
+  .. +6 more attributes ..
+}
+
+}
+
+@enduml

--- a/docs/diagrams/open_cvn_education_030_part_03_reference.puml
+++ b/docs/diagrams/open_cvn_education_030_part_03_reference.puml
@@ -7,7 +7,7 @@ top to bottom direction
 hide empty members
 
 package "CVN Education Reference - Section 030 Part 3" as area_education_030_part_03_reference {
-class "OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior030100000000" as entity_education_otrasactividadesmeritosnoincluidosenlarelacionanterior030100000000_030_100_000_000 <<entity>> {
+class "OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior" as entity_education_otrasactividadesmeritosnoincluidosenlarelacionanterior030100000000_030_100_000_000 <<entity>> {
   ciudad_de_realizacion_de_la_actividad : text <<optional, single>> [CVN: 030.100.000.060]
   comunidad_autonoma_region_de_realizacion_de_la_actividad : controlled_reference <<optional, single>> [CVN: 030.100.000.040]
   descripcion_de_la_actividad : text <<optional, single>> [CVN: 030.100.000.010]
@@ -105,7 +105,7 @@ controlled references:
 - ISO_3166 (code_list, enum=ineligible, items=312)
 end note
 
-class "PublicacionNombre030070000190" as entity_education_publicacionnombre030070000190_030_070_000_190 <<entity>> {
+class "PublicacionNombre" as entity_education_publicacionnombre030070000190_030_070_000_190 <<entity>> {
   publicacion_nombre : text <<optional, single>> [CVN: 030.070.000.190]
 }
 

--- a/docs/diagrams/open_cvn_education_030_part_04_reference.puml
+++ b/docs/diagrams/open_cvn_education_030_part_04_reference.puml
@@ -7,11 +7,11 @@ top to bottom direction
 hide empty members
 
 package "CVN Education Reference - Section 030 Part 4" as area_education_030_part_04_reference {
-class "PublicacionNombre030090000330" as entity_education_publicacionnombre030090000330_030_090_000_330 <<entity>> {
+class "PublicacionNombre" as entity_education_publicacionnombre030090000330_030_090_000_330 <<entity>> {
   publicacion_nombre : text <<optional, single>> [CVN: 030.090.000.330]
 }
 
-class "PublicacionTitulo030070000080" as entity_education_publicaciontitulo030070000080_030_070_000_080 <<entity>> {
+class "PublicacionTitulo" as entity_education_publicaciontitulo030070000080_030_070_000_080 <<entity>> {
   publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>> [CVN: 030.070.000.130]
   publicacion_deposito_legal : text <<optional, single>> [CVN: 030.070.000.180]
   publicacion_direccion_electronica : text <<optional, single>> [CVN: 030.070.000.160]

--- a/docs/diagrams/open_cvn_other_040.puml
+++ b/docs/diagrams/open_cvn_other_040.puml
@@ -2,220 +2,27 @@
 title Open CVN - Other CVN Concepts - Section 040
 
 skinparam classAttributeIconSize 0
-hide circle
+hide empty members
 
-package "Other CVN Concepts - Section 040" as area_other_040 {
-class "ActividadDeAtencionDeSaludEnOtrosPaisesExtranjeros" as entity_other_actividaddeatenciondesaludenotrospaisesextranjeros_040_060_000_000 <<entity>> {
-  actividad_de_atencion_de_salud_en_otros_paises_extranjeros : text <<optional, repeated>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  ciudad_de_la_entidad_financiadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
-  duracion_de_la_experiencia : duration_like <<optional, single>>
-  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
-  entidad_financiadora : value_object<EntityNameType> <<optional, single>>
-  .. +10 more attributes ..
+package "Other CVN Concepts - Section 040" as readable_section_040_index {
+class "Section 040 Part 1" as section_040_part_01 <<section>> {
+  entities : 9
+  file : open_cvn_other_040_part_01.puml
+  representative : ActividadDeAtencionDeSaludEnOtrosPaisesExtranjeros, ActividadEnCooperacionPracticandoLaAtencionDeSaludEnPaisesEnDesarrollo, ActividadEnCooperacionSanitariaEnPaisesEnDesarrollo, +6 more
 }
 
-class "ActividadEnCooperacionPracticandoLaAtencionDeSaludEnPaisesEnDesarrollo" as entity_other_actividadencooperacionpracticandolaatenciondesaludenpaisesendesarrollo_040_040_000_000 <<entity>> {
-  actividad_en_cooperacion_practicando_la_atencion_de_salud_en_paises_en_desarrollo : text <<optional, repeated>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  ciudad_de_la_entidad_financiadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
-  duracion_de_la_experiencia : duration_like <<optional, single>>
-  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
-  entidad_financiadora_de_la_experiencia : value_object<EntityNameType> <<optional, single>>
-  .. +10 more attributes ..
-}
-
-class "ActividadEnCooperacionSanitariaEnPaisesEnDesarrollo" as entity_other_actividadencooperacionsanitariaenpaisesendesarrollo_040_050_000_000 <<entity>> {
-  actividad_en_cooperacion_sanitaria_en_paises_en_desarrollo : text <<optional, repeated>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  ciudad_de_la_entidad_financiadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
-  duracion_de_la_experiencia : duration_like <<optional, single>>
-  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
-  entidad_financiadora : value_object<EntityNameType> <<optional, single>>
-  .. +10 more attributes ..
-}
-
-class "ActividadSanitariaEnInstitucionesDeLaUe" as entity_other_actividadsanitariaeninstitucionesdelaue_040_010_000_000 <<entity>> {
-  actividad_sanitaria_en_instituciones_de_la_ue : text <<optional, repeated>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  duracion_de_la_experiencia : duration_like <<optional, single>>
-  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
-  fecha_de_finalizacion_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
-  fecha_de_inicio_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
-  institucion_de_la_ue_de_la_que_depende_la_experiencia : value_object<EntityNameType> <<optional, single>>
-  .. +5 more attributes ..
-}
-
-class "ActividadSanitariaEnLaOms" as entity_other_actividadsanitariaenlaoms_040_020_000_000 <<entity>> {
-  actividad_sanitaria_en_la_oms : text <<optional, repeated>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  departamento_de_la_oms_del_que_dependio_la_experiencia : value_object<EntityNameType> <<optional, single>>
-  duracion_de_la_experiencia : duration_like <<optional, single>>
-  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
-  fecha_de_finalizacion_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
-  fecha_de_inicio_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
-  .. +5 more attributes ..
-}
-
-class "ActividadSanitariaEnOrganizacionesInternacionalesIntergubernamentales" as entity_other_actividadsanitariaenorganizacionesinternacionalesintergubernamentales_040_030_000_000 <<entity>> {
-  actividad_sanitaria_en_organizaciones_internacionales_intergubernamentales : text <<optional, repeated>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  duracion_de_la_experiencia : duration_like <<optional, single>>
-  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
-  fecha_de_finalizacion_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
-  fecha_de_inicio_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
-  organismo_internacional_departamento : value_object<EntityNameType> <<optional, single>>
-  .. +6 more attributes ..
-}
-
-class "ActividadSanitariaEnPaisesExtranjeros" as entity_other_actividadsanitariaenpaisesextranjeros_040_070_000_000 <<entity>> {
-  actividad_sanitaria_en_paises_extranjeros : text <<optional, repeated>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  ciudad_de_la_entidad_financiadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
-  duracion_de_la_experiencia : duration_like <<optional, single>>
-  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
-  entidad_financiadora : value_object<EntityNameType> <<optional, single>>
-  .. +10 more attributes ..
-}
-
-class "CongresosCursosYSeminariosOrientadosALaAtencionDeSalud" as entity_other_congresoscursosyseminariosorientadosalaatenciondesalud_040_130_000_000 <<entity>> {
-  ambito_del_evento : controlled_reference <<optional, single>>
-  ambito_del_evento_otros : text <<optional, single>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  ciudad_de_la_entidad_financiadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
-  congresos_cursos_y_seminarios_orientados_a_la_atencion_de_salud : text <<optional, repeated>>
-  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
-  .. +12 more attributes ..
-}
-
-class "CursosYSeminariosImpartidosOrientadosALaMejoraDeLaAtencionDeSaludParaProfesionalesSanitarios" as entity_other_cursosyseminariosimpartidosorientadosalamejoradelaatenciondesaludparaprofesionalessanitarios_040_090_000_000 <<entity>> {
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  ciudad_de_la_entidad_organizadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_organizadora : controlled_reference <<optional, single>>
-  cursos_y_seminarios_impartidos_orientados_a_la_mejora_de_la_atencion_de_salud_para_profesionales_sanitarios : text <<optional, repeated>>
-  entidad_de_realizacion : value_object<EntityNameType> <<optional, single>>
-  entidad_responsable_de_la_formacion : value_object<EntityNameType> <<optional, single>>
-  fecha_de_finalizacion : value_object<FlexibleDatesType> <<optional, single>>
-  .. +15 more attributes ..
-}
-
-class "NODeISBNISSN" as entity_other_nodeisbnissn_040_090_000_230 <<entity>> {
-  autor_de_correspondencia : boolean <<optional, single>>
-  identificador_de_publicacion_digital : text <<optional, repeated>>
-  n_o_de_isbn_issn : text <<optional, repeated>>
-  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
-  publicacion_deposito_legal : text <<optional, single>>
-  publicacion_direccion_electronica : text <<optional, single>>
-  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
-  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
-  .. +8 more attributes ..
-}
-
-class "OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior040140000000" as entity_other_otrasactividadesmeritosnoincluidosenlarelacionanterior040140000000_040_140_000_000 <<entity>> {
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  ciudad_de_la_entidad_financiadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
-  entidad_de_concesion_del_merito : value_object<EntityNameType> <<optional, single>>
-  entidad_de_la_experiencia : value_object<EntityNameType> <<optional, single>>
-  fecha_de_finalizacion_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
-  fecha_de_la_concesion : value_object<FlexibleDatesType> <<optional, single>>
-  .. +9 more attributes ..
-}
-
-class "ProtocolosYOtrosMaterialesDeAtencionDeSalud" as entity_other_protocolosyotrosmaterialesdeatenciondesalud_040_100_000_000 <<entity>> {
-  autores_as_p_o_de_firma_nombres : text <<optional, repeated>>
-  fecha_de_elaboracion : value_object<FlexibleDatesType> <<optional, single>>
-  nombre_del_protocolo_material : text <<optional, single>>
-  posicion_del_de_la_solicitante_sobre_el_total : decimal_number <<optional, single>>
-  protocolos_y_otros_materiales_de_atencion_de_salud : text <<optional, repeated>>
-  publicacion_titulo : text <<optional, single>>
-  tipologia : controlled_reference <<optional, single>>
-  tipologia_otros : text <<optional, single>>
-}
-
-class "ProyectosDeInnovacionSanitaria" as entity_other_proyectosdeinnovacionsanitaria_040_110_000_000 <<entity>> {
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  ciudad_de_la_entidad_financiadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
-  duracion : duration_like <<optional, single>>
-  entidad_de_realizacion : value_object<EntityNameType> <<optional, single>>
-  entidad_financiadora : value_object<EntityNameType> <<optional, single>>
-  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
-  .. +19 more attributes ..
-}
-
-class "ProyectosParaLaPlanificacionMejoraDeLaSanidad" as entity_other_proyectosparalaplanificacionmejoradelasanidad_040_120_000_000 <<entity>> {
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  ciudad_de_la_entidad_financiadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
-  duracion : duration_like <<optional, single>>
-  entidad_de_realizacion : value_object<EntityNameType> <<optional, single>>
-  entidad_financiadora : value_object<EntityNameType> <<optional, single>>
-  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
-  .. +17 more attributes ..
-}
-
-class "PublicacionNombre040090000380" as entity_other_publicacionnombre040090000380_040_090_000_380 <<entity>> {
-  publicacion_nombre : text <<optional, single>>
-}
-
-class "PublicacionNombre040100000180" as entity_other_publicacionnombre040100000180_040_100_000_180 <<entity>> {
-  publicacion_nombre : text <<optional, single>>
-}
-
-class "PublicacionTitulo040100000070" as entity_other_publicaciontitulo040100000070_040_100_000_070 <<entity>> {
-  autor_de_correspondencia : boolean <<optional, single>>
-  identificador_de_publicacion_digital : text <<optional, repeated>>
-  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
-  publicacion_deposito_legal : text <<optional, single>>
-  publicacion_direccion_electronica : text <<optional, single>>
-  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
-  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
-  publicacion_isbn_issn : text <<optional, repeated>>
-  .. +7 more attributes ..
-}
-
-class "PublicacionTitulo040130000180" as entity_other_publicaciontitulo040130000180_040_130_000_180 <<entity>> {
-  autor_de_correspondencia : boolean <<optional, single>>
-  identificador_de_publicacion_digital : text <<optional, repeated>>
-  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
-  publicacion_deposito_legal : text <<optional, single>>
-  publicacion_direccion_electronica : text <<optional, single>>
-  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
-  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
-  publicacion_isbn_issn : text <<optional, repeated>>
-  .. +7 more attributes ..
-}
-
-class "TutoriasSupervisionDeActividadesDeAtencionDeSalud" as entity_other_tutoriassupervisiondeactividadesdeatenciondesalud_040_080_000_000 <<entity>> {
-  ciudad_de_la_entidad_de_realizacion_de_la_tutoria : text <<optional, single>>
-  ciudad_de_la_entidad_organizadora_de_la_que_depende_el_programa : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion_de_la_tutoria : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_organizadora_de_la_que_depende_el_programa : controlled_reference <<optional, single>>
-  descripcion_del_programa : text <<optional, single>>
-  entidad_donde_realizo_la_tutoria : value_object<EntityNameType> <<optional, single>>
-  entidad_organizadora_de_la_que_depende_el_programa : value_object<EntityNameType> <<optional, single>>
-  frecuencia_de_la_actividad : decimal_number <<optional, single>>
-  .. +11 more attributes ..
+class "Section 040 Part 2" as section_040_part_02 <<section>> {
+  entities : 10
+  file : open_cvn_other_040_part_02.puml
+  representative : NODeISBNISSN, OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior040140000000, ProtocolosYOtrosMaterialesDeAtencionDeSalud, +7 more
 }
 
 }
 
+note bottom
+Readable subsection index for Section 040
+Detailed subsection files:
+- open_cvn_other_040_part_01.puml
+- open_cvn_other_040_part_02.puml
+end note
 @enduml

--- a/docs/diagrams/open_cvn_other_040_part_01.puml
+++ b/docs/diagrams/open_cvn_other_040_part_01.puml
@@ -1,0 +1,118 @@
+@startuml
+title Open CVN - Other CVN Concepts - Section 040 Part 1
+
+skinparam classAttributeIconSize 0
+hide circle
+
+package "Other CVN Concepts - Section 040 Part 1" as area_other_040_part_01 {
+class "ActividadDeAtencionDeSaludEnOtrosPaisesExtranjeros" as entity_other_actividaddeatenciondesaludenotrospaisesextranjeros_040_060_000_000 <<entity>> {
+  actividad_de_atencion_de_salud_en_otros_paises_extranjeros : text <<optional, repeated>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  ciudad_de_la_entidad_financiadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
+  duracion_de_la_experiencia : duration_like <<optional, single>>
+  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
+  entidad_financiadora : value_object<EntityNameType> <<optional, single>>
+  .. +10 more attributes ..
+}
+
+class "ActividadEnCooperacionPracticandoLaAtencionDeSaludEnPaisesEnDesarrollo" as entity_other_actividadencooperacionpracticandolaatenciondesaludenpaisesendesarrollo_040_040_000_000 <<entity>> {
+  actividad_en_cooperacion_practicando_la_atencion_de_salud_en_paises_en_desarrollo : text <<optional, repeated>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  ciudad_de_la_entidad_financiadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
+  duracion_de_la_experiencia : duration_like <<optional, single>>
+  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
+  entidad_financiadora_de_la_experiencia : value_object<EntityNameType> <<optional, single>>
+  .. +10 more attributes ..
+}
+
+class "ActividadEnCooperacionSanitariaEnPaisesEnDesarrollo" as entity_other_actividadencooperacionsanitariaenpaisesendesarrollo_040_050_000_000 <<entity>> {
+  actividad_en_cooperacion_sanitaria_en_paises_en_desarrollo : text <<optional, repeated>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  ciudad_de_la_entidad_financiadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
+  duracion_de_la_experiencia : duration_like <<optional, single>>
+  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
+  entidad_financiadora : value_object<EntityNameType> <<optional, single>>
+  .. +10 more attributes ..
+}
+
+class "ActividadSanitariaEnInstitucionesDeLaUe" as entity_other_actividadsanitariaeninstitucionesdelaue_040_010_000_000 <<entity>> {
+  actividad_sanitaria_en_instituciones_de_la_ue : text <<optional, repeated>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  duracion_de_la_experiencia : duration_like <<optional, single>>
+  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
+  fecha_de_finalizacion_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
+  fecha_de_inicio_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
+  institucion_de_la_ue_de_la_que_depende_la_experiencia : value_object<EntityNameType> <<optional, single>>
+  .. +5 more attributes ..
+}
+
+class "ActividadSanitariaEnLaOms" as entity_other_actividadsanitariaenlaoms_040_020_000_000 <<entity>> {
+  actividad_sanitaria_en_la_oms : text <<optional, repeated>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  departamento_de_la_oms_del_que_dependio_la_experiencia : value_object<EntityNameType> <<optional, single>>
+  duracion_de_la_experiencia : duration_like <<optional, single>>
+  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
+  fecha_de_finalizacion_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
+  fecha_de_inicio_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
+  .. +5 more attributes ..
+}
+
+class "ActividadSanitariaEnOrganizacionesInternacionalesIntergubernamentales" as entity_other_actividadsanitariaenorganizacionesinternacionalesintergubernamentales_040_030_000_000 <<entity>> {
+  actividad_sanitaria_en_organizaciones_internacionales_intergubernamentales : text <<optional, repeated>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  duracion_de_la_experiencia : duration_like <<optional, single>>
+  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
+  fecha_de_finalizacion_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
+  fecha_de_inicio_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
+  organismo_internacional_departamento : value_object<EntityNameType> <<optional, single>>
+  .. +6 more attributes ..
+}
+
+class "ActividadSanitariaEnPaisesExtranjeros" as entity_other_actividadsanitariaenpaisesextranjeros_040_070_000_000 <<entity>> {
+  actividad_sanitaria_en_paises_extranjeros : text <<optional, repeated>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  ciudad_de_la_entidad_financiadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
+  duracion_de_la_experiencia : duration_like <<optional, single>>
+  entidad_donde_realizo_la_experiencia : value_object<EntityNameType> <<optional, single>>
+  entidad_financiadora : value_object<EntityNameType> <<optional, single>>
+  .. +10 more attributes ..
+}
+
+class "CongresosCursosYSeminariosOrientadosALaAtencionDeSalud" as entity_other_congresoscursosyseminariosorientadosalaatenciondesalud_040_130_000_000 <<entity>> {
+  ambito_del_evento : controlled_reference <<optional, single>>
+  ambito_del_evento_otros : text <<optional, single>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  ciudad_de_la_entidad_financiadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
+  congresos_cursos_y_seminarios_orientados_a_la_atencion_de_salud : text <<optional, repeated>>
+  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
+  .. +12 more attributes ..
+}
+
+class "CursosYSeminariosImpartidosOrientadosALaMejoraDeLaAtencionDeSaludParaProfesionalesSanitarios" as entity_other_cursosyseminariosimpartidosorientadosalamejoradelaatenciondesaludparaprofesionalessanitarios_040_090_000_000 <<entity>> {
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  ciudad_de_la_entidad_organizadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_organizadora : controlled_reference <<optional, single>>
+  cursos_y_seminarios_impartidos_orientados_a_la_mejora_de_la_atencion_de_salud_para_profesionales_sanitarios : text <<optional, repeated>>
+  entidad_de_realizacion : value_object<EntityNameType> <<optional, single>>
+  entidad_responsable_de_la_formacion : value_object<EntityNameType> <<optional, single>>
+  fecha_de_finalizacion : value_object<FlexibleDatesType> <<optional, single>>
+  .. +15 more attributes ..
+}
+
+}
+
+@enduml

--- a/docs/diagrams/open_cvn_other_040_part_02.puml
+++ b/docs/diagrams/open_cvn_other_040_part_02.puml
@@ -1,0 +1,113 @@
+@startuml
+title Open CVN - Other CVN Concepts - Section 040 Part 2
+
+skinparam classAttributeIconSize 0
+hide circle
+
+package "Other CVN Concepts - Section 040 Part 2" as area_other_040_part_02 {
+class "NODeISBNISSN" as entity_other_nodeisbnissn_040_090_000_230 <<entity>> {
+  autor_de_correspondencia : boolean <<optional, single>>
+  identificador_de_publicacion_digital : text <<optional, repeated>>
+  n_o_de_isbn_issn : text <<optional, repeated>>
+  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
+  publicacion_deposito_legal : text <<optional, single>>
+  publicacion_direccion_electronica : text <<optional, single>>
+  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
+  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
+  .. +8 more attributes ..
+}
+
+class "OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior" as entity_other_otrasactividadesmeritosnoincluidosenlarelacionanterior040140000000_040_140_000_000 <<entity>> {
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  ciudad_de_la_entidad_financiadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
+  entidad_de_concesion_del_merito : value_object<EntityNameType> <<optional, single>>
+  entidad_de_la_experiencia : value_object<EntityNameType> <<optional, single>>
+  fecha_de_finalizacion_de_la_experiencia : value_object<FlexibleDatesType> <<optional, single>>
+  fecha_de_la_concesion : value_object<FlexibleDatesType> <<optional, single>>
+  .. +9 more attributes ..
+}
+
+class "ProtocolosYOtrosMaterialesDeAtencionDeSalud" as entity_other_protocolosyotrosmaterialesdeatenciondesalud_040_100_000_000 <<entity>> {
+  autores_as_p_o_de_firma_nombres : text <<optional, repeated>>
+  fecha_de_elaboracion : value_object<FlexibleDatesType> <<optional, single>>
+  nombre_del_protocolo_material : text <<optional, single>>
+  posicion_del_de_la_solicitante_sobre_el_total : decimal_number <<optional, single>>
+  protocolos_y_otros_materiales_de_atencion_de_salud : text <<optional, repeated>>
+  publicacion_titulo : text <<optional, single>>
+  tipologia : controlled_reference <<optional, single>>
+  tipologia_otros : text <<optional, single>>
+}
+
+class "ProyectosDeInnovacionSanitaria" as entity_other_proyectosdeinnovacionsanitaria_040_110_000_000 <<entity>> {
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  ciudad_de_la_entidad_financiadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
+  duracion : duration_like <<optional, single>>
+  entidad_de_realizacion : value_object<EntityNameType> <<optional, single>>
+  entidad_financiadora : value_object<EntityNameType> <<optional, single>>
+  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
+  .. +19 more attributes ..
+}
+
+class "ProyectosParaLaPlanificacionMejoraDeLaSanidad" as entity_other_proyectosparalaplanificacionmejoradelasanidad_040_120_000_000 <<entity>> {
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  ciudad_de_la_entidad_financiadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
+  duracion : duration_like <<optional, single>>
+  entidad_de_realizacion : value_object<EntityNameType> <<optional, single>>
+  entidad_financiadora : value_object<EntityNameType> <<optional, single>>
+  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
+  .. +17 more attributes ..
+}
+
+class "PublicacionNombre" as entity_other_publicacionnombre040090000380_040_090_000_380 <<entity>> {
+  publicacion_nombre : text <<optional, single>>
+}
+
+class "PublicacionNombre" as entity_other_publicacionnombre040100000180_040_100_000_180 <<entity>> {
+  publicacion_nombre : text <<optional, single>>
+}
+
+class "PublicacionTitulo" as entity_other_publicaciontitulo040100000070_040_100_000_070 <<entity>> {
+  autor_de_correspondencia : boolean <<optional, single>>
+  identificador_de_publicacion_digital : text <<optional, repeated>>
+  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
+  publicacion_deposito_legal : text <<optional, single>>
+  publicacion_direccion_electronica : text <<optional, single>>
+  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
+  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
+  publicacion_isbn_issn : text <<optional, repeated>>
+  .. +7 more attributes ..
+}
+
+class "PublicacionTitulo" as entity_other_publicaciontitulo040130000180_040_130_000_180 <<entity>> {
+  autor_de_correspondencia : boolean <<optional, single>>
+  identificador_de_publicacion_digital : text <<optional, repeated>>
+  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
+  publicacion_deposito_legal : text <<optional, single>>
+  publicacion_direccion_electronica : text <<optional, single>>
+  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
+  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
+  publicacion_isbn_issn : text <<optional, repeated>>
+  .. +7 more attributes ..
+}
+
+class "TutoriasSupervisionDeActividadesDeAtencionDeSalud" as entity_other_tutoriassupervisiondeactividadesdeatenciondesalud_040_080_000_000 <<entity>> {
+  ciudad_de_la_entidad_de_realizacion_de_la_tutoria : text <<optional, single>>
+  ciudad_de_la_entidad_organizadora_de_la_que_depende_el_programa : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion_de_la_tutoria : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_organizadora_de_la_que_depende_el_programa : controlled_reference <<optional, single>>
+  descripcion_del_programa : text <<optional, single>>
+  entidad_donde_realizo_la_tutoria : value_object<EntityNameType> <<optional, single>>
+  entidad_organizadora_de_la_que_depende_el_programa : value_object<EntityNameType> <<optional, single>>
+  frecuencia_de_la_actividad : decimal_number <<optional, single>>
+  .. +11 more attributes ..
+}
+
+}
+
+@enduml

--- a/docs/diagrams/open_cvn_other_040_part_02_reference.puml
+++ b/docs/diagrams/open_cvn_other_040_part_02_reference.puml
@@ -132,7 +132,7 @@ controlled references:
 - ISO_3166 (code_list, enum=ineligible, items=312)
 end note
 
-class "OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior040140000000" as entity_other_otrasactividadesmeritosnoincluidosenlarelacionanterior040140000000_040_140_000_000 <<entity>> {
+class "OtrasActividadesMeritosNoIncluidosEnLaRelacionAnterior" as entity_other_otrasactividadesmeritosnoincluidosenlarelacionanterior040140000000_040_140_000_000 <<entity>> {
   ciudad_de_la_entidad_de_realizacion : text <<optional, single>> [CVN: 040.140.000.060]
   ciudad_de_la_entidad_financiadora : text <<optional, single>> [CVN: 040.140.000.190]
   comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>> [CVN: 040.140.000.040]

--- a/docs/diagrams/open_cvn_other_040_part_03_reference.puml
+++ b/docs/diagrams/open_cvn_other_040_part_03_reference.puml
@@ -86,15 +86,15 @@ controlled references:
 - ISO_3166 (code_list, enum=ineligible, items=312)
 end note
 
-class "PublicacionNombre040090000380" as entity_other_publicacionnombre040090000380_040_090_000_380 <<entity>> {
+class "PublicacionNombre" as entity_other_publicacionnombre040090000380_040_090_000_380 <<entity>> {
   publicacion_nombre : text <<optional, single>> [CVN: 040.090.000.380]
 }
 
-class "PublicacionNombre040100000180" as entity_other_publicacionnombre040100000180_040_100_000_180 <<entity>> {
+class "PublicacionNombre" as entity_other_publicacionnombre040100000180_040_100_000_180 <<entity>> {
   publicacion_nombre : text <<optional, single>> [CVN: 040.100.000.180]
 }
 
-class "PublicacionTitulo040100000070" as entity_other_publicaciontitulo040100000070_040_100_000_070 <<entity>> {
+class "PublicacionTitulo" as entity_other_publicaciontitulo040100000070_040_100_000_070 <<entity>> {
   autor_de_correspondencia : boolean <<optional, single>> [CVN: 040.100.000.190]
   identificador_de_publicacion_digital : text <<optional, repeated>> [CVN: 040.100.000.200]
   publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>> [CVN: 040.100.000.120]
@@ -118,7 +118,7 @@ controlled references:
 - ISO_3166 (code_list, enum=ineligible, items=312)
 end note
 
-class "PublicacionTitulo040130000180" as entity_other_publicaciontitulo040130000180_040_130_000_180 <<entity>> {
+class "PublicacionTitulo" as entity_other_publicaciontitulo040130000180_040_130_000_180 <<entity>> {
   autor_de_correspondencia : boolean <<optional, single>> [CVN: 040.130.000.330]
   identificador_de_publicacion_digital : text <<optional, repeated>> [CVN: 040.130.000.340]
   publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>> [CVN: 040.130.000.240]

--- a/docs/diagrams/open_cvn_presentation_overview.puml
+++ b/docs/diagrams/open_cvn_presentation_overview.puml
@@ -1,0 +1,50 @@
+@startuml
+title Open CVN Presentation Overview
+
+skinparam classAttributeIconSize 0
+top to bottom direction
+hide empty members
+
+package "Open CVN Runtime Shape" as presentation_root {
+class "Open CVN Document" as presentation_document <<document>>
+class "Metadata" as presentation_metadata <<metadata>>
+class "Curriculum" as presentation_curriculum <<curriculum>>
+class "Extensions" as presentation_extensions <<extensions>>
+}
+
+package "Curriculum Areas" as presentation_areas {
+class "CVN Achievements" as presentation_area_achievements <<area>> {
+  entities : 2
+}
+class "CVN Education" as presentation_area_education <<area>> {
+  entities : 30
+}
+class "CVN Identity" as presentation_area_identity <<area>> {
+  entities : 1
+}
+class "Other CVN Concepts" as presentation_area_other <<area>> {
+  entities : 20
+}
+class "CVN Professional Experience" as presentation_area_professional_experience <<area>> {
+  entities : 3
+}
+class "CVN Research" as presentation_area_research <<area>> {
+  entities : 47
+}
+}
+
+presentation_document *-- presentation_metadata : metadata
+presentation_document *-- presentation_curriculum : curriculum
+presentation_document o-- presentation_extensions : extensions
+presentation_curriculum *-- presentation_area_achievements
+presentation_curriculum *-- presentation_area_education
+presentation_curriculum *-- presentation_area_identity
+presentation_curriculum *-- presentation_area_other
+presentation_curriculum *-- presentation_area_professional_experience
+presentation_curriculum *-- presentation_area_research
+
+note bottom
+Presentation view: compact overview for slides and memoria figures.
+Detailed readable/reference diagrams remain canonical for trace inspection.
+end note
+@enduml

--- a/docs/diagrams/open_cvn_research_050.puml
+++ b/docs/diagrams/open_cvn_research_050.puml
@@ -2,122 +2,27 @@
 title Open CVN - CVN Research - Section 050
 
 skinparam classAttributeIconSize 0
-hide circle
+hide empty members
 
-package "CVN Research - Section 050" as area_research_050 {
-class "ContratosConveniosOProyectosDeIDINoCompetitivosConAdministracionesOEntidadesPublicasOPrivadas" as entity_research_contratosconveniosoproyectosdeidinocompetitivosconadministracionesoentidadespublicasoprivadas_050_020_020_000 <<entity>> {
-  ambito_del_proyecto : controlled_reference <<optional, single>>
-  ambito_del_proyecto_otros : text <<optional, single>>
-  calidad_en_que_ha_participado_otros : text <<optional, single>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  codigo_de_proyecto_segun_la_entidad_financiadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  contratos_convenios_o_proyectos_de_i_d_i_no_competitivos_con_administraciones_o_entidades_publicas_o_privadas : text <<optional, repeated>>
-  duracion_del_proyecto : duration_like <<optional, single>>
-  .. +24 more attributes ..
+package "CVN Research - Section 050" as readable_section_050_index {
+class "Section 050 Part 1" as section_050_part_01 <<section>> {
+  entities : 8
+  file : open_cvn_research_050_part_01.puml
+  representative : ContratosConveniosOProyectosDeIDINoCompetitivosConAdministracionesOEntidadesPublicasOPrivadas, EntidadEsColaboradoraS, EntidadEsDestinatariaSDeLaActividad, +5 more
 }
 
-class "EntidadEsColaboradoraS" as entity_research_entidadescolaboradoras_050_030_020_190 <<entity>> {
-  ciudad_de_la_entidad_colaboradora : text <<optional, repeated>>
-  comunidad_autonoma_region_de_la_entidad_colaboradora : controlled_reference <<optional, repeated>>
-  entidad_es_colaboradora_s : value_object<EntityNameType> <<optional, repeated>>
-  pais_de_la_entidad_colaboradora : controlled_reference <<optional, repeated>>
-  tipo_de_entidad_es : value_object<EntityTypeType> <<optional, repeated>>
-  tipo_de_entidad_es_otros : text <<optional, repeated>>
-}
-
-class "EntidadEsDestinatariaSDeLaActividad" as entity_research_entidadesdestinatariasdelaactividad_050_030_020_230 <<entity>> {
-  ciudad_de_la_entidad_destinataria : text <<optional, repeated>>
-  comunidad_autonoma_region_de_la_entidad_destinataria : controlled_reference <<optional, repeated>>
-  entidad_es_destinataria_s_de_la_actividad : value_object<EntityNameType> <<optional, repeated>>
-  pais_de_la_entidad_destinataria : controlled_reference <<optional, repeated>>
-  tipo_de_entidad_es : value_object<EntityTypeType> <<optional, repeated>>
-  tipo_de_entidad_es_otros : text <<optional, repeated>>
-}
-
-class "EntidadEsFinanciadoraS" as entity_research_entidadesfinanciadoras_050_020_010_210 <<entity>> {
-  ciudad_de_la_entidad_financiadora : text <<optional, repeated>>
-  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, repeated>>
-  entidad_es_financiadora_s : value_object<EntityNameType> <<required, repeated>>
-  pais_de_la_entidad_financiadora : controlled_reference <<optional, repeated>>
-  tipo_de_entidad : value_object<EntityTypeType> <<optional, repeated>>
-  tipo_de_entidad_otros : text <<optional, repeated>>
-}
-
-class "GruposEquiposDeInvestigacionDesarrolloOInnovacion" as entity_research_gruposequiposdeinvestigaciondesarrollooinnovacion_050_010_000_000 <<entity>> {
-  ciudad_de_radicacion_del_grupo : text <<optional, single>>
-  clases_de_colaboracion : controlled_reference <<optional, single>>
-  codigo_normalizado : text <<optional, single>>
-  comunidad_autonoma_region_de_radicacion_del_grupo : controlled_reference <<optional, single>>
-  duracion : duration_like <<optional, single>>
-  entidad_a_la_que_pertenece : value_object<EntityNameType> <<optional, single>>
-  explicacion_narrativa_de_la_aportacion : text <<optional, single>>
-  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
-  .. +12 more attributes ..
-}
-
-class "NombreSEntidadEsFinanciadoraS" as entity_research_nombresentidadesfinanciadoras_050_020_020_140 <<entity>> {
-  ciudad_de_la_entidad_financiadora : text <<optional, repeated>>
-  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, repeated>>
-  nombre_s_entidad_es_financiadora_s : value_object<EntityNameType> <<required, repeated>>
-  pais_de_la_entidad_financiadora : controlled_reference <<optional, repeated>>
-  tipo_de_entidad : value_object<EntityTypeType> <<optional, repeated>>
-  tipo_de_entidad_otros : text <<optional, repeated>>
-}
-
-class "ObrasArtisticasYProfesionales" as entity_research_obrasartisticasyprofesionales_050_020_030_000 <<entity>> {
-  autores_as_p_o_de_firma : text <<optional, repeated>>
-  caracteristicas_catalogo : boolean <<optional, single>>
-  caracteristicas_comisario_de_exposicion : boolean <<optional, single>>
-  caracteristicas_fecha : value_object<FlexibleDatesType> <<optional, single>>
-  caracteristicas_monografica : boolean <<optional, single>>
-  ciudad_de_la_exposicion : text <<optional, single>>
-  comunidad_autonoma_region_de_la_exposicion : controlled_reference <<optional, single>>
-  descripcion : text <<optional, single>>
-  .. +11 more attributes ..
-}
-
-class "PropiedadIndustrialEIntelectual" as entity_research_propiedadindustrialeintelectual_050_030_010_000 <<entity>> {
-  ambito_geografico_espana : boolean <<optional, single>>
-  ambito_geografico_internacional_no_ue : boolean <<optional, single>>
-  ambito_geografico_patente_europea : boolean <<optional, single>>
-  codigo_de_referencia_n_o_de_registro_si_procede : text <<optional, single>>
-  comunidad_autonoma_region_de_prioridad : controlled_reference <<optional, single>>
-  en_este_caso_el_resultado_en_relacion_con_la_empresa_es_de : controlled_reference <<optional, single>>
-  entidad_titular_de_derechos : value_object<EntityNameType> <<optional, single>>
-  explotacion_comunidad_autonoma_region_en_las_que_se_ha_extendido_formalizado : controlled_reference <<optional, repeated>>
-  .. +24 more attributes ..
-}
-
-class "ProyectosDeIDIFinanciadosEnConvocatoriasCompetitivasDeAdministracionesOEntidadesPublicasYPrivadas" as entity_research_proyectosdeidifinanciadosenconvocatoriascompetitivasdeadministracionesoentidadespublicasyprivadas_050_020_010_000 <<entity>> {
-  ambito_del_proyecto : controlled_reference <<optional, single>>
-  ambito_del_proyecto_otros : text <<optional, single>>
-  calidad_en_que_ha_participado_otros : text <<optional, single>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  codigo_de_proyecto_segun_la_entidad_financiadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  duracion_del_proyecto : duration_like <<optional, single>>
-  entidad_donde_se_desarrolla : value_object<EntityNameType> <<required, single>>
-  .. +27 more attributes ..
-}
-
-class "ResultadosDerivadosDeActividadesEspecializadasYDeTransferenciaNoIncluidosEnApartadosAnteriores" as entity_research_resultadosderivadosdeactividadesespecializadasydetransferencianoincluidosenapartadosanteriores_050_030_020_000 <<entity>> {
-  ambito_de_la_actividad : controlled_reference <<optional, single>>
-  ambito_de_la_actividad_otros : text <<optional, single>>
-  calidad_en_que_ha_participado_otros : text <<optional, single>>
-  clave_de_actividad_convenios_de_colaboracion : boolean <<optional, single>>
-  clave_de_actividad_participacion_como_experto_a_tecnologico_a_en_labores_de_supervision_asesoria_evaluacion_o_peritaje : boolean <<optional, single>>
-  clave_de_actividad_participacion_en_la_generacion_de_empresas_spin_off_basadas_en_resultados_de_i_d_i : boolean <<optional, single>>
-  clave_de_actividad_puesta_en_marcha_de_nuevas_tecnicas_o_procedimientos_operacion_y_mantenimiento_de_grandes_instalaciones_o_equipamientos_complejos : boolean <<optional, single>>
-  clave_de_actividad_realizacion_de_servicios_tecnologicos_maduros_homologacion_calibracion_analisis_u_otros : boolean <<optional, single>>
-  .. +15 more attributes ..
-}
-
-class "TransferenciaEIntercambioDeConocimiento" as entity_research_transferenciaeintercambiodeconocimiento_050_040_000_000 <<entity>> {
-  transferencia_e_intercambio_de_conocimiento_050_040_000_000 : text <<optional, single>>
-  transferencia_e_intercambio_de_conocimiento_050_040_000_010 : text <<optional, single>>
+class "Section 050 Part 2" as section_050_part_02 <<section>> {
+  entities : 3
+  file : open_cvn_research_050_part_02.puml
+  representative : ProyectosDeIDIFinanciadosEnConvocatoriasCompetitivasDeAdministracionesOEntidadesPublicasYPrivadas, ResultadosDerivadosDeActividadesEspecializadasYDeTransferenciaNoIncluidosEnApartadosAnteriores, TransferenciaEIntercambioDeConocimiento
 }
 
 }
 
+note bottom
+Readable subsection index for Section 050
+Detailed subsection files:
+- open_cvn_research_050_part_01.puml
+- open_cvn_research_050_part_02.puml
+end note
 @enduml

--- a/docs/diagrams/open_cvn_research_050_part_01.puml
+++ b/docs/diagrams/open_cvn_research_050_part_01.puml
@@ -1,0 +1,94 @@
+@startuml
+title Open CVN - CVN Research - Section 050 Part 1
+
+skinparam classAttributeIconSize 0
+hide circle
+
+package "CVN Research - Section 050 Part 1" as area_research_050_part_01 {
+class "ContratosConveniosOProyectosDeIDINoCompetitivosConAdministracionesOEntidadesPublicasOPrivadas" as entity_research_contratosconveniosoproyectosdeidinocompetitivosconadministracionesoentidadespublicasoprivadas_050_020_020_000 <<entity>> {
+  ambito_del_proyecto : controlled_reference <<optional, single>>
+  ambito_del_proyecto_otros : text <<optional, single>>
+  calidad_en_que_ha_participado_otros : text <<optional, single>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  codigo_de_proyecto_segun_la_entidad_financiadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  contratos_convenios_o_proyectos_de_i_d_i_no_competitivos_con_administraciones_o_entidades_publicas_o_privadas : text <<optional, repeated>>
+  duracion_del_proyecto : duration_like <<optional, single>>
+  .. +24 more attributes ..
+}
+
+class "EntidadEsColaboradoraS" as entity_research_entidadescolaboradoras_050_030_020_190 <<entity>> {
+  ciudad_de_la_entidad_colaboradora : text <<optional, repeated>>
+  comunidad_autonoma_region_de_la_entidad_colaboradora : controlled_reference <<optional, repeated>>
+  entidad_es_colaboradora_s : value_object<EntityNameType> <<optional, repeated>>
+  pais_de_la_entidad_colaboradora : controlled_reference <<optional, repeated>>
+  tipo_de_entidad_es : value_object<EntityTypeType> <<optional, repeated>>
+  tipo_de_entidad_es_otros : text <<optional, repeated>>
+}
+
+class "EntidadEsDestinatariaSDeLaActividad" as entity_research_entidadesdestinatariasdelaactividad_050_030_020_230 <<entity>> {
+  ciudad_de_la_entidad_destinataria : text <<optional, repeated>>
+  comunidad_autonoma_region_de_la_entidad_destinataria : controlled_reference <<optional, repeated>>
+  entidad_es_destinataria_s_de_la_actividad : value_object<EntityNameType> <<optional, repeated>>
+  pais_de_la_entidad_destinataria : controlled_reference <<optional, repeated>>
+  tipo_de_entidad_es : value_object<EntityTypeType> <<optional, repeated>>
+  tipo_de_entidad_es_otros : text <<optional, repeated>>
+}
+
+class "EntidadEsFinanciadoraS" as entity_research_entidadesfinanciadoras_050_020_010_210 <<entity>> {
+  ciudad_de_la_entidad_financiadora : text <<optional, repeated>>
+  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, repeated>>
+  entidad_es_financiadora_s : value_object<EntityNameType> <<required, repeated>>
+  pais_de_la_entidad_financiadora : controlled_reference <<optional, repeated>>
+  tipo_de_entidad : value_object<EntityTypeType> <<optional, repeated>>
+  tipo_de_entidad_otros : text <<optional, repeated>>
+}
+
+class "GruposEquiposDeInvestigacionDesarrolloOInnovacion" as entity_research_gruposequiposdeinvestigaciondesarrollooinnovacion_050_010_000_000 <<entity>> {
+  ciudad_de_radicacion_del_grupo : text <<optional, single>>
+  clases_de_colaboracion : controlled_reference <<optional, single>>
+  codigo_normalizado : text <<optional, single>>
+  comunidad_autonoma_region_de_radicacion_del_grupo : controlled_reference <<optional, single>>
+  duracion : duration_like <<optional, single>>
+  entidad_a_la_que_pertenece : value_object<EntityNameType> <<optional, single>>
+  explicacion_narrativa_de_la_aportacion : text <<optional, single>>
+  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
+  .. +12 more attributes ..
+}
+
+class "NombreSEntidadEsFinanciadoraS" as entity_research_nombresentidadesfinanciadoras_050_020_020_140 <<entity>> {
+  ciudad_de_la_entidad_financiadora : text <<optional, repeated>>
+  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, repeated>>
+  nombre_s_entidad_es_financiadora_s : value_object<EntityNameType> <<required, repeated>>
+  pais_de_la_entidad_financiadora : controlled_reference <<optional, repeated>>
+  tipo_de_entidad : value_object<EntityTypeType> <<optional, repeated>>
+  tipo_de_entidad_otros : text <<optional, repeated>>
+}
+
+class "ObrasArtisticasYProfesionales" as entity_research_obrasartisticasyprofesionales_050_020_030_000 <<entity>> {
+  autores_as_p_o_de_firma : text <<optional, repeated>>
+  caracteristicas_catalogo : boolean <<optional, single>>
+  caracteristicas_comisario_de_exposicion : boolean <<optional, single>>
+  caracteristicas_fecha : value_object<FlexibleDatesType> <<optional, single>>
+  caracteristicas_monografica : boolean <<optional, single>>
+  ciudad_de_la_exposicion : text <<optional, single>>
+  comunidad_autonoma_region_de_la_exposicion : controlled_reference <<optional, single>>
+  descripcion : text <<optional, single>>
+  .. +11 more attributes ..
+}
+
+class "PropiedadIndustrialEIntelectual" as entity_research_propiedadindustrialeintelectual_050_030_010_000 <<entity>> {
+  ambito_geografico_espana : boolean <<optional, single>>
+  ambito_geografico_internacional_no_ue : boolean <<optional, single>>
+  ambito_geografico_patente_europea : boolean <<optional, single>>
+  codigo_de_referencia_n_o_de_registro_si_procede : text <<optional, single>>
+  comunidad_autonoma_region_de_prioridad : controlled_reference <<optional, single>>
+  en_este_caso_el_resultado_en_relacion_con_la_empresa_es_de : controlled_reference <<optional, single>>
+  entidad_titular_de_derechos : value_object<EntityNameType> <<optional, single>>
+  explotacion_comunidad_autonoma_region_en_las_que_se_ha_extendido_formalizado : controlled_reference <<optional, repeated>>
+  .. +24 more attributes ..
+}
+
+}
+
+@enduml

--- a/docs/diagrams/open_cvn_research_050_part_02.puml
+++ b/docs/diagrams/open_cvn_research_050_part_02.puml
@@ -1,0 +1,39 @@
+@startuml
+title Open CVN - CVN Research - Section 050 Part 2
+
+skinparam classAttributeIconSize 0
+hide circle
+
+package "CVN Research - Section 050 Part 2" as area_research_050_part_02 {
+class "ProyectosDeIDIFinanciadosEnConvocatoriasCompetitivasDeAdministracionesOEntidadesPublicasYPrivadas" as entity_research_proyectosdeidifinanciadosenconvocatoriascompetitivasdeadministracionesoentidadespublicasyprivadas_050_020_010_000 <<entity>> {
+  ambito_del_proyecto : controlled_reference <<optional, single>>
+  ambito_del_proyecto_otros : text <<optional, single>>
+  calidad_en_que_ha_participado_otros : text <<optional, single>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  codigo_de_proyecto_segun_la_entidad_financiadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  duracion_del_proyecto : duration_like <<optional, single>>
+  entidad_donde_se_desarrolla : value_object<EntityNameType> <<required, single>>
+  .. +27 more attributes ..
+}
+
+class "ResultadosDerivadosDeActividadesEspecializadasYDeTransferenciaNoIncluidosEnApartadosAnteriores" as entity_research_resultadosderivadosdeactividadesespecializadasydetransferencianoincluidosenapartadosanteriores_050_030_020_000 <<entity>> {
+  ambito_de_la_actividad : controlled_reference <<optional, single>>
+  ambito_de_la_actividad_otros : text <<optional, single>>
+  calidad_en_que_ha_participado_otros : text <<optional, single>>
+  clave_de_actividad_convenios_de_colaboracion : boolean <<optional, single>>
+  clave_de_actividad_participacion_como_experto_a_tecnologico_a_en_labores_de_supervision_asesoria_evaluacion_o_peritaje : boolean <<optional, single>>
+  clave_de_actividad_participacion_en_la_generacion_de_empresas_spin_off_basadas_en_resultados_de_i_d_i : boolean <<optional, single>>
+  clave_de_actividad_puesta_en_marcha_de_nuevas_tecnicas_o_procedimientos_operacion_y_mantenimiento_de_grandes_instalaciones_o_equipamientos_complejos : boolean <<optional, single>>
+  clave_de_actividad_realizacion_de_servicios_tecnologicos_maduros_homologacion_calibracion_analisis_u_otros : boolean <<optional, single>>
+  .. +15 more attributes ..
+}
+
+class "TransferenciaEIntercambioDeConocimiento" as entity_research_transferenciaeintercambiodeconocimiento_050_040_000_000 <<entity>> {
+  transferencia_e_intercambio_de_conocimiento_050_040_000_000 : text <<optional, single>>
+  transferencia_e_intercambio_de_conocimiento_050_040_000_010 : text <<optional, single>>
+}
+
+}
+
+@enduml

--- a/docs/diagrams/open_cvn_research_060.puml
+++ b/docs/diagrams/open_cvn_research_060.puml
@@ -2,387 +2,41 @@
 title Open CVN - CVN Research - Section 060
 
 skinparam classAttributeIconSize 0
-hide circle
+hide empty members
 
-package "CVN Research - Section 060" as area_research_060 {
-class "AcreditacionesReconocimientosObtenidos" as entity_research_acreditacionesreconocimientosobtenidos_060_030_090_000 <<entity>> {
-  acreditaciones_reconocimientos_obtenidos : text <<optional, repeated>>
-  ciudad_de_la_entidad_que_acredita : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_que_acredita : controlled_reference <<optional, single>>
-  entidad_que_acredita : value_object<EntityNameType> <<optional, single>>
-  fecha_de_obtencion : value_object<FlexibleDatesType> <<optional, single>>
-  fecha_del_reconocimiento : value_object<FlexibleDatesType> <<optional, single>>
-  nombre_descripcion : text <<optional, single>>
-  numero_de_tramos_de_docencia_reconocidos : decimal_number <<optional, single>>
-  .. +3 more attributes ..
+package "CVN Research - Section 060" as readable_section_060_index {
+class "Section 060 Part 1" as section_060_part_01 <<section>> {
+  entities : 10
+  file : open_cvn_research_060_part_01.puml
+  representative : AcreditacionesReconocimientosObtenidos, ActividadesDeDivulgacion, AmbitoDelCongreso, +7 more
 }
 
-class "ActividadesDeDivulgacion" as entity_research_actividadesdedivulgacion_060_010_040_000 <<entity>> {
-  actividades_de_divulgacion : text <<optional, repeated>>
-  autores_as_p_o_de_firma : text <<optional, repeated>>
-  ciudad_de_la_entidad_organizadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_organizadora : controlled_reference <<optional, single>>
-  intervencion_por : controlled_reference <<optional, single>>
-  intervencion_por_indicar : text <<optional, single>>
-  localizacion_nombre_del_evento : text <<optional, single>>
-  pais_de_la_entidad_organizadora : controlled_reference <<optional, single>>
-  .. +7 more attributes ..
+class "Section 060 Part 2" as section_060_part_02 <<section>> {
+  entities : 11
+  file : open_cvn_research_060_part_02.puml
+  representative : EvaluacionYRevisionDeProyectosYArticulosDeIDI, FormaDeContribucion, ForosYComitesNacionalesEInternacionales, +8 more
 }
 
-class "AmbitoDelCongreso" as entity_research_ambitodelcongreso_060_010_020_100 <<entity>> {
-  ambito_del_congreso : controlled_reference <<optional, single>>
-  ambito_del_congreso_otros : text <<optional, single>>
-  fecha_de_finalizacion : value_object<FlexibleDatesType> <<required, single>>
-  localizacion_ciudad : text <<optional, single>>
-  localizacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
-  localizacion_entidad_organizadora : value_object<EntityNameType> <<optional, single>>
-  localizacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
-  localizacion_nombre_del_congreso : text <<optional, single>>
-  .. +3 more attributes ..
+class "Section 060 Part 3" as section_060_part_03 <<section>> {
+  entities : 12
+  file : open_cvn_research_060_part_03.puml
+  representative : PremiosMencionesYDistinciones, ProduccionCientifica, PublicacionesDocumentosCientificosYTecnicos, +9 more
 }
 
-class "AmbitoDelEvento060010030070" as entity_research_ambitodelevento060010030070_060_010_030_070 <<entity>> {
-  ambito_del_evento : controlled_reference <<optional, single>>
-  ambito_del_evento_otros : text <<optional, single>>
-  fecha_de_finalizacion : value_object<FlexibleDatesType> <<required, single>>
-  localizacion_ciudad : text <<optional, single>>
-  localizacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
-  localizacion_entidad_organizadora : value_object<EntityNameType> <<optional, single>>
-  localizacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
-  localizacion_nombre_del_evento : text <<optional, single>>
-  .. +3 more attributes ..
-}
-
-class "AmbitoDelEvento060010040080" as entity_research_ambitodelevento060010040080_060_010_040_080 <<entity>> {
-  ambito_del_evento : controlled_reference <<optional, single>>
-  ambito_del_evento_otros : text <<optional, single>>
-  localizacion_ciudad : text <<optional, single>>
-  localizacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
-  localizacion_entidad_organizadora : value_object<EntityNameType> <<optional, single>>
-  localizacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
-  localizacion_nombre_del_evento : text <<optional, single>>
-  localizacion_pais : controlled_reference <<optional, single>>
-  .. +2 more attributes ..
-}
-
-class "AyudasYBecasObtenidas" as entity_research_ayudasybecasobtenidas_060_030_010_000 <<entity>> {
-  ayudas_y_becas_obtenidas : text <<optional, repeated>>
-  ciudad_de_la_entidad_que_la_concede : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_que_la_concede : controlled_reference <<optional, single>>
-  duracion_de_la_ayuda : duration_like <<optional, single>>
-  entidad_de_realizacion : value_object<EntityNameType> <<required, single>>
-  entidad_que_la_concede : value_object<EntityNameType> <<optional, single>>
-  facultad_escuela_unidad_centro_hospital_o_instituto : value_object<EntityNameType> <<optional, single>>
-  fecha : value_object<FlexibleDatesType> <<optional, single>>
-  .. +9 more attributes ..
-}
-
-class "ComitesCientificosTecnicosYOAsesores" as entity_research_comitescientificostecnicosyoasesores_060_020_010_000 <<entity>> {
-  ambito_de_la_actividad : controlled_reference <<optional, single>>
-  ambito_de_la_actividad_otros : text <<optional, single>>
-  ciudad_de_la_entidad_de_la_que_depende_el_programa : text <<optional, single>>
-  ciudad_de_radicacion : text <<optional, single>>
-  codigo_unesco_especializacion_primaria : controlled_reference <<optional, repeated>>
-  codigo_unesco_especializacion_secundaria : controlled_reference <<optional, repeated>>
-  codigo_unesco_especializacion_terciaria : controlled_reference <<optional, repeated>>
-  comites_cientificos_tecnicos_y_o_asesores : text <<optional, repeated>>
-  .. +11 more attributes ..
-}
-
-class "ConsejosEditoriales" as entity_research_consejoseditoriales_060_030_030_000 <<entity>> {
-  ambito : controlled_reference <<optional, single>>
-  ambito_otros : text <<optional, single>>
-  categoria_profesional : text <<optional, single>>
-  ciudad_de_la_entidad_de_afiliacion : text <<optional, single>>
-  ciudad_de_radicacion : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_afiliacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_radicacion : controlled_reference <<optional, single>>
-  consejos_editoriales : text <<optional, repeated>>
-  .. +10 more attributes ..
-}
-
-class "EntidadesParticipantes" as entity_research_entidadesparticipantes_060_020_020_100 <<entity>> {
-  ciudad_de_la_entidad_participante : text <<optional, repeated>>
-  comunidad_autonoma_region_de_la_entidad_participante : controlled_reference <<optional, repeated>>
-  entidades_participantes : value_object<EntityNameType> <<optional, repeated>>
-  pais_de_la_entidad_participante : controlled_reference <<optional, repeated>>
-  tipo_de_entidad : value_object<EntityTypeType> <<optional, repeated>>
-  tipo_de_entidad_otros : text <<optional, repeated>>
-}
-
-class "EstanciasEnCentrosPublicosOPrivados" as entity_research_estanciasencentrospublicosoprivados_060_010_050_000 <<entity>> {
-  capacidades_adquiridas_posteriormente_desarrolladas : text <<optional, single>>
-  centro_entidad_de_realizacion : value_object<EntityNameType> <<required, single>>
-  ciudad_de_la_entidad_financiadora : text <<optional, single>>
-  codigo_unesco_especializacion_primaria : controlled_reference <<optional, repeated>>
-  codigo_unesco_especializacion_secundaria : controlled_reference <<optional, repeated>>
-  codigo_unesco_especializacion_terciaria : controlled_reference <<optional, repeated>>
-  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
-  entidad_fuente_de_la_financiacion : value_object<EntityNameType> <<optional, single>>
-  .. +20 more attributes ..
-}
-
-class "EvaluacionYRevisionDeProyectosYArticulosDeIDI" as entity_research_evaluacionyrevisiondeproyectosyarticulosdeidi_060_020_060_000 <<entity>> {
-  ambito : controlled_reference <<optional, single>>
-  ambito_otros : text <<optional, single>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
-  evaluacion_y_revision_de_proyectos_y_articulos_de_i_d_i : text <<optional, repeated>>
-  fecha_de_finalizacion : value_object<FlexibleDatesType> <<optional, single>>
-  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
-  .. +10 more attributes ..
-}
-
-class "FormaDeContribucion" as entity_research_formadecontribucion_060_010_020_220 <<entity>> {
-  autor_de_correspondencia : boolean <<optional, single>>
-  forma_de_contribucion : controlled_reference <<optional, single>>
-  identificador_de_publicacion_digital : text <<optional, repeated>>
-  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
-  publicacion_deposito_legal : text <<optional, single>>
-  publicacion_direccion_electronica : text <<optional, single>>
-  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
-  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
-  .. +8 more attributes ..
-}
-
-class "ForosYComitesNacionalesEInternacionales" as entity_research_forosycomitesnacionaleseinternacionales_060_020_050_000 <<entity>> {
-  categoria_profesional : text <<optional, single>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  ciudad_de_la_entidad_organizadora : text <<optional, single>>
-  ciudad_de_la_entidad_que_representa : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_organizadora : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_que_representa : controlled_reference <<optional, single>>
-  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
-  .. +12 more attributes ..
-}
-
-class "GestionDeIDI" as entity_research_gestiondeidi_060_020_040_000 <<entity>> {
-  ambito_territorial : controlled_reference <<optional, single>>
-  ambito_territorial_otros : text <<optional, single>>
-  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
-  entorno_duracion : duration_like <<optional, single>>
-  entorno_entidad_donde_se_ejercio_la_responsabilidad : value_object<EntityNameType> <<optional, single>>
-  entorno_fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
-  entorno_tipo_de_entidad : value_object<EntityTypeType> <<optional, single>>
-  .. +15 more attributes ..
-}
-
-class "IndicadoresGeneralesDeCalidadDeLaProduccionCientifica" as entity_research_indicadoresgeneralesdecalidaddelaproduccioncientifica_060_010_060_000 <<entity>> {
-  indicadores_generales_de_calidad_de_la_produccion_cientifica_060_010_060_000 : text <<optional, single>>
-  indicadores_generales_de_calidad_de_la_produccion_cientifica_060_010_060_010 : text <<optional, single>>
-}
-
-class "OrganizacionDeActividadesDeIDI" as entity_research_organizaciondeactividadesdeidi_060_020_030_000 <<entity>> {
-  ambito_de_la_reunion : controlled_reference <<optional, single>>
-  ambito_de_la_reunion_otros : text <<optional, single>>
-  ciudad_de_la_actividad : text <<optional, single>>
-  ciudad_de_la_entidad_convocante : text <<optional, single>>
-  comunidad_autonoma_region_de_la_actividad : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_convocante : controlled_reference <<optional, single>>
-  duracion : duration_like <<optional, single>>
-  entidad_convocante : value_object<EntityNameType> <<optional, single>>
-  .. +12 more attributes ..
-}
-
-class "OtrasDistincionesCarreraProfesionalYOEmpresarial" as entity_research_otrasdistincionescarreraprofesionalyoempresarial_060_030_060_000 <<entity>> {
-  ambito : controlled_reference <<optional, single>>
-  ambito_otros : text <<optional, single>>
-  breve_descripcion_del_ambito_de_capacidades_cientificas_o_tecnologicas_del_ascenso_y_cambios_de_responsabilidad : text <<optional, single>>
-  ciudad_de_la_entidad_que_concede_el_reconocimiento : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_que_concede_el_reconocimiento : controlled_reference <<optional, single>>
-  entidad_que_lo_concede : value_object<EntityNameType> <<optional, single>>
-  fecha_de_concesion : value_object<FlexibleDatesType> <<optional, single>>
-  otras_distinciones_carrera_profesional_y_o_empresarial : text <<optional, repeated>>
-  .. +3 more attributes ..
-}
-
-class "OtrosMeritosDeLaActividadInvestigadora" as entity_research_otrosmeritosdelaactividadinvestigadora_060_030_110_000 <<entity>> {
-  otros_meritos_de_la_actividad_investigadora_060_030_110_000 : text <<optional, single>>
-  otros_meritos_de_la_actividad_investigadora_060_030_110_010 : text <<optional, single>>
-}
-
-class "OtrosModosDeColaboracionConInvestigadoresAsOTecnologosAs" as entity_research_otrosmodosdecolaboracionconinvestigadoresasotecnologosas_060_020_020_000 <<entity>> {
-  ciudad_de_radicacion : text <<optional, single>>
-  comunidad_autonoma_region_de_radicacion : controlled_reference <<optional, single>>
-  descripcion_del_objeto_de_la_colaboracion : text <<optional, single>>
-  duracion : duration_like <<optional, single>>
-  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
-  modo_de_relacion : controlled_reference <<optional, single>>
-  modo_de_relacion_otros : text <<optional, single>>
-  nombres_de_los_investigadores_principales_ip_co_ip : text <<optional, repeated>>
-  .. +5 more attributes ..
-}
-
-class "PeriodosDeActividadInvestigadoraDocenteYDeTransferenciaDelConocimiento" as entity_research_periodosdeactividadinvestigadoradocenteydetransferenciadelconocimiento_060_030_070_000 <<entity>> {
-  ambito : controlled_reference <<optional, single>>
-  ambito_otros : text <<optional, single>>
-  ano_de_convocatoria : text <<optional, single>>
-  ano_de_finalizacion : text <<optional, single>>
-  ano_de_inicio : text <<optional, single>>
-  calificacion_obtenida : text <<optional, single>>
-  ciudad_de_la_entidad_que_acredita : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_que_acredita : controlled_reference <<optional, single>>
-  .. +12 more attributes ..
-}
-
-class "PremiosDeInnovacionDocente" as entity_research_premiosdeinnovaciondocente_060_030_080_000 <<entity>> {
-  a_propuesta_de : text <<optional, single>>
-  ciudad_de_la_entidad_que_concede_el_premio : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_que_concede_el_premio : controlled_reference <<optional, single>>
-  entidad_que_concede : value_object<EntityNameType> <<optional, single>>
-  explicacion_narrativa_del_merito : text <<optional, single>>
-  fecha_de_concesion : value_object<FlexibleDatesType> <<optional, single>>
-  nombre_del_premio : text <<optional, single>>
-  pais_de_la_entidad_que_concede_el_premio : controlled_reference <<optional, single>>
-  .. +3 more attributes ..
-}
-
-class "PremiosMencionesYDistinciones" as entity_research_premiosmencionesydistinciones_060_030_050_000 <<entity>> {
-  breve_descripcion_del_titulo_o_premio : text <<optional, single>>
-  ciudad_de_la_entidad_que_lo_concede : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_que_lo_concede : controlled_reference <<optional, single>>
-  entidad_que_lo_concede : value_object<EntityNameType> <<optional, single>>
-  fecha_de_concesion : value_object<FlexibleDatesType> <<optional, single>>
-  pais_de_la_entidad_que_lo_concede : controlled_reference <<optional, single>>
-  premios_menciones_y_distinciones : text <<optional, repeated>>
-  reconocimientos_ligados_a_su_concesion : text <<optional, single>>
-  .. +2 more attributes ..
-}
-
-class "ProduccionCientifica" as entity_research_produccioncientifica_060_010_000_000 <<entity>> {
-  fuente_de_indice_h : controlled_reference <<optional, single>>
-  fuente_de_indice_h_otros : text <<optional, single>>
-  indice_h_fecha_de_aplicacion : value_object<FlexibleDatesType> <<optional, single>>
-  indice_h_valor : decimal_number <<optional, single>>
-  produccion_cientifica : text <<optional, repeated>>
-}
-
-class "PublicacionesDocumentosCientificosYTecnicos" as entity_research_publicacionesdocumentoscientificosytecnicos_060_010_010_000 <<entity>> {
-  autor_de_correspondencia : boolean <<optional, single>>
-  autores_as_p_o_de_firma_nombre : text <<optional, repeated>>
-  categoria : controlled_reference <<optional, repeated>>
-  ciudad_de_publicacion : text <<optional, single>>
-  coleccion : text <<optional, single>>
-  fuente_de_citas : controlled_reference <<optional, repeated>>
-  fuente_de_citas_otros : text <<optional, repeated>>
-  fuente_del_dato : controlled_reference <<optional, single>>
-  .. +25 more attributes ..
-}
-
-class "PublicacionIndiceDeImpactoDeAnoDePublicacion" as entity_research_publicacionindicedeimpactodeanodepublicacion_060_010_010_240 <<entity>> {
-  categoria : controlled_reference <<optional, repeated>>
-  fuente_de_impacto : controlled_reference <<optional, repeated>>
-  fuente_de_impacto_otros : text <<optional, repeated>>
-  numero_de_revistas_en_la_categoria : decimal_number <<optional, repeated>>
-  posicion_que_ocupa_la_revista_en_la_categoria : decimal_number <<optional, repeated>>
-  publicacion_indice_de_impacto_de_ano_de_publicacion : text <<optional, repeated>>
-  revista_dentro_del_25_de_mayor_indice_de_impacto : boolean <<optional, repeated>>
-}
-
-class "PublicacionNombre060010020370" as entity_research_publicacionnombre060010020370_060_010_020_370 <<entity>> {
-  publicacion_nombre : text <<optional, single>>
-}
-
-class "PublicacionNombre060010030350" as entity_research_publicacionnombre060010030350_060_010_030_350 <<entity>> {
-  publicacion_nombre : text <<optional, single>>
-}
-
-class "PublicacionNombre060010040360" as entity_research_publicacionnombre060010040360_060_010_040_360 <<entity>> {
-  publicacion_nombre : text <<optional, single>>
-}
-
-class "PublicacionTipo060010030190" as entity_research_publicaciontipo060010030190_060_010_030_190 <<entity>> {
-  autor_de_correspondencia : boolean <<optional, single>>
-  identificador_de_publicacion_digital : text <<optional, repeated>>
-  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
-  publicacion_deposito_legal : text <<optional, single>>
-  publicacion_direccion_electronica : text <<optional, single>>
-  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
-  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
-  publicacion_isbn_issn : text <<optional, repeated>>
-  .. +8 more attributes ..
-}
-
-class "PublicacionTipo060010040200" as entity_research_publicaciontipo060010040200_060_010_040_200 <<entity>> {
-  autor_de_correspondencia : boolean <<optional, single>>
-  identificador_de_publicacion_digital : text <<optional, repeated>>
-  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
-  publicacion_deposito_legal : text <<optional, single>>
-  publicacion_direccion_electronica : text <<optional, single>>
-  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
-  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
-  publicacion_isbn_issn : text <<optional, repeated>>
-  .. +8 more attributes ..
-}
-
-class "RedesDeCooperacion" as entity_research_redesdecooperacion_060_030_040_000 <<entity>> {
-  ciudad_de_la_entidad_de_afiliacion : text <<optional, single>>
-  ciudad_de_radicacion : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_afiliacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_radicacion : controlled_reference <<optional, single>>
-  duracion : duration_like <<optional, single>>
-  entidad_es_participante_s : value_object<EntityNameType> <<optional, repeated>>
-  entidad_que_realizo_la_seleccion : value_object<EntityNameType> <<optional, single>>
-  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
-  .. +11 more attributes ..
-}
-
-class "ResumenDeOtrosMeritos" as entity_research_resumendeotrosmeritos_060_030_100_000 <<entity>> {
-  ciudad_de_la_entidad_que_acredita : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_que_acredita : controlled_reference <<optional, single>>
-  entidad_que_acredita : value_object<EntityNameType> <<optional, single>>
-  fecha_de_concesion : value_object<FlexibleDatesType> <<optional, single>>
-  pais_de_la_entidad_que_acredita : controlled_reference <<optional, single>>
-  resumen_de_otros_meritos : text <<optional, repeated>>
-  resumen_de_otros_meritos_en_texto_libre : text <<optional, single>>
-  tipo_de_entidad : value_object<EntityTypeType> <<optional, single>>
-  .. +1 more attributes ..
-}
-
-class "SociedadesCientificasYAsociacionesProfesionales" as entity_research_sociedadescientificasyasociacionesprofesionales_060_030_020_000 <<entity>> {
-  categoria_profesional : text <<optional, single>>
-  ciudad_de_la_entidad_de_afiliacion : text <<optional, single>>
-  ciudad_de_radicacion : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_de_afiliacion : controlled_reference <<optional, single>>
-  comunidad_autonoma_region_de_radicacion : controlled_reference <<optional, single>>
-  entidad_de_afiliacion : value_object<EntityNameType> <<optional, single>>
-  fecha_de_finalizacion : value_object<FlexibleDatesType> <<optional, single>>
-  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
-  .. +8 more attributes ..
-}
-
-class "Soporte" as entity_research_soporte_060_010_010_070 <<entity>> {
-  publicacion_nombre : text <<optional, single>>
-  soporte : controlled_reference <<optional, single>>
-}
-
-class "TrabajosPresentadosEnCongresosNacionalesOInternacionales" as entity_research_trabajospresentadosencongresosnacionalesointernacionales_060_010_020_000 <<entity>> {
-  autores_as_p_o_de_firma : text <<optional, repeated>>
-  ciudad_de_la_entidad_organizadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_organizadora : controlled_reference <<optional, single>>
-  forma_de_contribucion : controlled_reference <<optional, single>>
-  fuente_de_citas : controlled_reference <<optional, repeated>>
-  fuente_de_citas_otros : text <<optional, repeated>>
-  intervencion_por : controlled_reference <<optional, single>>
-  intervencion_por_otros : text <<optional, single>>
-  .. +11 more attributes ..
-}
-
-class "TrabajosPresentadosEnJornadasSeminariosTalleresDeTrabajoYOCursosNacionalesOInternacionales" as entity_research_trabajospresentadosenjornadasseminariostalleresdetrabajoyocursosnacionalesointernacionales_060_010_030_000 <<entity>> {
-  autores_as_p_o_de_firma : text <<optional, repeated>>
-  ciudad_de_la_entidad_organizadora : text <<optional, single>>
-  comunidad_autonoma_region_de_la_entidad_organizadora : controlled_reference <<optional, single>>
-  fuente_de_citas : controlled_reference <<optional, repeated>>
-  fuente_de_citas_otros : text <<optional, repeated>>
-  intervencion_por : controlled_reference <<optional, single>>
-  localizacion_nombre_del_evento : text <<optional, single>>
-  numero_de_citas : decimal_number <<optional, repeated>>
-  .. +8 more attributes ..
+class "Section 060 Part 4" as section_060_part_04 <<section>> {
+  entities : 3
+  file : open_cvn_research_060_part_04.puml
+  representative : Soporte, TrabajosPresentadosEnCongresosNacionalesOInternacionales, TrabajosPresentadosEnJornadasSeminariosTalleresDeTrabajoYOCursosNacionalesOInternacionales
 }
 
 }
 
+note bottom
+Readable subsection index for Section 060
+Detailed subsection files:
+- open_cvn_research_060_part_01.puml
+- open_cvn_research_060_part_02.puml
+- open_cvn_research_060_part_03.puml
+- open_cvn_research_060_part_04.puml
+end note
 @enduml

--- a/docs/diagrams/open_cvn_research_060_part_01.puml
+++ b/docs/diagrams/open_cvn_research_060_part_01.puml
@@ -1,0 +1,127 @@
+@startuml
+title Open CVN - CVN Research - Section 060 Part 1
+
+skinparam classAttributeIconSize 0
+hide circle
+
+package "CVN Research - Section 060 Part 1" as area_research_060_part_01 {
+class "AcreditacionesReconocimientosObtenidos" as entity_research_acreditacionesreconocimientosobtenidos_060_030_090_000 <<entity>> {
+  acreditaciones_reconocimientos_obtenidos : text <<optional, repeated>>
+  ciudad_de_la_entidad_que_acredita : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_que_acredita : controlled_reference <<optional, single>>
+  entidad_que_acredita : value_object<EntityNameType> <<optional, single>>
+  fecha_de_obtencion : value_object<FlexibleDatesType> <<optional, single>>
+  fecha_del_reconocimiento : value_object<FlexibleDatesType> <<optional, single>>
+  nombre_descripcion : text <<optional, single>>
+  numero_de_tramos_de_docencia_reconocidos : decimal_number <<optional, single>>
+  .. +3 more attributes ..
+}
+
+class "ActividadesDeDivulgacion" as entity_research_actividadesdedivulgacion_060_010_040_000 <<entity>> {
+  actividades_de_divulgacion : text <<optional, repeated>>
+  autores_as_p_o_de_firma : text <<optional, repeated>>
+  ciudad_de_la_entidad_organizadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_organizadora : controlled_reference <<optional, single>>
+  intervencion_por : controlled_reference <<optional, single>>
+  intervencion_por_indicar : text <<optional, single>>
+  localizacion_nombre_del_evento : text <<optional, single>>
+  pais_de_la_entidad_organizadora : controlled_reference <<optional, single>>
+  .. +7 more attributes ..
+}
+
+class "AmbitoDelCongreso" as entity_research_ambitodelcongreso_060_010_020_100 <<entity>> {
+  ambito_del_congreso : controlled_reference <<optional, single>>
+  ambito_del_congreso_otros : text <<optional, single>>
+  fecha_de_finalizacion : value_object<FlexibleDatesType> <<required, single>>
+  localizacion_ciudad : text <<optional, single>>
+  localizacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
+  localizacion_entidad_organizadora : value_object<EntityNameType> <<optional, single>>
+  localizacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
+  localizacion_nombre_del_congreso : text <<optional, single>>
+  .. +3 more attributes ..
+}
+
+class "AmbitoDelEvento" as entity_research_ambitodelevento060010030070_060_010_030_070 <<entity>> {
+  ambito_del_evento : controlled_reference <<optional, single>>
+  ambito_del_evento_otros : text <<optional, single>>
+  fecha_de_finalizacion : value_object<FlexibleDatesType> <<required, single>>
+  localizacion_ciudad : text <<optional, single>>
+  localizacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
+  localizacion_entidad_organizadora : value_object<EntityNameType> <<optional, single>>
+  localizacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
+  localizacion_nombre_del_evento : text <<optional, single>>
+  .. +3 more attributes ..
+}
+
+class "AmbitoDelEvento" as entity_research_ambitodelevento060010040080_060_010_040_080 <<entity>> {
+  ambito_del_evento : controlled_reference <<optional, single>>
+  ambito_del_evento_otros : text <<optional, single>>
+  localizacion_ciudad : text <<optional, single>>
+  localizacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
+  localizacion_entidad_organizadora : value_object<EntityNameType> <<optional, single>>
+  localizacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
+  localizacion_nombre_del_evento : text <<optional, single>>
+  localizacion_pais : controlled_reference <<optional, single>>
+  .. +2 more attributes ..
+}
+
+class "AyudasYBecasObtenidas" as entity_research_ayudasybecasobtenidas_060_030_010_000 <<entity>> {
+  ayudas_y_becas_obtenidas : text <<optional, repeated>>
+  ciudad_de_la_entidad_que_la_concede : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_que_la_concede : controlled_reference <<optional, single>>
+  duracion_de_la_ayuda : duration_like <<optional, single>>
+  entidad_de_realizacion : value_object<EntityNameType> <<required, single>>
+  entidad_que_la_concede : value_object<EntityNameType> <<optional, single>>
+  facultad_escuela_unidad_centro_hospital_o_instituto : value_object<EntityNameType> <<optional, single>>
+  fecha : value_object<FlexibleDatesType> <<optional, single>>
+  .. +9 more attributes ..
+}
+
+class "ComitesCientificosTecnicosYOAsesores" as entity_research_comitescientificostecnicosyoasesores_060_020_010_000 <<entity>> {
+  ambito_de_la_actividad : controlled_reference <<optional, single>>
+  ambito_de_la_actividad_otros : text <<optional, single>>
+  ciudad_de_la_entidad_de_la_que_depende_el_programa : text <<optional, single>>
+  ciudad_de_radicacion : text <<optional, single>>
+  codigo_unesco_especializacion_primaria : controlled_reference <<optional, repeated>>
+  codigo_unesco_especializacion_secundaria : controlled_reference <<optional, repeated>>
+  codigo_unesco_especializacion_terciaria : controlled_reference <<optional, repeated>>
+  comites_cientificos_tecnicos_y_o_asesores : text <<optional, repeated>>
+  .. +11 more attributes ..
+}
+
+class "ConsejosEditoriales" as entity_research_consejoseditoriales_060_030_030_000 <<entity>> {
+  ambito : controlled_reference <<optional, single>>
+  ambito_otros : text <<optional, single>>
+  categoria_profesional : text <<optional, single>>
+  ciudad_de_la_entidad_de_afiliacion : text <<optional, single>>
+  ciudad_de_radicacion : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_afiliacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_radicacion : controlled_reference <<optional, single>>
+  consejos_editoriales : text <<optional, repeated>>
+  .. +10 more attributes ..
+}
+
+class "EntidadesParticipantes" as entity_research_entidadesparticipantes_060_020_020_100 <<entity>> {
+  ciudad_de_la_entidad_participante : text <<optional, repeated>>
+  comunidad_autonoma_region_de_la_entidad_participante : controlled_reference <<optional, repeated>>
+  entidades_participantes : value_object<EntityNameType> <<optional, repeated>>
+  pais_de_la_entidad_participante : controlled_reference <<optional, repeated>>
+  tipo_de_entidad : value_object<EntityTypeType> <<optional, repeated>>
+  tipo_de_entidad_otros : text <<optional, repeated>>
+}
+
+class "EstanciasEnCentrosPublicosOPrivados" as entity_research_estanciasencentrospublicosoprivados_060_010_050_000 <<entity>> {
+  capacidades_adquiridas_posteriormente_desarrolladas : text <<optional, single>>
+  centro_entidad_de_realizacion : value_object<EntityNameType> <<required, single>>
+  ciudad_de_la_entidad_financiadora : text <<optional, single>>
+  codigo_unesco_especializacion_primaria : controlled_reference <<optional, repeated>>
+  codigo_unesco_especializacion_secundaria : controlled_reference <<optional, repeated>>
+  codigo_unesco_especializacion_terciaria : controlled_reference <<optional, repeated>>
+  comunidad_autonoma_region_de_la_entidad_financiadora : controlled_reference <<optional, single>>
+  entidad_fuente_de_la_financiacion : value_object<EntityNameType> <<optional, single>>
+  .. +20 more attributes ..
+}
+
+}
+
+@enduml

--- a/docs/diagrams/open_cvn_research_060_part_01_reference.puml
+++ b/docs/diagrams/open_cvn_research_060_part_01_reference.puml
@@ -76,7 +76,7 @@ controlled references:
 - ISO_3166 (code_list, enum=ineligible, items=312)
 end note
 
-class "AmbitoDelEvento060010030070" as entity_research_ambitodelevento060010030070_060_010_030_070 <<entity>> {
+class "AmbitoDelEvento" as entity_research_ambitodelevento060010030070_060_010_030_070 <<entity>> {
   ambito_del_evento : controlled_reference <<optional, single>> [CVN: 060.010.030.050]
   ambito_del_evento_otros : text <<optional, single>> [CVN: 060.010.030.060]
   fecha_de_finalizacion : value_object<FlexibleDatesType> <<required, single>> [CVN: 060.010.030.370]
@@ -98,7 +98,7 @@ controlled references:
 - ISO_3166 (code_list, enum=ineligible, items=312)
 end note
 
-class "AmbitoDelEvento060010040080" as entity_research_ambitodelevento060010040080_060_010_040_080 <<entity>> {
+class "AmbitoDelEvento" as entity_research_ambitodelevento060010040080_060_010_040_080 <<entity>> {
   ambito_del_evento : controlled_reference <<optional, single>> [CVN: 060.010.040.060]
   ambito_del_evento_otros : text <<optional, single>> [CVN: 060.010.040.070]
   localizacion_ciudad : text <<optional, single>> [CVN: 060.010.040.160]

--- a/docs/diagrams/open_cvn_research_060_part_02.puml
+++ b/docs/diagrams/open_cvn_research_060_part_02.puml
@@ -1,0 +1,128 @@
+@startuml
+title Open CVN - CVN Research - Section 060 Part 2
+
+skinparam classAttributeIconSize 0
+hide circle
+
+package "CVN Research - Section 060 Part 2" as area_research_060_part_02 {
+class "EvaluacionYRevisionDeProyectosYArticulosDeIDI" as entity_research_evaluacionyrevisiondeproyectosyarticulosdeidi_060_020_060_000 <<entity>> {
+  ambito : controlled_reference <<optional, single>>
+  ambito_otros : text <<optional, single>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
+  evaluacion_y_revision_de_proyectos_y_articulos_de_i_d_i : text <<optional, repeated>>
+  fecha_de_finalizacion : value_object<FlexibleDatesType> <<optional, single>>
+  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
+  .. +10 more attributes ..
+}
+
+class "FormaDeContribucion" as entity_research_formadecontribucion_060_010_020_220 <<entity>> {
+  autor_de_correspondencia : boolean <<optional, single>>
+  forma_de_contribucion : controlled_reference <<optional, single>>
+  identificador_de_publicacion_digital : text <<optional, repeated>>
+  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
+  publicacion_deposito_legal : text <<optional, single>>
+  publicacion_direccion_electronica : text <<optional, single>>
+  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
+  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
+  .. +8 more attributes ..
+}
+
+class "ForosYComitesNacionalesEInternacionales" as entity_research_forosycomitesnacionaleseinternacionales_060_020_050_000 <<entity>> {
+  categoria_profesional : text <<optional, single>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  ciudad_de_la_entidad_organizadora : text <<optional, single>>
+  ciudad_de_la_entidad_que_representa : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_organizadora : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_que_representa : controlled_reference <<optional, single>>
+  entidad_organizadora : value_object<EntityNameType> <<optional, single>>
+  .. +12 more attributes ..
+}
+
+class "GestionDeIDI" as entity_research_gestiondeidi_060_020_040_000 <<entity>> {
+  ambito_territorial : controlled_reference <<optional, single>>
+  ambito_territorial_otros : text <<optional, single>>
+  ciudad_de_la_entidad_de_realizacion : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_realizacion : controlled_reference <<optional, single>>
+  entorno_duracion : duration_like <<optional, single>>
+  entorno_entidad_donde_se_ejercio_la_responsabilidad : value_object<EntityNameType> <<optional, single>>
+  entorno_fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
+  entorno_tipo_de_entidad : value_object<EntityTypeType> <<optional, single>>
+  .. +15 more attributes ..
+}
+
+class "IndicadoresGeneralesDeCalidadDeLaProduccionCientifica" as entity_research_indicadoresgeneralesdecalidaddelaproduccioncientifica_060_010_060_000 <<entity>> {
+  indicadores_generales_de_calidad_de_la_produccion_cientifica_060_010_060_000 : text <<optional, single>>
+  indicadores_generales_de_calidad_de_la_produccion_cientifica_060_010_060_010 : text <<optional, single>>
+}
+
+class "OrganizacionDeActividadesDeIDI" as entity_research_organizaciondeactividadesdeidi_060_020_030_000 <<entity>> {
+  ambito_de_la_reunion : controlled_reference <<optional, single>>
+  ambito_de_la_reunion_otros : text <<optional, single>>
+  ciudad_de_la_actividad : text <<optional, single>>
+  ciudad_de_la_entidad_convocante : text <<optional, single>>
+  comunidad_autonoma_region_de_la_actividad : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_convocante : controlled_reference <<optional, single>>
+  duracion : duration_like <<optional, single>>
+  entidad_convocante : value_object<EntityNameType> <<optional, single>>
+  .. +12 more attributes ..
+}
+
+class "OtrasDistincionesCarreraProfesionalYOEmpresarial" as entity_research_otrasdistincionescarreraprofesionalyoempresarial_060_030_060_000 <<entity>> {
+  ambito : controlled_reference <<optional, single>>
+  ambito_otros : text <<optional, single>>
+  breve_descripcion_del_ambito_de_capacidades_cientificas_o_tecnologicas_del_ascenso_y_cambios_de_responsabilidad : text <<optional, single>>
+  ciudad_de_la_entidad_que_concede_el_reconocimiento : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_que_concede_el_reconocimiento : controlled_reference <<optional, single>>
+  entidad_que_lo_concede : value_object<EntityNameType> <<optional, single>>
+  fecha_de_concesion : value_object<FlexibleDatesType> <<optional, single>>
+  otras_distinciones_carrera_profesional_y_o_empresarial : text <<optional, repeated>>
+  .. +3 more attributes ..
+}
+
+class "OtrosMeritosDeLaActividadInvestigadora" as entity_research_otrosmeritosdelaactividadinvestigadora_060_030_110_000 <<entity>> {
+  otros_meritos_de_la_actividad_investigadora_060_030_110_000 : text <<optional, single>>
+  otros_meritos_de_la_actividad_investigadora_060_030_110_010 : text <<optional, single>>
+}
+
+class "OtrosModosDeColaboracionConInvestigadoresAsOTecnologosAs" as entity_research_otrosmodosdecolaboracionconinvestigadoresasotecnologosas_060_020_020_000 <<entity>> {
+  ciudad_de_radicacion : text <<optional, single>>
+  comunidad_autonoma_region_de_radicacion : controlled_reference <<optional, single>>
+  descripcion_del_objeto_de_la_colaboracion : text <<optional, single>>
+  duracion : duration_like <<optional, single>>
+  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
+  modo_de_relacion : controlled_reference <<optional, single>>
+  modo_de_relacion_otros : text <<optional, single>>
+  nombres_de_los_investigadores_principales_ip_co_ip : text <<optional, repeated>>
+  .. +5 more attributes ..
+}
+
+class "PeriodosDeActividadInvestigadoraDocenteYDeTransferenciaDelConocimiento" as entity_research_periodosdeactividadinvestigadoradocenteydetransferenciadelconocimiento_060_030_070_000 <<entity>> {
+  ambito : controlled_reference <<optional, single>>
+  ambito_otros : text <<optional, single>>
+  ano_de_convocatoria : text <<optional, single>>
+  ano_de_finalizacion : text <<optional, single>>
+  ano_de_inicio : text <<optional, single>>
+  calificacion_obtenida : text <<optional, single>>
+  ciudad_de_la_entidad_que_acredita : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_que_acredita : controlled_reference <<optional, single>>
+  .. +12 more attributes ..
+}
+
+class "PremiosDeInnovacionDocente" as entity_research_premiosdeinnovaciondocente_060_030_080_000 <<entity>> {
+  a_propuesta_de : text <<optional, single>>
+  ciudad_de_la_entidad_que_concede_el_premio : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_que_concede_el_premio : controlled_reference <<optional, single>>
+  entidad_que_concede : value_object<EntityNameType> <<optional, single>>
+  explicacion_narrativa_del_merito : text <<optional, single>>
+  fecha_de_concesion : value_object<FlexibleDatesType> <<optional, single>>
+  nombre_del_premio : text <<optional, single>>
+  pais_de_la_entidad_que_concede_el_premio : controlled_reference <<optional, single>>
+  .. +3 more attributes ..
+}
+
+}
+
+@enduml

--- a/docs/diagrams/open_cvn_research_060_part_03.puml
+++ b/docs/diagrams/open_cvn_research_060_part_03.puml
@@ -1,0 +1,124 @@
+@startuml
+title Open CVN - CVN Research - Section 060 Part 3
+
+skinparam classAttributeIconSize 0
+hide circle
+
+package "CVN Research - Section 060 Part 3" as area_research_060_part_03 {
+class "PremiosMencionesYDistinciones" as entity_research_premiosmencionesydistinciones_060_030_050_000 <<entity>> {
+  breve_descripcion_del_titulo_o_premio : text <<optional, single>>
+  ciudad_de_la_entidad_que_lo_concede : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_que_lo_concede : controlled_reference <<optional, single>>
+  entidad_que_lo_concede : value_object<EntityNameType> <<optional, single>>
+  fecha_de_concesion : value_object<FlexibleDatesType> <<optional, single>>
+  pais_de_la_entidad_que_lo_concede : controlled_reference <<optional, single>>
+  premios_menciones_y_distinciones : text <<optional, repeated>>
+  reconocimientos_ligados_a_su_concesion : text <<optional, single>>
+  .. +2 more attributes ..
+}
+
+class "ProduccionCientifica" as entity_research_produccioncientifica_060_010_000_000 <<entity>> {
+  fuente_de_indice_h : controlled_reference <<optional, single>>
+  fuente_de_indice_h_otros : text <<optional, single>>
+  indice_h_fecha_de_aplicacion : value_object<FlexibleDatesType> <<optional, single>>
+  indice_h_valor : decimal_number <<optional, single>>
+  produccion_cientifica : text <<optional, repeated>>
+}
+
+class "PublicacionesDocumentosCientificosYTecnicos" as entity_research_publicacionesdocumentoscientificosytecnicos_060_010_010_000 <<entity>> {
+  autor_de_correspondencia : boolean <<optional, single>>
+  autores_as_p_o_de_firma_nombre : text <<optional, repeated>>
+  categoria : controlled_reference <<optional, repeated>>
+  ciudad_de_publicacion : text <<optional, single>>
+  coleccion : text <<optional, single>>
+  fuente_de_citas : controlled_reference <<optional, repeated>>
+  fuente_de_citas_otros : text <<optional, repeated>>
+  fuente_del_dato : controlled_reference <<optional, single>>
+  .. +25 more attributes ..
+}
+
+class "PublicacionIndiceDeImpactoDeAnoDePublicacion" as entity_research_publicacionindicedeimpactodeanodepublicacion_060_010_010_240 <<entity>> {
+  categoria : controlled_reference <<optional, repeated>>
+  fuente_de_impacto : controlled_reference <<optional, repeated>>
+  fuente_de_impacto_otros : text <<optional, repeated>>
+  numero_de_revistas_en_la_categoria : decimal_number <<optional, repeated>>
+  posicion_que_ocupa_la_revista_en_la_categoria : decimal_number <<optional, repeated>>
+  publicacion_indice_de_impacto_de_ano_de_publicacion : text <<optional, repeated>>
+  revista_dentro_del_25_de_mayor_indice_de_impacto : boolean <<optional, repeated>>
+}
+
+class "PublicacionNombre" as entity_research_publicacionnombre060010020370_060_010_020_370 <<entity>> {
+  publicacion_nombre : text <<optional, single>>
+}
+
+class "PublicacionNombre" as entity_research_publicacionnombre060010030350_060_010_030_350 <<entity>> {
+  publicacion_nombre : text <<optional, single>>
+}
+
+class "PublicacionNombre" as entity_research_publicacionnombre060010040360_060_010_040_360 <<entity>> {
+  publicacion_nombre : text <<optional, single>>
+}
+
+class "PublicacionTipo" as entity_research_publicaciontipo060010030190_060_010_030_190 <<entity>> {
+  autor_de_correspondencia : boolean <<optional, single>>
+  identificador_de_publicacion_digital : text <<optional, repeated>>
+  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
+  publicacion_deposito_legal : text <<optional, single>>
+  publicacion_direccion_electronica : text <<optional, single>>
+  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
+  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
+  publicacion_isbn_issn : text <<optional, repeated>>
+  .. +8 more attributes ..
+}
+
+class "PublicacionTipo" as entity_research_publicaciontipo060010040200_060_010_040_200 <<entity>> {
+  autor_de_correspondencia : boolean <<optional, single>>
+  identificador_de_publicacion_digital : text <<optional, repeated>>
+  publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>>
+  publicacion_deposito_legal : text <<optional, single>>
+  publicacion_direccion_electronica : text <<optional, single>>
+  publicacion_editorial : value_object<EntityNameType> <<optional, single>>
+  publicacion_fecha : value_object<FlexibleDatesType> <<optional, single>>
+  publicacion_isbn_issn : text <<optional, repeated>>
+  .. +8 more attributes ..
+}
+
+class "RedesDeCooperacion" as entity_research_redesdecooperacion_060_030_040_000 <<entity>> {
+  ciudad_de_la_entidad_de_afiliacion : text <<optional, single>>
+  ciudad_de_radicacion : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_afiliacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_radicacion : controlled_reference <<optional, single>>
+  duracion : duration_like <<optional, single>>
+  entidad_es_participante_s : value_object<EntityNameType> <<optional, repeated>>
+  entidad_que_realizo_la_seleccion : value_object<EntityNameType> <<optional, single>>
+  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
+  .. +11 more attributes ..
+}
+
+class "ResumenDeOtrosMeritos" as entity_research_resumendeotrosmeritos_060_030_100_000 <<entity>> {
+  ciudad_de_la_entidad_que_acredita : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_que_acredita : controlled_reference <<optional, single>>
+  entidad_que_acredita : value_object<EntityNameType> <<optional, single>>
+  fecha_de_concesion : value_object<FlexibleDatesType> <<optional, single>>
+  pais_de_la_entidad_que_acredita : controlled_reference <<optional, single>>
+  resumen_de_otros_meritos : text <<optional, repeated>>
+  resumen_de_otros_meritos_en_texto_libre : text <<optional, single>>
+  tipo_de_entidad : value_object<EntityTypeType> <<optional, single>>
+  .. +1 more attributes ..
+}
+
+class "SociedadesCientificasYAsociacionesProfesionales" as entity_research_sociedadescientificasyasociacionesprofesionales_060_030_020_000 <<entity>> {
+  categoria_profesional : text <<optional, single>>
+  ciudad_de_la_entidad_de_afiliacion : text <<optional, single>>
+  ciudad_de_radicacion : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_de_afiliacion : controlled_reference <<optional, single>>
+  comunidad_autonoma_region_de_radicacion : controlled_reference <<optional, single>>
+  entidad_de_afiliacion : value_object<EntityNameType> <<optional, single>>
+  fecha_de_finalizacion : value_object<FlexibleDatesType> <<optional, single>>
+  fecha_de_inicio : value_object<FlexibleDatesType> <<optional, single>>
+  .. +8 more attributes ..
+}
+
+}
+
+@enduml

--- a/docs/diagrams/open_cvn_research_060_part_04.puml
+++ b/docs/diagrams/open_cvn_research_060_part_04.puml
@@ -1,0 +1,39 @@
+@startuml
+title Open CVN - CVN Research - Section 060 Part 4
+
+skinparam classAttributeIconSize 0
+hide circle
+
+package "CVN Research - Section 060 Part 4" as area_research_060_part_04 {
+class "Soporte" as entity_research_soporte_060_010_010_070 <<entity>> {
+  publicacion_nombre : text <<optional, single>>
+  soporte : controlled_reference <<optional, single>>
+}
+
+class "TrabajosPresentadosEnCongresosNacionalesOInternacionales" as entity_research_trabajospresentadosencongresosnacionalesointernacionales_060_010_020_000 <<entity>> {
+  autores_as_p_o_de_firma : text <<optional, repeated>>
+  ciudad_de_la_entidad_organizadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_organizadora : controlled_reference <<optional, single>>
+  forma_de_contribucion : controlled_reference <<optional, single>>
+  fuente_de_citas : controlled_reference <<optional, repeated>>
+  fuente_de_citas_otros : text <<optional, repeated>>
+  intervencion_por : controlled_reference <<optional, single>>
+  intervencion_por_otros : text <<optional, single>>
+  .. +11 more attributes ..
+}
+
+class "TrabajosPresentadosEnJornadasSeminariosTalleresDeTrabajoYOCursosNacionalesOInternacionales" as entity_research_trabajospresentadosenjornadasseminariostalleresdetrabajoyocursosnacionalesointernacionales_060_010_030_000 <<entity>> {
+  autores_as_p_o_de_firma : text <<optional, repeated>>
+  ciudad_de_la_entidad_organizadora : text <<optional, single>>
+  comunidad_autonoma_region_de_la_entidad_organizadora : controlled_reference <<optional, single>>
+  fuente_de_citas : controlled_reference <<optional, repeated>>
+  fuente_de_citas_otros : text <<optional, repeated>>
+  intervencion_por : controlled_reference <<optional, single>>
+  localizacion_nombre_del_evento : text <<optional, single>>
+  numero_de_citas : decimal_number <<optional, repeated>>
+  .. +8 more attributes ..
+}
+
+}
+
+@enduml

--- a/docs/diagrams/open_cvn_research_060_part_05_reference.puml
+++ b/docs/diagrams/open_cvn_research_060_part_05_reference.puml
@@ -22,19 +22,19 @@ controlled references:
 - CVN_CATEGORY_A (hierarchical_code_list, enum=ineligible, items=547)
 end note
 
-class "PublicacionNombre060010020370" as entity_research_publicacionnombre060010020370_060_010_020_370 <<entity>> {
+class "PublicacionNombre" as entity_research_publicacionnombre060010020370_060_010_020_370 <<entity>> {
   publicacion_nombre : text <<optional, single>> [CVN: 060.010.020.370]
 }
 
-class "PublicacionNombre060010030350" as entity_research_publicacionnombre060010030350_060_010_030_350 <<entity>> {
+class "PublicacionNombre" as entity_research_publicacionnombre060010030350_060_010_030_350 <<entity>> {
   publicacion_nombre : text <<optional, single>> [CVN: 060.010.030.350]
 }
 
-class "PublicacionNombre060010040360" as entity_research_publicacionnombre060010040360_060_010_040_360 <<entity>> {
+class "PublicacionNombre" as entity_research_publicacionnombre060010040360_060_010_040_360 <<entity>> {
   publicacion_nombre : text <<optional, single>> [CVN: 060.010.040.360]
 }
 
-class "PublicacionTipo060010030190" as entity_research_publicaciontipo060010030190_060_010_030_190 <<entity>> {
+class "PublicacionTipo" as entity_research_publicaciontipo060010030190_060_010_030_190 <<entity>> {
   autor_de_correspondencia : boolean <<optional, single>> [CVN: 060.010.030.390]
   identificador_de_publicacion_digital : text <<optional, repeated>> [CVN: 060.010.030.400]
   publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>> [CVN: 060.010.030.250]
@@ -60,7 +60,7 @@ controlled references:
 - ISO_3166 (code_list, enum=ineligible, items=312)
 end note
 
-class "PublicacionTipo060010040200" as entity_research_publicaciontipo060010040200_060_010_040_200 <<entity>> {
+class "PublicacionTipo" as entity_research_publicaciontipo060010040200_060_010_040_200 <<entity>> {
   autor_de_correspondencia : boolean <<optional, single>> [CVN: 060.010.040.390]
   identificador_de_publicacion_digital : text <<optional, repeated>> [CVN: 060.010.040.400]
   publicacion_comunidad_autonoma_region : controlled_reference <<optional, single>> [CVN: 060.010.040.260]

--- a/docs/pipeline/known_limitations.md
+++ b/docs/pipeline/known_limitations.md
@@ -5,6 +5,29 @@
 This document records known limitations of the current pipeline so later issues
 do not need to rediscover them.
 
+## Limitation Classification Matrix
+
+| Limitation | Category | Impact | Current Handling | Follow-Up Action | Blocker Status |
+| --- | --- | --- | --- | --- | --- |
+| `xs:choice` is not enforced as mutual exclusivity in generated structural bindings | `generated_binding_limitation` | Generated bindings can accept XML states invalid under the source XSD | Confined to structural interoperability; semantic/domain layers avoid treating generated bindings as the public Open CVN contract | Keep documentation and regression coverage; do not manually patch `src/generated/` | Accepted limitation, not MVP blocker |
+| Wrapper type evidence requires XSD-enriched normalization | `generated_binding_limitation` | Custom normalization callers without XSD paths cannot attach wrapper-aware field shapes | Canonical generation provides `CVN.xsd` and `Common.xsd`; no-XSD behavior remains supported | Document boundary and keep enriched/no-XSD regression tests | Accepted limitation, not MVP blocker |
+| Generated list defaults do not enforce every `minOccurs` cardinality | `generated_binding_limitation` | Structural object construction can accept empty lists where XSD expects values | Structural layer preserves generated behavior; Open CVN runtime models define the public JSON contract | Keep semantic cardinality policy outside generated bindings | Accepted limitation, not MVP blocker |
+| Some generated attributes are typed as `object` | `generated_binding_limitation` | Weaker structural validation and poorer ergonomics | Avoid leaking weak generated types into Open CVN public models | Confirm boundary during issue `#71` | Accepted limitation, not MVP blocker |
+| XML helper wrapper types are less ergonomic than primitives | `generated_binding_limitation` | Structural XML fidelity is usable but delicate for direct application code | Domain-facing wrapper components exist for canonical generation | Keep wrapper guidance and avoid direct generated-wrapper UX promises | Accepted limitation, not MVP blocker |
+| `tree_model` requires `--unnest-classes` xsdata override | `generated_binding_limitation` | Structural generation is reproducible but target-specific | Documented runner behavior | Keep workflow documentation aligned | Accepted limitation, not MVP blocker |
+| JSON Schema cannot express every CVN semantic rule | `runtime_validation_gap` | Schema-valid JSON can still miss curated semantic expectations | JSON Schema runs before Pydantic runtime validation; trace annotations preserve evidence | Evaluate conservative semantic warnings in issue `#71` | Not blocker if warnings remain clear |
+| CVN XML import is semantic partial for recognized CVN items | `runtime_validation_gap` | XML import is not a complete official CVN XML-to-Open-CVN converter | Diagnostics preserve mapped/unmapped counts, trace, and fallback `other` entries | Improve documentation and add metrics only where useful | Accepted MVP constraint, not blocker |
+| JSON Schema validation runs before runtime model validation | `documentation_gap` | Users may see schema errors before Pydantic errors for the same payload | Structured parser errors expose layer-specific codes | Document validation order clearly | Accepted UX limitation, not blocker |
+| LLM-assisted PDF import is best-effort and provider-dependent | `runtime_validation_gap` | Schema-valid LLM output may be incomplete or factually wrong | External LLM use is opt-in, locally validated, and records provenance | Strengthen documentation and provenance if needed | Accepted MVP constraint, not blocker |
+| Conceptual relationships require curation | `future_research` | Generated metadata cannot prove a full CVN ontology | Conceptual extraction emits conservative relationships only | Add curated rules only with stronger evidence | Not blocker |
+| Domain-area diagrams can be verbose | `documentation_gap` | Large diagrams are difficult to use in slides or compact review contexts | Readable/reference split exists; PNGs are derived review artifacts | Use PNG audit from issue `#71` to add presentation views and split large readable diagrams | Not blocker |
+| `CVNTreeModel.xml` diverges from `CVNTreeModel_v1.0.xsd` | `source_package_limitation` | Generated tree-model binding cannot fully parse canonical XML through the XSD alone | Normalization treats XML as source evidence and records mismatch | Preserve explicit documentation; do not hide mismatch | External constraint, not project bug |
+| Auxiliary catalog families preserve historical packaging drift | `source_package_limitation` | Automated resolution cannot rely on filenames or schema locations alone | Repository-aware path mapping and auxiliary documentation | Keep links to source-package docs | External constraint, not project bug |
+| `CVN_AGENCY_C` remains unresolved from the source package alone | `source_package_limitation` | Cannot promote this reference to a strict resolved enum/catalog from current evidence | Preserved as unresolved/manual-only reference | Revisit only if stronger official evidence appears | External constraint, not project bug |
+| `Subtype_Spa.xml` lacks a direct table-family bridge | `source_package_limitation` | Subtype-backed families cannot be strictly bridged per table family | Classify as subtype-backed but enum-ineligible | Revisit only if reliable bridge evidence appears | External constraint, not project bug |
+| Strict enum eligibility is evidence-backed but conservative | `future_research` | Some compact tables remain review-required instead of strict enums | Dynamic evidence controls eligibility; weak cases stay open | Add versioned overrides only with curated evidence | Not blocker |
+| PDF generation depends on a TeX engine | `runtime_validation_gap` | A Python-only install cannot compile PDFs unless a usable engine is available | Current implementation discovers local `latexmk` or `pdflatex` | Issue `#71` should add managed Tectonic discovery/cache/download where practical, plus `pdf doctor` | Actionable hardening item |
+
 ## Structural Binding Limitations
 
 ### `xs:choice` Is Not Enforced As Mutual Exclusivity
@@ -164,6 +187,23 @@ do not need to rediscover them.
   - later validator UX work may add grouped multi-layer diagnostics if users need
     schema and runtime errors in the same result
 
+### Open CVN Semantic Validation Is Warning-Oriented
+
+- Confirmed behavior:
+  - issue `#71` adds conservative semantic warnings after generated JSON Schema
+    validation and Pydantic runtime validation pass
+  - current checks warn about entry `type` prefixes that do not match their
+    curriculum section, trace values that do not look like CVN codes, and
+    controlled-reference-like objects that carry provenance without `code`,
+    `label`, `raw_value`, or `uri`
+- Impact:
+  - accepted documents can return `valid_with_warnings` when they are structurally
+    valid but semantically suspicious
+  - unusual but valid future data is not rejected by these checks
+- Expected follow-up:
+  - promote a warning to a hard failure only if the rule becomes part of the
+    documented public Open CVN contract
+
 ### LLM-Assisted PDF Import Is Best-Effort And Provider-Dependent
 
 - Confirmed behavior:
@@ -185,6 +225,23 @@ do not need to rediscover them.
     are available
   - future work may add richer confidence/provenance fields or human review flows
     before treating LLM-assisted data as authoritative
+
+### PDF Generation Uses Managed Tectonic When Available
+
+- Confirmed behavior:
+  - issue `#71` adds managed Tectonic discovery before system TeX engines
+  - compiler discovery order is managed `tectonic`, system `tectonic`, `latexmk`,
+    then `pdflatex`
+  - the managed executable is cached under the Open CVN cache directory and can be
+    diagnosed with `open-cvn pdf doctor`
+- Impact:
+  - typical Python application use no longer depends exclusively on a separately
+    installed TeX distribution
+  - first-use managed download still requires platform support and network access;
+    offline environments need a cached managed executable or a system TeX engine
+- Expected follow-up:
+  - keep download URLs, version pins, and checksums current when upgrading the
+    managed Tectonic version
 
 ## Conceptual Extraction Limitations
 
@@ -292,6 +349,9 @@ do not need to rediscover them.
   - issue `#14` defines semantic policy for side-package references
   - issue `#15` should decide which of these auxiliary artifacts become domain
     sources versus support registries
+  - issue `#71` classifies this as an external source-package constraint and
+    links readers to `docs/cvn_source_package_auxiliary_artifacts.md` for the
+    preserved package layout and drift details
 
 ### Some Annex-I Table References Remain Unresolved From The Package Alone
 
@@ -305,6 +365,9 @@ do not need to rediscover them.
   - issue `#14` defines open versus closed treatment for unresolved tables
   - issue `#15` should preserve such cases as explicit external or manual-only
     references unless stronger evidence is introduced
+  - issue `#71` keeps this as a `source_package_limitation`; tooling must not hide
+    it behind a lossy conversion or promote it to a strict enum without stronger
+    official evidence
 
 ### `Subtype_Spa.xml` Does Not Provide A Direct Table-Family Bridge
 
@@ -322,6 +385,9 @@ do not need to rediscover them.
     bridge evidence exists
   - later maintenance work may add a stricter bridge only if reliable evidence
     is introduced from the preserved source package
+  - issue `#71` records this as an evidence limitation, not an implementation
+    oversight, because the preserved subtype XML is not keyed by table-family
+    names
 
 ### Strict Enum Eligibility Is Evidence-Backed But Conservative
 

--- a/docs/pipeline/open_cvn_json_format.md
+++ b/docs/pipeline/open_cvn_json_format.md
@@ -27,6 +27,12 @@ The conceptual inventory remains the semantic source of truth for:
 The generated JSON Schema remains the validation artifact. It must reflect this
 format before issue `#49` relies on it for Open CVN JSON import.
 
+The structural packages under `src/generated/` are not the source of truth for
+this public JSON contract. They remain an interoperability layer for official CVN
+XML/XSD artifacts. Weaknesses inherited from structural generation, such as loose
+`xs:choice` handling or generated `object` attributes, must not be interpreted as
+permission to weaken the Open CVN JSON root shape.
+
 ## Root Object
 
 Every Open CVN JSON document is an object with these canonical root fields:

--- a/docs/roadmap/cvn_generation_roadmap.md
+++ b/docs/roadmap/cvn_generation_roadmap.md
@@ -56,6 +56,7 @@ Goal:
 | `#68` | Application MVP tests and documentation | Completed | End-to-end MVP workflow tests, application user guide, verification, and epic `#60` closure completed |
 | `#69` | LLM-assisted PDF import fallback | Completed | Deterministic-first PDF import, explicit external-LLM opt-in, OpenAI Responses provider adapter, local validation, CLI storage, mocked tests, and workflow docs implemented |
 | `#70` | Semantic CVN XML import to Open CVN JSON | Completed | Runtime schema-backed CVN code mapping, semantic partial XML import, deterministic PDF XML handoff before LLM fallback, synthetic fixtures, tests, and documentation implemented |
+| `#71` | Limitations hardening and documentation | Completed | Limitation classification, semantic warnings, XML coverage diagnostics, managed Tectonic PDF engine, PDF doctor, LLM provenance, diagram usability hardening, and full-suite verification completed |
 
 Corrective planning after hotfixes `#4`, `#5`, and `#6`:
 
@@ -523,3 +524,5 @@ Authoritative records:
 - `docs/roadmap/issues/issue-67-pdf-generation-and-preview-handoff.md`
 - `docs/roadmap/issues/issue-68-application-mvp-tests-and-documentation.md`
 - `docs/roadmap/issues/issue-69-llm-assisted-import-spike.md`
+- `docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md`
+- `docs/roadmap/issues/issue-71-limitations-hardening-and-documentation.md`

--- a/docs/roadmap/issues/issue-71-limitations-hardening-and-documentation.md
+++ b/docs/roadmap/issues/issue-71-limitations-hardening-and-documentation.md
@@ -143,169 +143,260 @@ Use these categories throughout this issue:
 
 ## Execution Plan
 
-### Task 1 - Scope And Baseline Audit
+This plan is executed with explicit progress markers. Every work update should
+state the current `Task N/Subtask N.M`, summarize the subtask before doing it,
+and end by saying whether the user needs to modify any file plus the next step.
+Code changes should normally be left for the user unless the user explicitly
+asks the agent to implement them.
 
-- Subtask 1.1: read `docs/pipeline/known_limitations.md` and list each limitation
-  with one classification category.
-- Subtask 1.2: read `docs/context/current_status.md` and confirm no limitation is
-  missing from the current-status blocking limitations section.
-- Subtask 1.3: read `docs/roadmap/cvn_generation_roadmap.md` and confirm issue
-  `#71` should be represented as follow-up work after issue `#70`.
-- Subtask 1.4: confirm `docs/memoria/` remains out of scope.
-- Subtask 1.5: record baseline git status before edits, preserving unrelated
-  untracked or user-owned files.
+### Task 1 - Scope, Baseline, And Work Ownership
 
-Expected output: confirmed limitation inventory and issue boundary.
+Summary: confirm issue boundaries, preserve user-owned files, and keep the
+implementation workflow explicit.
 
-### Task 2 - Build A Limitation Classification Matrix
+- Subtask 1.1: read `git status --short` before edits and record unrelated
+  changed files as user-owned. Current known baseline includes modified
+  `initial_prompt.md`, which must not be reverted or changed by this issue.
+- Subtask 1.2: confirm `docs/memoria/` remains out of scope.
+- Subtask 1.3: confirm `src/generated/` remains out of scope for manual edits.
+- Subtask 1.4: record that documentation changes may be done by the agent, while
+  code changes should be performed by the user unless explicitly delegated.
 
-- Subtask 2.1: add a classification matrix to `docs/pipeline/known_limitations.md`.
-- Subtask 2.2: include columns for limitation, category, impact, current handling,
-  follow-up action, and blocker status.
-- Subtask 2.3: mark official source-package inconsistencies as non-project bugs.
-- Subtask 2.4: mark generated binding limitations as confined to the structural
-  interoperability layer when Open CVN runtime models avoid leaking the weakness.
-- Subtask 2.5: mark runtime validation gaps that should be addressed in later tasks
-  of this issue.
+Expected output: safe baseline and clear ownership of code edits.
 
-Expected output: future readers can understand what is blocked, accepted, or
-actionable without reading every issue record.
+### Task 2 - Limitation Inventory And Classification Matrix
 
-### Task 3 - Document Official Source Package Constraints
+Summary: make all current limitations defensible through one auditable matrix.
 
-- Subtask 3.1: expand the `CVNTreeModel.xml` mismatch explanation if needed.
-- Subtask 3.2: ensure `CVN_AGENCY_C` is documented as unresolved from the source
-  package alone.
-- Subtask 3.3: ensure `Subtype_Spa.xml` bridge limitations are documented as an
-  evidence problem, not an implementation oversight.
-- Subtask 3.4: ensure auxiliary packaging drift is linked from the limitation
-  register to the auxiliary artifact documentation.
+- Subtask 2.1: read `docs/pipeline/known_limitations.md` and list each current
+  limitation.
+- Subtask 2.2: add a classification matrix to `docs/pipeline/known_limitations.md`
+  with columns for limitation, category, impact, current handling, follow-up
+  action, and blocker status.
+- Subtask 2.3: classify official CVN source-package inconsistencies as
+  `source_package_limitation`, not project bugs.
+- Subtask 2.4: classify generated binding weaknesses as
+  `generated_binding_limitation` confined to the structural interoperability
+  layer when the Open CVN runtime contract avoids leaking them.
+- Subtask 2.5: classify Open CVN checks, XML diagnostics, PDF generation, LLM
+  provenance, and diagram usability as `runtime_validation_gap` or
+  `documentation_gap` according to the final implementation.
+
+Expected output: future readers can distinguish blockers, accepted MVP limits,
+and actionable hardening items.
+
+### Task 3 - Official Source Package Constraints
+
+Summary: document source-package problems as external constraints with trace.
+
+- Subtask 3.1: expand or confirm the `CVNTreeModel.xml` versus
+  `CVNTreeModel_v1.0.xsd` mismatch explanation.
+- Subtask 3.2: confirm `CVN_AGENCY_C` remains unresolved from the preserved
+  source package alone.
+- Subtask 3.3: confirm `Subtype_Spa.xml` proves subtype catalog availability but
+  does not provide a direct bridge from table-family names such as `CVN_KNOW_A`.
+- Subtask 3.4: link auxiliary packaging drift from the limitation register to the
+  auxiliary artifact documentation.
 
 Expected output: source-package limitations are auditable and defensible.
 
-### Task 4 - Confirm Generated Binding Weaknesses Are Confined
+### Task 4 - Generated Binding Boundary Review
 
-- Subtask 4.1: inspect current Open CVN runtime models and generated domain
-  components to verify weak structural types do not define the public JSON root.
-- Subtask 4.2: add documentation explaining that `src/generated/` remains an
-  interoperability layer, not the final Open CVN contract.
+Summary: keep structural fidelity separate from the public Open CVN contract.
+
+- Subtask 4.1: inspect Open CVN runtime models and generated domain components to
+  verify weak structural types do not define the public JSON root.
+- Subtask 4.2: document that `src/generated/` remains an interoperability layer,
+  not the final Open CVN contract.
 - Subtask 4.3: add tests only if inspection finds a public Open CVN model accepting
-  an invalid wrapper or malformed value that should be rejected.
+  an invalid wrapper or malformed value that should already be rejected.
 - Subtask 4.4: do not edit generated files manually.
 
-Expected output: clear boundary between structural fidelity and Open CVN runtime
-contract.
+Expected output: clear boundary between generated structural bindings and runtime
+Open CVN validation.
 
-### Task 5 - Evaluate Minimal Runtime Semantic Validation
+### Task 5 - Minimal Runtime Semantic Validation Decision
+
+Summary: add only conservative semantic warnings if they reduce risk without
+rejecting valid unusual documents.
 
 - Subtask 5.1: decide whether a small `src/open_cvn/semantic_validation.py` module
   is justified.
-- Subtask 5.2: if implemented, validate only conservative rules:
-  - section-compatible entry `type` prefixes
-  - plausible CVN trace code format
-  - controlled references carrying at least `code`, `label`, or `raw_value`
-  - supported `schema_version` major version
-- Subtask 5.3: return warnings rather than hard failures unless a rule is already
-  part of the public Open CVN contract.
-- Subtask 5.4: add focused tests in `tests/test_open_cvn_semantic_validation_unit.py`
-  if a new module is created.
+- Subtask 5.2: if implemented by the user, validate only conservative warning
+  rules: section-compatible entry `type` prefixes, plausible CVN trace code
+  format, and controlled references carrying at least `code`, `label`, or
+  `raw_value`.
+- Subtask 5.3: keep these checks as warnings unless a rule is already part of the
+  public Open CVN contract.
+- Subtask 5.4: if implemented, add focused tests in
+  `tests/test_open_cvn_semantic_validation_unit.py` and regression coverage in
+  `tests/test_open_cvn_json_import_unit.py`.
 - Subtask 5.5: document the difference between JSON Schema validation, Pydantic
-  validation, and Open CVN semantic validation.
+  validation, and optional Open CVN semantic warnings.
 
 Expected output: either a documented decision not to add runtime semantic
-validation yet, or a small tested validation layer.
+validation yet, or a small tested warning layer.
 
-### Task 6 - Improve XML Semantic Partial Import Diagnostics
+### Task 6 - XML Semantic Partial Import Diagnostics
 
-- Subtask 6.1: inspect `src/open_cvn/xml_semantic_import.py` diagnostics for
-  counts of items and fields seen, mapped, and unmapped.
-- Subtask 6.2: add missing counters only if current diagnostics are incomplete.
-- Subtask 6.3: add synthetic fixtures only for non-personal XML scenarios that
-  increase section coverage or unmapped preservation confidence.
-- Subtask 6.4: update parser workflow documentation so `semantic_partial` is
-  described as expected MVP behavior.
+Summary: make semantic partial XML import measurable rather than vague.
 
-Expected output: XML import limitations are measurable rather than vague.
+- Subtask 6.1: inspect `src/open_cvn/xml_semantic_import.py` diagnostics. Current
+  known diagnostics already include `items_seen`, `items_mapped`,
+  `items_unmapped`, `fields_seen`, `fields_mapped`, `fields_unmapped`, and
+  `unmapped_codes`.
+- Subtask 6.2: if implemented by the user, add only missing high-value metrics
+  such as `mapped_sections`, `section_counts`, or mapping coverage percentages.
+- Subtask 6.3: add synthetic non-personal XML fixtures only if they increase
+  section coverage or unmapped preservation confidence.
+- Subtask 6.4: update `docs/development/parser_workflow.md` so
+  `semantic_partial` and `trace_only` are described as expected MVP diagnostics,
+  not proof of complete CVN conversion.
 
-### Task 7 - Improve PDF Generation Diagnostics
+Expected output: XML import limitations are measurable and documented.
 
-- Subtask 7.1: review current missing-compiler behavior in `src/open_cvn_app/pdf.py`.
-- Subtask 7.2: update `docs/development/pdf_generation_workflow.md` with install
-  guidance for supported TeX engines.
-- Subtask 7.3: decide whether to add a CLI diagnostic command such as
-  `open-cvn pdf doctor`.
-- Subtask 7.4: if a diagnostic command is added, cover available and missing
-  compiler cases with mocked tests.
-- Subtask 7.5: keep automated tests independent from a real local TeX installation.
+### Task 7 - Python-Managed TeX Engine For PDF Generation
 
-Expected output: PDF generation dependency failures are explicit and user-actionable.
+Summary: make PDF generation work from Python-managed requirements where feasible,
+without relying only on a system TeX install.
 
-### Task 8 - Improve LLM Import Limitation And Provenance Handling
+- Subtask 7.1: document the dependency research result: PyPI packages such as
+  `PyLaTeX`, `latex`, `latex2pdf`, and PyPI `tinytex` do not provide a reliable
+  LaTeX engine; the real `tectonic` project ships a single executable rather than
+  a usable PyPI engine package.
+- Subtask 7.2: update the intended compiler discovery order to prefer a managed
+  `tectonic` executable, then system `tectonic`, then `latexmk`, then `pdflatex`.
+- Subtask 7.3: if implemented by the user, add a managed Tectonic binary download
+  and cache layer, with platform detection, version pinning, hash verification
+  when practical, and a cache path such as `~/.cache/open-cvn/tectonic/`.
+- Subtask 7.4: preserve offline behavior: if no cached managed engine and no
+  system engine exists, fail with an actionable diagnostic rather than silently
+  skipping PDF generation.
+- Subtask 7.5: keep automated tests independent from a real local TeX install and
+  from real network access by mocking downloader, cache, compiler lookup, and
+  runner behavior.
+- Subtask 7.6: update `docs/development/pdf_generation_workflow.md` to explain
+  managed Tectonic, cache behavior, offline behavior, system fallback, and
+  remaining limitations.
 
-- Subtask 8.1: review LLM provenance stored under
+Expected output: PDF generation no longer depends exclusively on a separately
+installed system TeX distribution when the managed Tectonic path is available.
+
+### Task 8 - PDF Doctor Command
+
+Summary: give users one command to diagnose local PDF generation readiness.
+
+- Subtask 8.1: if implemented by the user, add `open-cvn pdf doctor` to inspect
+  managed Tectonic cache availability, system `tectonic`, `latexmk`, `pdflatex`,
+  cache path, and recommended next action.
+- Subtask 8.2: ensure `pdf doctor` does not compile a real document by default.
+- Subtask 8.3: add mocked CLI and PDF unit tests for available engine, missing
+  engine, cached managed engine, and unavailable managed download scenarios.
+- Subtask 8.4: document `pdf doctor` in `docs/development/pdf_generation_workflow.md`.
+
+Expected output: PDF generation dependency failures become user-actionable before
+running a full export.
+
+### Task 9 - LLM Import Limitation And Provenance Handling
+
+Summary: keep LLM import visibly non-authoritative and review-required.
+
+- Subtask 9.1: review provenance stored under
   `extensions["x-open-cvn.llm_import"]`.
-- Subtask 8.2: document that schema-valid LLM output is not proof of factual
+- Subtask 9.2: document that schema-valid LLM output is not proof of factual
   completeness or correctness.
-- Subtask 8.3: add warning/provenance fields only if current results do not make
-  LLM origin visible enough to downstream users.
-- Subtask 8.4: preserve the current explicit opt-in requirement through
+- Subtask 9.3: if implemented by the user, add explicit provenance fields such as
+  `review_required: true` and `authoritative: false` only if current provenance is
+  not visible enough to downstream users.
+- Subtask 9.4: preserve the explicit opt-in requirement through
   `--allow-external-llm`.
-- Subtask 8.5: keep provider calls mocked in automated tests.
+- Subtask 9.5: keep provider calls mocked in automated tests.
 
-Expected output: LLM import remains privacy-conscious, opt-in, validated, and
-clearly non-authoritative.
+Expected output: LLM import remains privacy-conscious, opt-in, locally validated,
+and clearly non-authoritative.
 
-### Task 9 - Add Presentation-Friendly Diagram Guidance
+### Task 10 - Diagram PNG Audit And Generator Improvements
 
-- Subtask 9.1: document the difference between reference diagrams and presentation
-  diagrams in `docs/diagrams/README.md` if not already clear.
-- Subtask 9.2: decide whether to create a small curated diagram set under
-  `docs/diagrams/presentation/`.
-- Subtask 9.3: if curated diagrams are added, keep canonical generated diagrams
-  unchanged and document curated diagrams as human-facing views.
+Summary: use the existing rendered PNGs to identify concrete diagram usability
+problems, then improve generated diagrams without manual diagram edits.
 
-Expected output: diagram verbosity is managed without losing canonical traceability.
+- Subtask 10.1: audit existing `docs/diagrams/*.png` dimensions. Current observed
+  high-risk renders include `open_cvn_research_060.png` at `3660 x 1571`,
+  `open_cvn_other_040.png` at `3062 x 1065`, `open_cvn_education_030.png` at
+  `3033 x 1318`, and tall reference chunks such as
+  `open_cvn_research_050_part_02_reference.png` at `1678 x 2269`.
+- Subtask 10.2: classify diagram size and readability as `documentation_gap`, not
+  a pipeline correctness bug.
+- Subtask 10.3: if implemented by the user, modify
+  `src/cvn_codegen/conceptual_model_diagrams.py` so large readable views are split
+  as well as large reference views. Priority split targets are `research_060`,
+  `other_040`, and `education_030`.
+- Subtask 10.4: if implemented by the user, add presentation-friendly generated
+  diagrams such as `open_cvn_presentation_overview.puml` and a compact import or
+  workflow view. These should contain few boxes, no attributes, and be suitable
+  for TFG slides or memory figures.
+- Subtask 10.5: if implemented by the user, improve rendered labels for fallback
+  names such as `PublicacionNombre030090000330` by using a shorter human label and
+  preserving the CVN code in attributes or notes, while keeping PlantUML aliases
+  deterministic.
+- Subtask 10.6: keep `.puml` files as canonical generated artifacts and treat PNGs
+  as derived review artifacts.
+- Subtask 10.7: update `docs/diagrams/README.md` with the three diagram tiers:
+  readable, reference, and presentation.
 
-### Task 10 - Update Entry Points And Roadmap
+Expected output: diagram output remains traceable, while large PNGs become easier
+to inspect and presentation use gets a compact generated option.
 
-- Subtask 10.1: update `docs/context/current_status.md` with issue `#71` as the
-  current follow-up issue.
-- Subtask 10.2: update `docs/roadmap/cvn_generation_roadmap.md` with issue `#71`
+### Task 11 - Entry Points, Roadmap, And Persistent Docs
+
+Summary: make issue `#71` discoverable from future sessions.
+
+- Subtask 11.1: update `docs/context/current_status.md` with issue `#71` as the
+  current or completed follow-up issue.
+- Subtask 11.2: update `docs/roadmap/cvn_generation_roadmap.md` with issue `#71`
   status and scope.
-- Subtask 10.3: update `PROJECT_GUIDE.md` if the project orientation or document
-  map changes.
-- Subtask 10.4: update `docs/context/project_context_index.md` if the issue map
-  changes.
-- Subtask 10.5: update `AGENTS.md` only if operational rules or map entries change.
+- Subtask 11.3: update `docs/context/project_context_index.md` so issue `#71` is
+  listed in the roadmap map.
+- Subtask 11.4: update `PROJECT_GUIDE.md` only if human-facing orientation or the
+  document map changes.
+- Subtask 11.5: update `AGENTS.md` only if operational rules or map entries
+  change.
 
-Expected output: future sessions can discover issue `#71` and its purpose.
+Expected output: future sessions can discover issue `#71`, its purpose, and its
+status.
 
-### Task 11 - Targeted Verification
+### Task 12 - Targeted Verification
 
-- Subtask 11.1: run targeted tests for any runtime code changed in this issue.
-- Subtask 11.2: if XML import diagnostics changed, run:
+Summary: run only verification relevant to touched areas before the full suite.
+
+- Subtask 12.1: if semantic validation changed, run
+  `uv run pytest -n auto tests/test_open_cvn_semantic_validation_unit.py tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`.
+- Subtask 12.2: if XML diagnostics changed, run
   `uv run pytest -n auto tests/test_xml_semantic_import_unit.py tests/test_cvn_xml_import_unit.py -v`.
-- Subtask 11.3: if JSON semantic validation changed, run:
-  `uv run pytest -n auto tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py -v`.
-- Subtask 11.4: if PDF diagnostics changed, run:
+- Subtask 12.3: if PDF engine or doctor behavior changed, run
   `uv run pytest -n auto tests/test_open_cvn_app_pdf_unit.py tests/test_open_cvn_app_cli_unit.py -v`.
-- Subtask 11.5: if LLM provenance changed, run:
+- Subtask 12.4: if LLM provenance changed, run
   `uv run pytest -n auto tests/test_llm_import_unit.py tests/test_llm_providers_unit.py -v`.
+- Subtask 12.5: if diagrams changed, run
+  `uv run pytest -n auto tests/test_conceptual_model_diagrams_unit.py tests/test_generation_pipeline_conceptual_diagrams.py -v`.
 
-Expected output: targeted tests pass for all touched runtime paths.
+Expected output: targeted tests pass for all touched runtime or generation paths.
 
-### Task 12 - Full Verification And Closure
+### Task 13 - Full Verification And Closure
 
-- Subtask 12.1: run `uv run pytest -n auto tests`.
-- Subtask 12.2: record the exact result in this issue document.
-- Subtask 12.3: record implementation notes and deviations in this issue document.
-- Subtask 12.4: update `docs/context/current_status.md` with the final issue `#71`
+Summary: close issue `#71` only after docs, any user-made code changes, and tests
+are aligned.
+
+- Subtask 13.1: run `uv run pytest -n auto tests`.
+- Subtask 13.2: record the exact result in this issue document.
+- Subtask 13.3: record implementation notes and deviations in this issue document.
+- Subtask 13.4: update `docs/context/current_status.md` with the final issue `#71`
   result.
-- Subtask 12.5: mark this issue completed only after documentation and verification
-  are both aligned.
+- Subtask 13.5: mark this issue completed only after documentation and
+  verification are both aligned.
 
-Expected output: issue `#71` closes with documented limitations, any implemented
-hardening, and verification evidence.
+Expected output: issue `#71` closes with classified limitations, selected
+hardening, PDF engine strategy, diagram PNG audit, and verification evidence.
 
 ## Acceptance Criteria
 
@@ -350,4 +441,52 @@ hardening, and verification evidence.
 
 ## Status
 
-- Status: planned
+- Status: completed
+- Completed on: 2026-07-18
+
+## Implementation Notes
+
+- Added a classified limitation matrix to `docs/pipeline/known_limitations.md`
+  covering official source-package constraints, generated binding limits,
+  runtime validation gaps, documentation gaps, and future-research items.
+- Documented official-source constraints as external limitations, including the
+  `CVNTreeModel.xml`/`CVNTreeModel_v1.0.xsd` mismatch, unresolved
+  `CVN_AGENCY_C`, subtype-family bridging limits, and auxiliary packaging drift.
+- Documented the boundary between `src/generated/` structural interoperability
+  bindings and the public Open CVN JSON runtime contract.
+- Implemented conservative Open CVN semantic warnings after JSON Schema and
+  Pydantic validation for section/type consistency, plausible CVN trace codes,
+  and empty controlled-reference values.
+- Extended semantic partial CVN XML import diagnostics with mapping coverage,
+  mapped sections, and section counts.
+- Added managed Tectonic support for PDF generation with cache discovery,
+  optional download, hash verification, system fallback, and `open-cvn pdf
+  doctor` diagnostics.
+- Marked LLM-assisted imports explicitly as `review_required: true` and
+  `authoritative: false` in provenance metadata.
+- Improved conceptual diagram generation with split readable views, a compact
+  presentation overview diagram, deterministic label cleanup, and updated diagram
+  tier documentation.
+
+## Deviations From Original Plan
+
+- Runtime code changes were implemented by the agent after the user authorized
+  end-to-end implementation. The original issue text said code changes should
+  normally be left to the user unless explicitly delegated.
+- PDF generation hardening went beyond documentation by adding a managed Tectonic
+  binary strategy. It still preserves offline failure behavior and does not make
+  PDF generation mandatory when no compiler is available.
+- Diagram hardening changed the generator and regenerated canonical `.puml`
+  artifacts; PNG files remain derived review artifacts and were not treated as
+  canonical sources.
+- `src/generated/` was not manually edited.
+- `docs/memoria/` was not modified.
+
+## Verification
+
+- Targeted semantic validation, XML diagnostics, PDF, CLI, LLM, and diagram
+  verification passed with:
+  `uv run pytest -n auto tests/test_open_cvn_semantic_validation_unit.py tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py tests/test_xml_semantic_import_unit.py tests/test_cvn_xml_import_unit.py tests/test_open_cvn_app_pdf_unit.py tests/test_open_cvn_app_cli_unit.py tests/test_llm_import_unit.py tests/test_llm_providers_unit.py tests/test_conceptual_model_diagrams_unit.py tests/test_generation_pipeline_conceptual_diagrams.py -v`
+- Targeted verification result: `108 passed in 69.88s (0:01:09)`
+- Full-suite verification passed with: `uv run pytest -n auto tests`
+- Full-suite verification result: `488 passed in 845.43s (0:14:05)`

--- a/initial_prompt.md
+++ b/initial_prompt.md
@@ -1,9 +1,8 @@
-/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 70. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
+/caveman Lee @README.md @PROJECT_GUIDE.md @AGENTS.md y @docs/roadmap/issues/issue-71-limitations-hardening-and-documentation.md y Crea un plan detallado con Todas las task necesarias para poder completar el objetivo y el desarrollo del issue 71. Primero unicamente debes de crear el plan de ejecución. Investiga en internet en cualquer punto de la sesion cualquier informacion que necesites sobre esto
 
 
 
-Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-70-semantic-cvn-xml-import-to-open-cvn-json.md
-
+Acepto el plan. Para cada paso debes de marcar en que task estamos. En caso de que se desarrollen unas subtask tambien debes denotar en que subtask estamos dentro de dada task. Para cada paso debes de indicar si Al principio un resumen de que va a ser cada task/subtask, y al final indicar si es necesari que yo modifique algun fichero y finalemnte el siguiente paso a seguir. En el caso en el que se tenga que modificar ficheros (salbo que te indique lo contrario) lo hare yo, sobre todo para el codigo. Una vez que acepte el paln deberas de establecerlo en @docs/roadmap/issues/issue-71-limitations-hardening-and-documentation.md
 
 
 comienza con el plan, haz tu todo lo que puedas sin necesitar mi intervencion, cuando la necesites notificame. No hagas cosas para las que no tengas toda la informacion

--- a/src/cvn_codegen/conceptual_model_diagrams.py
+++ b/src/cvn_codegen/conceptual_model_diagrams.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -28,7 +29,10 @@ LARGE_AREA_ATTRIBUTE_THRESHOLD = 80
 LARGE_REFERENCE_VOCABULARY_PAIR_THRESHOLD = 12
 LARGE_REFERENCE_SECTION_ENTITY_THRESHOLD = 6
 LARGE_REFERENCE_SECTION_ATTRIBUTE_THRESHOLD = 120
+LARGE_READABLE_SECTION_ENTITY_THRESHOLD = 12
+LARGE_READABLE_SECTION_ATTRIBUTE_THRESHOLD = 160
 OVERVIEW_SAMPLE_LIMIT = 3
+CODE_SUFFIX_PATTERN = re.compile(r"^(?P<label>.*?)(?P<code>\d{12})$")
 DEPENDENCY_COLORS = (
     "#1f77b4",
     "#ff7f0e",
@@ -64,7 +68,7 @@ def render_conceptual_model_diagrams(
     inventory: ConceptualModelInventory,
 ) -> tuple[DiagramArtifact, ...]:
     """Render readable and reference PlantUML diagrams from a conceptual inventory."""
-    artifacts = [render_overview_diagram(inventory)]
+    artifacts = [render_overview_diagram(inventory), render_presentation_overview_diagram(inventory)]
     for area in sorted(inventory.domain_areas, key=lambda item: item.area_id):
         artifacts.extend(render_readable_area_diagrams(inventory, area))
     artifacts.append(render_reference_overview_diagram(inventory))
@@ -130,6 +134,60 @@ def render_overview_diagram(inventory: ConceptualModelInventory) -> DiagramArtif
     )
 
 
+def render_presentation_overview_diagram(inventory: ConceptualModelInventory) -> DiagramArtifact:
+    """Render compact presentation-oriented overview without attributes."""
+    lines = build_header("Open CVN Presentation Overview")
+    lines.extend(
+        [
+            "skinparam classAttributeIconSize 0",
+            "top to bottom direction",
+            "hide empty members",
+            "",
+            'package "Open CVN Runtime Shape" as presentation_root {',
+            'class "Open CVN Document" as presentation_document <<document>>',
+            'class "Metadata" as presentation_metadata <<metadata>>',
+            'class "Curriculum" as presentation_curriculum <<curriculum>>',
+            'class "Extensions" as presentation_extensions <<extensions>>',
+            "}",
+            "",
+            'package "Curriculum Areas" as presentation_areas {',
+        ]
+    )
+    for area in sorted(inventory.domain_areas, key=lambda item: item.area_id):
+        if area.area_id == "core":
+            continue
+        lines.append(
+            f'class "{escape_text(area.name)}" as presentation_area_{normalize_alias(area.area_id)} <<area>> {{'
+        )
+        lines.append(f"  entities : {len(area.entities)}")
+        lines.append("}")
+    lines.extend(
+        [
+            "}",
+            "",
+            "presentation_document *-- presentation_metadata : metadata",
+            "presentation_document *-- presentation_curriculum : curriculum",
+            "presentation_document o-- presentation_extensions : extensions",
+        ]
+    )
+    for area in sorted(inventory.domain_areas, key=lambda item: item.area_id):
+        if area.area_id != "core":
+            lines.append(f"presentation_curriculum *-- presentation_area_{normalize_alias(area.area_id)}")
+    lines.extend(
+        [
+            "",
+            "note bottom",
+            "Presentation view: compact overview for slides and memoria figures.",
+            "Detailed readable/reference diagrams remain canonical for trace inspection.",
+            "end note",
+            "@enduml",
+        ]
+    )
+    return DiagramArtifact(
+        filename="open_cvn_presentation_overview.puml",
+        title="Open CVN Presentation Overview",
+        content="\n".join(lines) + "\n",
+    )
 def render_readable_area_diagrams(
     inventory: ConceptualModelInventory,
     area: ConceptualDomainArea,
@@ -139,10 +197,22 @@ def render_readable_area_diagrams(
         return (render_domain_area_diagram(inventory, area),)
     sections = build_readable_sections(area)
     artifacts = [render_large_area_index_diagram(area, sections)]
-    artifacts.extend(
-        render_readable_section_diagram(inventory, area, section)
-        for section in sections
-    )
+    for section in sections:
+        artifacts.extend(render_readable_section_artifacts(inventory, area, section))
+    return tuple(artifacts)
+
+
+def render_readable_section_artifacts(
+    inventory: ConceptualModelInventory,
+    area: ConceptualDomainArea,
+    section: ReadableSection,
+) -> tuple[DiagramArtifact, ...]:
+    """Render one readable section, splitting oversized sections into chunks."""
+    if not requires_split_readable_section(section):
+        return (render_readable_section_diagram(inventory, area, section),)
+    chunks = split_readable_section(section)
+    artifacts = [render_readable_subsection_index_diagram(area, section, chunks)]
+    artifacts.extend(render_readable_section_diagram(inventory, area, chunk) for chunk in chunks)
     return tuple(artifacts)
 
 
@@ -211,6 +281,40 @@ def render_readable_section_diagram(
         package_alias=f"{area_alias(area.area_id)}_{normalize_alias(section.key)}",
         entities=section.entities,
         attribute_limit=READABLE_ATTRIBUTE_LIMIT,
+    )
+
+
+def render_readable_subsection_index_diagram(
+    area: ConceptualDomainArea,
+    section: ReadableSection,
+    chunks: tuple[ReadableSection, ...],
+) -> DiagramArtifact:
+    """Render compact index for oversized readable sections."""
+    lines = build_header(f"Open CVN - {area.name} - {section.title}")
+    lines.extend(
+        [
+            "skinparam classAttributeIconSize 0",
+            "hide empty members",
+            "",
+            f'package "{escape_text(area.name)} - {section.title}" as readable_section_{normalize_alias(section.key)}_index {{',
+        ]
+    )
+    for chunk in chunks:
+        lines.extend(render_section_summary_block(chunk))
+        lines.append("")
+    lines.append("}")
+    lines.append("")
+    lines.append("note bottom")
+    lines.append(f"Readable subsection index for {escape_text(section.title)}")
+    lines.append("Detailed subsection files:")
+    for chunk in chunks:
+        lines.append(f"- {escape_text(chunk.filename)}")
+    lines.append("end note")
+    lines.append("@enduml")
+    return DiagramArtifact(
+        filename=section.filename,
+        title=f"Open CVN - {area.name} - {section.title}",
+        content="\n".join(lines) + "\n",
     )
 
 
@@ -607,6 +711,54 @@ def requires_split_reference_section(section: ReadableSection) -> bool:
     )
 
 
+def requires_split_readable_section(section: ReadableSection) -> bool:
+    """Return whether one readable section still needs deeper splitting."""
+    entity_count = len(section.entities)
+    attribute_count = sum(len(entity.attributes) for entity in section.entities)
+    return (
+        entity_count > LARGE_READABLE_SECTION_ENTITY_THRESHOLD
+        or attribute_count > LARGE_READABLE_SECTION_ATTRIBUTE_THRESHOLD
+    )
+
+
+def split_readable_section(section: ReadableSection) -> tuple[ReadableSection, ...]:
+    """Split one oversized readable section into smaller deterministic chunks."""
+    chunks: list[ReadableSection] = []
+    current_entities: list[ConceptualEntity] = []
+    current_attribute_count = 0
+    part_number = 1
+    for entity in section.entities:
+        entity_attribute_count = len(entity.attributes)
+        if current_entities and (
+            len(current_entities) >= LARGE_READABLE_SECTION_ENTITY_THRESHOLD
+            or current_attribute_count + entity_attribute_count > LARGE_READABLE_SECTION_ATTRIBUTE_THRESHOLD
+        ):
+            chunks.append(build_readable_chunk(section, tuple(current_entities), part_number))
+            current_entities = []
+            current_attribute_count = 0
+            part_number += 1
+        current_entities.append(entity)
+        current_attribute_count += entity_attribute_count
+    if current_entities:
+        chunks.append(build_readable_chunk(section, tuple(current_entities), part_number))
+    return tuple(chunks)
+
+
+def build_readable_chunk(
+    section: ReadableSection,
+    entities: tuple[ConceptualEntity, ...],
+    part_number: int,
+) -> ReadableSection:
+    """Build one chunked readable subsection descriptor."""
+    chunk_key = f"{section.key}_part_{part_number:02d}"
+    return ReadableSection(
+        key=chunk_key,
+        title=f"{section.title} Part {part_number}",
+        filename=f"{section.filename.removesuffix('.puml')}_part_{part_number:02d}.puml",
+        entities=entities,
+    )
+
+
 def split_reference_section(section: ReadableSection) -> tuple[ReadableSection, ...]:
     """Split one oversized reference section into smaller deterministic chunks."""
     chunks: list[ReadableSection] = []
@@ -754,10 +906,21 @@ def render_entity_declaration(
 ) -> str:
     """Render a PlantUML class declaration for one conceptual entity."""
     alias = entity_alias(entity.entity_id)
-    name = escape_text(entity.name)
+    name = escape_text(display_entity_name(entity))
     if not include_attributes:
         return f'class "{name}" as {alias} <<{stereotype}>>'
     return f'class "{name}" as {alias} <<{stereotype}>> {{'
+
+
+def display_entity_name(entity: ConceptualEntity) -> str:
+    """Return a readable entity label while preserving stable aliases elsewhere."""
+    match = CODE_SUFFIX_PATTERN.match(entity.name)
+    if match is None:
+        return entity.name
+    label = match.group("label")
+    if not label:
+        return entity.name
+    return label
 
 
 def render_external_entity_declaration(entity: ConceptualEntity) -> str:

--- a/src/open_cvn/json_import.py
+++ b/src/open_cvn/json_import.py
@@ -27,6 +27,7 @@ from open_cvn.parser_contract import (
     CvnSourceFormat,
     CvnValidationStatus,
 )
+from open_cvn.semantic_validation import validate_open_cvn_semantics
 
 
 def parse_open_cvn_json(source: CvnInput, *, source_identifier: str | None = None) -> CvnParseResult:
@@ -131,11 +132,15 @@ def validate_open_cvn_json(
             trace=trace,
         )
 
-    warnings = _version_warnings(open_cvn_document.schema_version)
+    normalized_document = open_cvn_document.model_dump(mode="json", exclude_none=True)
+    warnings = (
+        *_version_warnings(open_cvn_document.schema_version),
+        *validate_open_cvn_semantics(normalized_document),
+    )
     return CvnParseResult(
         source_format=CvnSourceFormat.OPEN_CVN_JSON,
         source_identifier=source_identifier,
-        data=open_cvn_document.model_dump(mode="json", exclude_none=True),
+        data=normalized_document,
         validation_status=(
             CvnValidationStatus.VALID_WITH_WARNINGS if warnings else CvnValidationStatus.VALID
         ),

--- a/src/open_cvn/llm_import.py
+++ b/src/open_cvn/llm_import.py
@@ -224,6 +224,8 @@ def _attach_llm_provenance(
         "fallback_reason": fallback_reason,
         "provider_metadata": dict(provider_metadata),
         "validation": "local_open_cvn_json",
+        "review_required": True,
+        "authoritative": False,
     }
     result["extensions"] = extensions
     return result

--- a/src/open_cvn/parser_contract.py
+++ b/src/open_cvn/parser_contract.py
@@ -48,6 +48,7 @@ class CvnErrorCode(str, Enum):
     INVALID_JSON = "invalid_json"
     JSON_SCHEMA_VALIDATION_FAILURE = "json_schema_validation_failure"
     PYDANTIC_VALIDATION_FAILURE = "pydantic_validation_failure"
+    SEMANTIC_VALIDATION_WARNING = "semantic_validation_warning"
 
 
 class CvnParseIssue(BaseModel):

--- a/src/open_cvn/semantic_validation.py
+++ b/src/open_cvn/semantic_validation.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from open_cvn.import_utils import make_warning
+from open_cvn.parser_contract import CvnErrorCode, CvnParseIssue
+
+
+REPEATED_SECTIONS = (
+    "education",
+    "research",
+    "professional_experience",
+    "achievements",
+    "other",
+)
+CVN_CODE_PATTERN = re.compile(r"^\d{3}(?:\.\d{3}){3}$")
+CONTROLLED_REFERENCE_MARKERS = {"source", "reference_status", "semantic_reference_kind"}
+CONTROLLED_REFERENCE_VALUE_KEYS = {"code", "label", "raw_value", "uri"}
+
+
+def validate_open_cvn_semantics(document: Mapping[str, Any]) -> tuple[CvnParseIssue, ...]:
+    """Return conservative Open CVN semantic warnings for schema-valid documents."""
+
+    warnings: list[CvnParseIssue] = []
+    curriculum = document.get("curriculum")
+    if not isinstance(curriculum, Mapping):
+        return ()
+    for section in REPEATED_SECTIONS:
+        entries = curriculum.get(section)
+        if not isinstance(entries, list):
+            continue
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, Mapping):
+                continue
+            path = ("curriculum", section, str(index))
+            warnings.extend(_entry_type_warnings(entry, section=section, path=path))
+            warnings.extend(_trace_code_warnings(entry, path=path))
+            data = entry.get("data")
+            if isinstance(data, Mapping):
+                warnings.extend(_controlled_reference_warnings(data, path=(*path, "data")))
+    return tuple(warnings)
+
+
+def _entry_type_warnings(
+    entry: Mapping[str, Any], *, section: str, path: tuple[str, ...]
+) -> tuple[CvnParseIssue, ...]:
+    entry_type = entry.get("type")
+    if not isinstance(entry_type, str):
+        return ()
+    expected_prefix = f"{section}."
+    if entry_type.startswith(expected_prefix):
+        return ()
+    return (
+        make_warning(
+            code=CvnErrorCode.SEMANTIC_VALIDATION_WARNING,
+            message="Open CVN entry type does not match its curriculum section prefix.",
+            path=(*path, "type"),
+            details={"section": section, "entry_type": entry_type, "expected_prefix": expected_prefix},
+        ),
+    )
+
+
+def _trace_code_warnings(entry: Mapping[str, Any], *, path: tuple[str, ...]) -> tuple[CvnParseIssue, ...]:
+    trace = entry.get("trace")
+    if not isinstance(trace, Mapping):
+        return ()
+    codes = trace.get("cvn_codes")
+    if not isinstance(codes, list):
+        return ()
+    warnings: list[CvnParseIssue] = []
+    for index, code in enumerate(codes):
+        if isinstance(code, str) and CVN_CODE_PATTERN.match(code):
+            continue
+        warnings.append(
+            make_warning(
+                code=CvnErrorCode.SEMANTIC_VALIDATION_WARNING,
+                message="Open CVN trace contains a value that does not look like a CVN code.",
+                path=(*path, "trace", "cvn_codes", str(index)),
+                details={"cvn_code": str(code)},
+            )
+        )
+    return tuple(warnings)
+
+
+def _controlled_reference_warnings(
+    value: Any, *, path: tuple[str, ...]
+) -> tuple[CvnParseIssue, ...]:
+    warnings: list[CvnParseIssue] = []
+    if isinstance(value, Mapping):
+        keys = set(str(key) for key in value.keys())
+        if keys & CONTROLLED_REFERENCE_MARKERS and not _has_reference_value(value):
+            warnings.append(
+                make_warning(
+                    code=CvnErrorCode.SEMANTIC_VALIDATION_WARNING,
+                    message="Controlled reference has provenance but no code, label, raw_value, or uri.",
+                    path=path,
+                    details={"keys": sorted(keys)},
+                )
+            )
+        for key, child in value.items():
+            warnings.extend(_controlled_reference_warnings(child, path=(*path, str(key))))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            warnings.extend(_controlled_reference_warnings(child, path=(*path, str(index))))
+    return tuple(warnings)
+
+
+def _has_reference_value(value: Mapping[str, Any]) -> bool:
+    for key in CONTROLLED_REFERENCE_VALUE_KEYS:
+        item = value.get(key)
+        if item not in (None, ""):
+            return True
+    return False

--- a/src/open_cvn/xml_semantic_import.py
+++ b/src/open_cvn/xml_semantic_import.py
@@ -65,6 +65,7 @@ def import_cvn_xml_semantically(
 
         if entity.domain_area_id == "identity":
             curriculum["identity"].update(data)
+            section_counts["identity"] += 1
         else:
             section = _section_name(entity)
             section_counts[section] += 1
@@ -109,6 +110,10 @@ def import_cvn_xml_semantically(
                 "fields_seen": counters["fields_seen"],
                 "fields_mapped": counters["fields_mapped"],
                 "fields_unmapped": counters["fields_unmapped"],
+                "item_mapping_coverage": _coverage(counters["items_mapped"], counters["items_seen"]),
+                "field_mapping_coverage": _coverage(counters["fields_mapped"], counters["fields_seen"]),
+                "mapped_sections": sorted(section_counts),
+                "section_counts": dict(sorted(section_counts.items())),
                 "unmapped_codes": unmapped_codes,
             },
         },
@@ -159,6 +164,12 @@ def _section_name(entity: XmlEntityMapping) -> str:
 
 def _entry_id(section: str, code: str, number: int) -> str:
     return f"{section}-{code.replace('.', '-')}-{number:03d}"
+
+
+def _coverage(mapped: int, seen: int) -> float:
+    if seen == 0:
+        return 0.0
+    return round(mapped / seen, 4)
 
 
 def _local_name(tag: object) -> str:

--- a/src/open_cvn_app/cli.py
+++ b/src/open_cvn_app/cli.py
@@ -16,6 +16,7 @@ from open_cvn_app.pdf import (
     PdfCompilationError,
     PdfGenerationUnavailable,
     PdfPreviewError,
+    diagnose_pdf_environment,
     format_compilation_diagnostics,
     generate_pdf_document,
 )
@@ -203,6 +204,8 @@ def build_parser() -> argparse.ArgumentParser:
     _add_store_path_option(pdf_generate_parser)
     _add_version_option(pdf_generate_parser)
     pdf_generate_parser.set_defaults(handler=_handle_pdf_generate)
+    pdf_doctor_parser = pdf_subparsers.add_parser("doctor", help="Check PDF generation engine availability.")
+    pdf_doctor_parser.set_defaults(handler=_handle_pdf_doctor)
 
     return parser
 
@@ -543,6 +546,7 @@ def _handle_pdf_generate(args: argparse.Namespace) -> AppResult:
             version=args.version_name,
             output_path=args.output,
             open_pdf=args.open,
+            allow_managed_tectonic_download=True,
         )
     except StorageError as exc:
         return AppResult.failed("PDF generation failed.", error=str(exc))
@@ -565,6 +569,32 @@ def _handle_pdf_generate(args: argparse.Namespace) -> AppResult:
     if result.preview_opened:
         lines.append("Preview handoff: opened")
     return AppResult.ok("\n".join(lines))
+
+
+def _handle_pdf_doctor(args: argparse.Namespace) -> AppResult:
+    diagnostic = diagnose_pdf_environment()
+    lines = [
+        "PDF generation environment:",
+        f"Managed Tectonic cache: {diagnostic.managed_cache_path}",
+        f"Managed Tectonic: {diagnostic.managed_tectonic or '-'}",
+        f"System tectonic: {diagnostic.system_tectonic or '-'}",
+        f"latexmk: {diagnostic.latexmk or '-'}",
+        f"pdflatex: {diagnostic.pdflatex or '-'}",
+        f"Managed download supported: {diagnostic.managed_download_supported}",
+    ]
+    if diagnostic.selected_engine:
+        lines.extend(
+            (
+                f"Selected engine: {diagnostic.selected_engine}",
+                f"Selected executable: {diagnostic.selected_executable}",
+                "Next action: run open-cvn pdf generate.",
+            )
+        )
+        return AppResult.ok("\n".join(lines))
+    lines.append(
+        "Next action: run open-cvn pdf generate to download managed Tectonic, or install tectonic, latexmk, or pdflatex."
+    )
+    return AppResult.failed("PDF generation unavailable.", error="\n".join(lines))
 
 
 def _handle_pdf_import(args: argparse.Namespace) -> AppResult:

--- a/src/open_cvn_app/pdf.py
+++ b/src/open_cvn_app/pdf.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import os
+import hashlib
+import platform
 import shutil
 import subprocess
+import tarfile
 import tempfile
+import urllib.request
 import webbrowser
+import zipfile
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,7 +19,9 @@ from open_cvn_app.latex import render_latex_document
 from open_cvn_app.storage import CurriculumRepository
 
 
-DEFAULT_COMPILERS = ("latexmk", "pdflatex")
+MANAGED_TECTONIC_VERSION = "0.16.9"
+MANAGED_TECTONIC_CACHE_ENV = "OPEN_CVN_TECTONIC_CACHE"
+DEFAULT_COMPILERS = ("tectonic", "latexmk", "pdflatex")
 DEFAULT_TIMEOUT_SECONDS = 60
 
 
@@ -22,6 +29,27 @@ DEFAULT_TIMEOUT_SECONDS = 60
 class TexCompiler:
     name: str
     executable: str
+    managed: bool = False
+
+
+@dataclass(frozen=True)
+class ManagedTectonicAsset:
+    platform_key: str
+    archive_name: str
+    url: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class PdfEnvironmentDiagnostic:
+    managed_cache_path: Path
+    managed_tectonic: str | None
+    system_tectonic: str | None
+    latexmk: str | None
+    pdflatex: str | None
+    selected_engine: str | None
+    selected_executable: str | None
+    managed_download_supported: bool
 
 
 @dataclass(frozen=True)
@@ -64,18 +92,70 @@ class PdfPreviewError(RuntimeError):
 CompilerLookup = Callable[[str], str | None]
 Runner = Callable[..., subprocess.CompletedProcess[str]]
 PreviewOpener = Callable[[str], bool]
+ManagedDownloader = Callable[[Path], Path]
 
 
 def discover_tex_compiler(
     *,
     lookup: CompilerLookup = shutil.which,
     compiler_order: Sequence[str] = DEFAULT_COMPILERS,
+    managed_cache_dir: Path | None = None,
+    allow_managed_download: bool = False,
+    managed_downloader: ManagedDownloader | None = None,
 ) -> TexCompiler:
+    cache_dir = managed_cache_dir or managed_tectonic_cache_dir()
+    cached_tectonic = cached_managed_tectonic_path(cache_dir)
+    if cached_tectonic is not None:
+        return TexCompiler(name="tectonic", executable=str(cached_tectonic), managed=True)
+    if allow_managed_download:
+        downloader = managed_downloader or download_managed_tectonic
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            downloaded = downloader(cache_dir)
+        except (OSError, RuntimeError, ValueError):
+            downloaded = None
+        if downloaded is not None:
+            return TexCompiler(name="tectonic", executable=str(downloaded), managed=True)
     for compiler_name in compiler_order:
         executable = lookup(compiler_name)
         if executable:
             return TexCompiler(name=compiler_name, executable=executable)
     raise PdfGenerationUnavailable(compiler_order)
+
+
+def diagnose_pdf_environment(
+    *,
+    lookup: CompilerLookup = shutil.which,
+    managed_cache_dir: Path | None = None,
+) -> PdfEnvironmentDiagnostic:
+    cache_dir = managed_cache_dir or managed_tectonic_cache_dir()
+    managed_tectonic = cached_managed_tectonic_path(cache_dir)
+    system_tectonic = lookup("tectonic")
+    latexmk = lookup("latexmk")
+    pdflatex = lookup("pdflatex")
+    selected_engine = selected_executable = None
+    if managed_tectonic is not None:
+        selected_engine = "managed tectonic"
+        selected_executable = str(managed_tectonic)
+    elif system_tectonic:
+        selected_engine = "tectonic"
+        selected_executable = system_tectonic
+    elif latexmk:
+        selected_engine = "latexmk"
+        selected_executable = latexmk
+    elif pdflatex:
+        selected_engine = "pdflatex"
+        selected_executable = pdflatex
+    return PdfEnvironmentDiagnostic(
+        managed_cache_path=cache_dir,
+        managed_tectonic=str(managed_tectonic) if managed_tectonic is not None else None,
+        system_tectonic=system_tectonic,
+        latexmk=latexmk,
+        pdflatex=pdflatex,
+        selected_engine=selected_engine,
+        selected_executable=selected_executable,
+        managed_download_supported=tectonic_asset_for_current_platform() is not None,
+    )
 
 
 def generate_pdf_document(
@@ -88,9 +168,17 @@ def generate_pdf_document(
     runner: Runner = subprocess.run,
     preview_opener: PreviewOpener = webbrowser.open,
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    allow_managed_tectonic_download: bool = False,
+    managed_cache_dir: Path | None = None,
+    managed_downloader: ManagedDownloader | None = None,
 ) -> PdfGenerationResult:
     materialized = repository.materialize_version(version)
-    compiler = discover_tex_compiler(lookup=compiler_lookup)
+    compiler = discover_tex_compiler(
+        lookup=compiler_lookup,
+        allow_managed_download=allow_managed_tectonic_download,
+        managed_cache_dir=managed_cache_dir,
+        managed_downloader=managed_downloader,
+    )
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -150,17 +238,53 @@ def _compile_tex(
     timeout_seconds: int,
 ) -> Path:
     expected_pdf = build_dir / f"{tex_path.stem}.pdf"
-    diagnostics = (
-        _run_latexmk(compiler, tex_path, build_dir=build_dir, runner=runner, timeout_seconds=timeout_seconds)
-        if compiler.name == "latexmk"
-        else _run_pdflatex(compiler, tex_path, build_dir=build_dir, runner=runner, timeout_seconds=timeout_seconds)
-    )
+    if compiler.name == "tectonic":
+        diagnostics = _run_tectonic(
+            compiler,
+            tex_path,
+            build_dir=build_dir,
+            runner=runner,
+            timeout_seconds=timeout_seconds,
+        )
+    elif compiler.name == "latexmk":
+        diagnostics = _run_latexmk(
+            compiler,
+            tex_path,
+            build_dir=build_dir,
+            runner=runner,
+            timeout_seconds=timeout_seconds,
+        )
+    else:
+        diagnostics = _run_pdflatex(
+            compiler,
+            tex_path,
+            build_dir=build_dir,
+            runner=runner,
+            timeout_seconds=timeout_seconds,
+        )
     failing = next((diagnostic for diagnostic in diagnostics if diagnostic.return_code != 0), None)
     if failing is not None:
         raise PdfCompilationError("PDF compilation failed.", diagnostics)
     if not expected_pdf.exists():
         raise PdfCompilationError("PDF compiler finished but did not create the expected PDF.", diagnostics)
     return expected_pdf
+
+
+def _run_tectonic(
+    compiler: TexCompiler,
+    tex_path: Path,
+    *,
+    build_dir: Path,
+    runner: Runner,
+    timeout_seconds: int,
+) -> tuple[CompilerRunDiagnostic, ...]:
+    command = (
+        compiler.executable,
+        str(tex_path),
+        "--outdir",
+        str(build_dir),
+    )
+    return (_run_compiler(command, build_dir=build_dir, runner=runner, timeout_seconds=timeout_seconds),)
 
 
 def _run_latexmk(
@@ -269,3 +393,111 @@ def _compact_output(value: str, *, limit: int = 1200) -> str:
     if len(normalized) <= limit:
         return normalized
     return f"{normalized[:limit]}... <truncated>"
+
+
+def managed_tectonic_cache_dir() -> Path:
+    configured = os.environ.get(MANAGED_TECTONIC_CACHE_ENV)
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".cache" / "open-cvn" / "tectonic" / MANAGED_TECTONIC_VERSION
+
+
+def cached_managed_tectonic_path(cache_dir: Path) -> Path | None:
+    executable = "tectonic.exe" if os.name == "nt" else "tectonic"
+    candidate = cache_dir / executable
+    if candidate.exists() and os.access(candidate, os.X_OK):
+        return candidate
+    return None
+
+
+def download_managed_tectonic(cache_dir: Path) -> Path:
+    asset = tectonic_asset_for_current_platform()
+    if asset is None:
+        raise RuntimeError("Managed Tectonic download is not available for this platform.")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = cache_dir / asset.archive_name
+    with urllib.request.urlopen(asset.url, timeout=60) as response:  # noqa: S310 - pinned GitHub release URL.
+        archive_bytes = response.read()
+    digest = hashlib.sha256(archive_bytes).hexdigest()
+    if digest != asset.sha256:
+        raise ValueError("Downloaded Tectonic archive checksum does not match the pinned release digest.")
+    archive_path.write_bytes(archive_bytes)
+    _extract_tectonic_archive(archive_path, cache_dir)
+    cached = cached_managed_tectonic_path(cache_dir)
+    if cached is None:
+        raise RuntimeError("Managed Tectonic archive did not provide an executable.")
+    return cached
+
+
+def tectonic_asset_for_current_platform() -> ManagedTectonicAsset | None:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "linux" and machine in {"x86_64", "amd64"}:
+        return _asset(
+            "x86_64-unknown-linux-gnu",
+            "f3c825128095dc3399ea11c08c18035b33050a216930c295c79e8eb11bd21de4",
+            extension="tar.gz",
+        )
+    if system == "linux" and machine in {"aarch64", "arm64"}:
+        return _asset(
+            "aarch64-unknown-linux-musl",
+            "f9aa39017dbd51f111fdb93dda222178cbe51c8193508fc567b523cc74fff9c1",
+            extension="tar.gz",
+        )
+    if system == "darwin" and machine in {"x86_64", "amd64"}:
+        return _asset(
+            "x86_64-apple-darwin",
+            "79d8839fa3594bfea9b2bf2ac0a0455bcc4d0de956a5e5c403107e9a72f79e86",
+            extension="tar.gz",
+        )
+    if system == "darwin" and machine in {"aarch64", "arm64"}:
+        return _asset(
+            "aarch64-apple-darwin",
+            "edb67c61aba768289f6da441c9e6f523cfaff4f8b2a5708523ef29c543f8e88e",
+            extension="tar.gz",
+        )
+    if system == "windows" and machine in {"x86_64", "amd64"}:
+        return _asset(
+            "x86_64-pc-windows-msvc",
+            "131a24604785a9600989a3d91225f597df52ac06f00aeffe86fd529f99ee5cdd",
+            extension="zip",
+        )
+    return None
+
+
+def _asset(platform_key: str, sha256: str, *, extension: str) -> ManagedTectonicAsset:
+    archive_name = f"tectonic-{MANAGED_TECTONIC_VERSION}-{platform_key}.{extension}"
+    return ManagedTectonicAsset(
+        platform_key=platform_key,
+        archive_name=archive_name,
+        url=(
+            "https://github.com/tectonic-typesetting/tectonic/releases/download/"
+            f"tectonic%40{MANAGED_TECTONIC_VERSION}/{archive_name}"
+        ),
+        sha256=sha256,
+    )
+
+
+def _extract_tectonic_archive(archive_path: Path, cache_dir: Path) -> None:
+    executable = "tectonic.exe" if os.name == "nt" else "tectonic"
+    if archive_path.suffix == ".zip":
+        with zipfile.ZipFile(archive_path) as archive:
+            member_name = _single_executable_member(archive.namelist(), executable)
+            (cache_dir / executable).write_bytes(archive.read(member_name))
+    else:
+        with tarfile.open(archive_path, "r:gz") as archive:
+            names = archive.getnames()
+            member_name = _single_executable_member(names, executable)
+            member = archive.extractfile(member_name)
+            if member is None:
+                raise RuntimeError("Tectonic archive executable could not be read.")
+            (cache_dir / executable).write_bytes(member.read())
+    if os.name != "nt":
+        (cache_dir / executable).chmod(0o755)
+
+
+def _single_executable_member(names: Sequence[str], executable: str) -> str:
+    matches = [name for name in names if Path(name).name == executable]
+    if len(matches) != 1:
+        raise RuntimeError("Tectonic archive does not contain exactly one executable.")
+    return matches[0]

--- a/tests/test_conceptual_model_diagrams_unit.py
+++ b/tests/test_conceptual_model_diagrams_unit.py
@@ -156,6 +156,7 @@ def test_render_conceptual_model_diagrams_is_deterministic_and_agnostic():
     assert "BaseCvnDomainModel" not in combined
     assert "Field(" not in combined
     assert "open_cvn_identity_reference.puml" in {artifact.filename for artifact in first}
+    assert "open_cvn_presentation_overview.puml" in {artifact.filename for artifact in first}
 
 
 def test_write_conceptual_model_diagrams_writes_all_artifacts(tmp_path: Path):
@@ -171,6 +172,7 @@ def test_write_conceptual_model_diagrams_writes_all_artifacts(tmp_path: Path):
         "open_cvn_core_reference.puml",
         "open_cvn_identity.puml",
         "open_cvn_identity_reference.puml",
+        "open_cvn_presentation_overview.puml",
     ]
     assert all(path.exists() for path in written_paths)
     assert (tmp_path / "open_cvn_identity.puml").read_text(encoding="utf-8").startswith("@startuml")

--- a/tests/test_llm_import_unit.py
+++ b/tests/test_llm_import_unit.py
@@ -81,6 +81,8 @@ def test_import_pdf_with_llm_validates_and_attaches_provenance(tmp_path: Path):
         "fallback_reason": "pdf_without_extractable_xml",
         "provider_metadata": {"mock": True, "tokens": 12},
         "validation": "local_open_cvn_json",
+        "review_required": True,
+        "authoritative": False,
     }
     assert result.trace is not None
     assert result.trace.extracted_from == "llm_fallback"

--- a/tests/test_open_cvn_app_cli_unit.py
+++ b/tests/test_open_cvn_app_cli_unit.py
@@ -20,6 +20,7 @@ import open_cvn_app.cli as cli_module
 from open_cvn_app import __version__
 from open_cvn_app.cli import build_parser, run
 from open_cvn_app.pdf import CompilerRunDiagnostic, PdfCompilationError, PdfGenerationResult, PdfGenerationUnavailable
+from open_cvn_app.pdf import PdfEnvironmentDiagnostic
 from open_cvn_app.storage import CurriculumCreate, CurriculumRepository, initialize_store
 
 
@@ -722,6 +723,50 @@ def test_pdf_generate_reports_missing_compiler(capsys: pytest.CaptureFixture[str
     assert "No supported TeX compiler found" in captured.err
 
 
+def test_pdf_doctor_reports_available_engine(capsys: pytest.CaptureFixture[str], monkeypatch, tmp_path):
+    diagnostic = PdfEnvironmentDiagnostic(
+        managed_cache_path=tmp_path / "tectonic",
+        managed_tectonic=str(tmp_path / "tectonic" / "tectonic"),
+        system_tectonic=None,
+        latexmk=None,
+        pdflatex=None,
+        selected_engine="managed tectonic",
+        selected_executable=str(tmp_path / "tectonic" / "tectonic"),
+        managed_download_supported=True,
+    )
+
+    monkeypatch.setattr(cli_module, "diagnose_pdf_environment", lambda: diagnostic)
+
+    exit_code = run(["pdf", "doctor"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "PDF generation environment:" in output
+    assert "Selected engine: managed tectonic" in output
+
+
+def test_pdf_doctor_reports_missing_engine(capsys: pytest.CaptureFixture[str], monkeypatch, tmp_path):
+    diagnostic = PdfEnvironmentDiagnostic(
+        managed_cache_path=tmp_path / "tectonic",
+        managed_tectonic=None,
+        system_tectonic=None,
+        latexmk=None,
+        pdflatex=None,
+        selected_engine=None,
+        selected_executable=None,
+        managed_download_supported=True,
+    )
+
+    monkeypatch.setattr(cli_module, "diagnose_pdf_environment", lambda: diagnostic)
+
+    exit_code = run(["pdf", "doctor"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "PDF generation unavailable." in captured.err
+    assert "run open-cvn pdf generate to download managed Tectonic" in captured.err
+
+
 def test_pdf_generate_writes_master_pdf(capsys: pytest.CaptureFixture[str], monkeypatch, tmp_path):
     store_path, curriculum = _create_store_with_curriculum(tmp_path)
     repository = CurriculumRepository(store_path)
@@ -752,7 +797,14 @@ def test_pdf_generate_writes_master_pdf(capsys: pytest.CaptureFixture[str], monk
     assert "Generated PDF version 'master'" in output
     assert "Validation status: valid" in output
     assert "Compiler: latexmk" in output
-    assert calls == [{"version": "master", "output_path": str(output_path), "open_pdf": False}]
+    assert calls == [
+        {
+            "version": "master",
+            "output_path": str(output_path),
+            "open_pdf": False,
+            "allow_managed_tectonic_download": True,
+        }
+    ]
 
 
 def test_pdf_generate_writes_materialized_derived_pdf(capsys: pytest.CaptureFixture[str], monkeypatch, tmp_path):

--- a/tests/test_open_cvn_app_pdf_unit.py
+++ b/tests/test_open_cvn_app_pdf_unit.py
@@ -11,6 +11,8 @@ from open_cvn_app.pdf import (
     PdfCompilationError,
     PdfGenerationUnavailable,
     PdfPreviewError,
+    cached_managed_tectonic_path,
+    diagnose_pdf_environment,
     discover_tex_compiler,
     format_compilation_diagnostics,
     generate_pdf_document,
@@ -31,6 +33,37 @@ def _repository_with_master(tmp_path: Path, document_path: Path | None = None) -
     curriculum = repository.create_curriculum(CurriculumCreate(display_name="Master CV", document=document))
     repository.assign_master_curriculum(curriculum.id)
     return repository
+
+
+def test_discover_tex_compiler_prefers_cached_managed_tectonic(tmp_path):
+    executable = tmp_path / "tectonic"
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o755)
+
+    compiler = discover_tex_compiler(lookup=lambda name: "/usr/bin/latexmk", managed_cache_dir=tmp_path)
+
+    assert compiler.name == "tectonic"
+    assert compiler.executable == str(executable)
+    assert compiler.managed is True
+
+
+def test_discover_tex_compiler_can_download_managed_tectonic(tmp_path):
+    def downloader(cache_dir: Path) -> Path:
+        executable = cache_dir / "tectonic"
+        executable.write_text("#!/bin/sh\n", encoding="utf-8")
+        executable.chmod(0o755)
+        return executable
+
+    compiler = discover_tex_compiler(
+        lookup=lambda name: None,
+        managed_cache_dir=tmp_path,
+        allow_managed_download=True,
+        managed_downloader=downloader,
+    )
+
+    assert compiler.name == "tectonic"
+    assert compiler.executable == str(tmp_path / "tectonic")
+    assert compiler.managed is True
 
 
 def test_discover_tex_compiler_prefers_latexmk():
@@ -57,7 +90,26 @@ def test_discover_tex_compiler_reports_missing_compiler():
     with pytest.raises(PdfGenerationUnavailable, match="No supported TeX compiler found") as exc_info:
         discover_tex_compiler(lookup=lambda name: None)
 
-    assert exc_info.value.searched_compilers == ("latexmk", "pdflatex")
+    assert exc_info.value.searched_compilers == ("tectonic", "latexmk", "pdflatex")
+
+
+def test_cached_managed_tectonic_ignores_non_executable(tmp_path):
+    executable = tmp_path / "tectonic"
+    executable.write_text("not executable", encoding="utf-8")
+
+    assert cached_managed_tectonic_path(tmp_path) is None
+
+
+def test_diagnose_pdf_environment_reports_selected_engine(tmp_path):
+    executable = tmp_path / "tectonic"
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o755)
+
+    diagnostic = diagnose_pdf_environment(lookup=lambda name: "/usr/bin/latexmk", managed_cache_dir=tmp_path)
+
+    assert diagnostic.managed_tectonic == str(executable)
+    assert diagnostic.selected_engine == "managed tectonic"
+    assert diagnostic.selected_executable == str(executable)
 
 
 def test_generate_pdf_document_with_latexmk_copies_expected_pdf(tmp_path):
@@ -90,6 +142,41 @@ def test_generate_pdf_document_with_latexmk_copies_expected_pdf(tmp_path):
     assert len(calls) == 1
     assert calls[0][1:5] == ("-pdf", "-interaction=nonstopmode", "-halt-on-error", "-outdir")
     assert environments[0]["SOURCE_DATE_EPOCH"] == "0"
+
+
+def test_generate_pdf_document_with_tectonic_copies_expected_pdf(tmp_path):
+    repository = _repository_with_master(tmp_path)
+    output_path = tmp_path / "cv.pdf"
+    calls: list[tuple[str, ...]] = []
+    cache_dir = tmp_path / "tectonic-cache"
+
+    def downloader(cache_dir: Path) -> Path:
+        executable = cache_dir / "tectonic"
+        executable.write_text("#!/bin/sh\n", encoding="utf-8")
+        executable.chmod(0o755)
+        return executable
+
+    def runner(command: tuple[str, ...], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        tex_path = Path(command[1])
+        (Path(kwargs["cwd"]) / f"{tex_path.stem}.pdf").write_bytes(b"%PDF-1.4\n")
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    result = generate_pdf_document(
+        repository,
+        version="master",
+        output_path=output_path,
+        compiler_lookup=lambda name: None,
+        runner=runner,
+        allow_managed_tectonic_download=True,
+        managed_cache_dir=cache_dir,
+        managed_downloader=downloader,
+    )
+
+    assert result.compiler_name == "tectonic"
+    assert output_path.read_bytes() == b"%PDF-1.4\n"
+    assert calls[0][0] == str(cache_dir / "tectonic")
+    assert calls[0][2] == "--outdir"
 
 
 def test_generate_pdf_document_with_pdflatex_runs_two_passes(tmp_path):

--- a/tests/test_open_cvn_semantic_validation_unit.py
+++ b/tests/test_open_cvn_semantic_validation_unit.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+
+from open_cvn import CvnErrorCode, CvnValidationStatus, validate_open_cvn_json
+from open_cvn.semantic_validation import validate_open_cvn_semantics
+
+
+FIXTURES = Path("tests/fixtures/open_cvn")
+
+
+def _valid_document():
+    return json.loads((FIXTURES / "valid_minimal.json").read_text(encoding="utf-8"))
+
+
+def test_semantic_validation_warns_for_section_type_mismatch():
+    document = _valid_document()
+    document["curriculum"]["education"].append(
+        {"id": "research-in-education", "type": "research.publication", "data": {}}
+    )
+
+    warnings = validate_open_cvn_semantics(document)
+
+    assert len(warnings) == 1
+    assert warnings[0].code == CvnErrorCode.SEMANTIC_VALIDATION_WARNING
+    assert warnings[0].path == ("curriculum", "education", "0", "type")
+
+
+def test_semantic_validation_warns_for_invalid_trace_code():
+    document = _valid_document()
+    document["curriculum"]["research"].append(
+        {
+            "id": "research-001",
+            "type": "research.publication",
+            "data": {},
+            "trace": {"cvn_codes": ["not-a-cvn-code"]},
+        }
+    )
+
+    warnings = validate_open_cvn_semantics(document)
+
+    assert warnings[0].path == ("curriculum", "research", "0", "trace", "cvn_codes", "0")
+
+
+def test_semantic_validation_warns_for_empty_controlled_reference():
+    document = _valid_document()
+    document["curriculum"]["achievements"].append(
+        {
+            "id": "achievement-001",
+            "type": "achievements.award",
+            "data": {"kind": {"source": "CVN_TEST"}},
+        }
+    )
+
+    warnings = validate_open_cvn_semantics(document)
+
+    assert warnings[0].path == ("curriculum", "achievements", "0", "data", "kind")
+
+
+def test_json_validation_returns_semantic_warnings_after_schema_and_pydantic_validation():
+    document = _valid_document()
+    document["curriculum"]["education"].append(
+        {"id": "research-in-education", "type": "research.publication", "data": {}}
+    )
+
+    result = validate_open_cvn_json(document, source_identifier="semantic-warning")
+
+    assert result.validation_status == CvnValidationStatus.VALID_WITH_WARNINGS
+    assert result.warnings[0].code == CvnErrorCode.SEMANTIC_VALIDATION_WARNING

--- a/tests/test_parser_validator_contract_unit.py
+++ b/tests/test_parser_validator_contract_unit.py
@@ -43,6 +43,7 @@ def test_contract_error_codes_cover_issue_47_cases():
         "invalid_json",
         "json_schema_validation_failure",
         "pydantic_validation_failure",
+        "semantic_validation_warning",
     }
 
 

--- a/tests/test_xml_semantic_import_unit.py
+++ b/tests/test_xml_semantic_import_unit.py
@@ -24,12 +24,17 @@ def test_semantic_import_populates_identity():
 def test_semantic_import_populates_education_entry_and_validates():
     document = _import_fixture("semantic_education.xml")
     validation = validate_open_cvn_json(document, source_identifier="semantic_education.xml")
+    diagnostic = document["extensions"]["x-open-cvn.xml_import"]
 
     assert validation.validation_status == CvnValidationStatus.VALID
     entry = document["curriculum"]["education"][0]
     assert entry["id"] == "education-020-010-010-000-001"
     assert entry["type"].startswith("education.")
     assert entry["data"]["nombre_del_titulo"]["raw_value"] == "Synthetic Computer Science Degree"
+    assert diagnostic["mapped_sections"] == ["education"]
+    assert diagnostic["section_counts"] == {"education": 1}
+    assert diagnostic["item_mapping_coverage"] == 1.0
+    assert diagnostic["field_mapping_coverage"] == 1.0
 
 
 def test_semantic_import_populates_research_entry():
@@ -48,4 +53,6 @@ def test_semantic_import_preserves_unmapped_item():
 
     assert diagnostic["mapping_status"] == "trace_only"
     assert diagnostic["items_unmapped"] == 1
+    assert diagnostic["mapped_sections"] == []
+    assert diagnostic["item_mapping_coverage"] == 0.0
     assert document["curriculum"]["other"][0]["type"] == "other.unmapped_cvn_item"


### PR DESCRIPTION
## Summary

- Classifies known limitations by source, impact, handling, and blocker status.
- Adds conservative Open CVN semantic warnings after JSON Schema and Pydantic validation.
- Extends semantic partial XML import diagnostics with coverage metrics.
- Adds managed Tectonic PDF discovery/cache/download support and `open-cvn pdf doctor`.
- Marks LLM-assisted imports as review-required and non-authoritative.
- Improves conceptual diagram generation with split readable views and a presentation overview.
- Updates persistent roadmap, status, workflow, and limitation documentation for issue #71.

## Verification

- `uv run pytest -n auto tests/test_open_cvn_semantic_validation_unit.py tests/test_open_cvn_json_import_unit.py tests/test_parser_validator_contract_unit.py tests/test_xml_semantic_import_unit.py tests/test_cvn_xml_import_unit.py tests/test_open_cvn_app_pdf_unit.py tests/test_open_cvn_app_cli_unit.py tests/test_llm_import_unit.py tests/test_llm_providers_unit.py tests/test_conceptual_model_diagrams_unit.py tests/test_generation_pipeline_conceptual_diagrams.py -v`
  - `108 passed in 69.88s`
- `uv run pytest -n auto tests`
  - `488 passed in 845.43s (0:14:05)`

## Notes

- `docs/memoria/` was not modified.
- `src/generated/` was not manually edited.